### PR TITLE
Migrate non-sensitive secrets to GitHub Variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.LIGHTSAIL_SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ secrets.LIGHTSAIL_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+          ssh-keyscan -H ${{ vars.LIGHTSAIL_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Write deploy script
         run: |
@@ -62,19 +62,19 @@ jobs:
         run: |
           cat > /tmp/env-file << ENVFILE
           SECRET_KEY=${{ secrets.SECRET_KEY }}
-          DATABASE_URL=mysql+pymysql://${{ secrets.MYSQL_USER }}:${{ secrets.MYSQL_PASSWORD }}@db:3306/${{ secrets.MYSQL_DATABASE }}
+          DATABASE_URL=mysql+pymysql://${{ vars.MYSQL_USER }}:${{ secrets.MYSQL_PASSWORD }}@db:3306/${{ vars.MYSQL_DATABASE }}
           UPLOAD_FOLDER=/app/uploads
           MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}
-          MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}
-          MYSQL_USER=${{ secrets.MYSQL_USER }}
+          MYSQL_DATABASE=${{ vars.MYSQL_DATABASE }}
+          MYSQL_USER=${{ vars.MYSQL_USER }}
           MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}
           ENVFILE
 
       - name: Deploy application
         run: |
           SSH_OPTS="-i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=15 -o ServerAliveCountMax=20"
-          SSH_CMD="ssh $SSH_OPTS ${{ env.SSH_USER }}@${{ secrets.LIGHTSAIL_HOST }}"
-          scp $SSH_OPTS /tmp/env-file ${{ env.SSH_USER }}@${{ secrets.LIGHTSAIL_HOST }}:~/app/.env
+          SSH_CMD="ssh $SSH_OPTS ${{ env.SSH_USER }}@${{ vars.LIGHTSAIL_HOST }}"
+          scp $SSH_OPTS /tmp/env-file ${{ env.SSH_USER }}@${{ vars.LIGHTSAIL_HOST }}:~/app/.env
           $SSH_CMD 'bash -s' < /tmp/deploy.sh
 
       - name: Cleanup

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,9 +11,9 @@ on:
 
 env:
   TF_VAR_ssh_public_key: ${{ secrets.LIGHTSAIL_SSH_PUBLIC_KEY }}
-  TF_VAR_repo_url: ${{ secrets.REPO_URL }}
-  TF_VAR_domain_name: ${{ secrets.DOMAIN_NAME }}
-  TF_VAR_route53_zone_id: ${{ secrets.ROUTE53_ZONE_ID }}
+  TF_VAR_repo_url: ${{ vars.REPO_URL }}
+  TF_VAR_domain_name: ${{ vars.DOMAIN_NAME }}
+  TF_VAR_route53_zone_id: ${{ vars.ROUTE53_ZONE_ID }}
 
 jobs:
   terraform:

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
 - [ ] Add SSL/HTTPS to the website (Let's Encrypt)
-- [ ] Migrate non-sensitive GitHub Secrets to GitHub Variables
+- [x] Migrate non-sensitive GitHub Secrets to GitHub Variables
 - [ ] Add a way to have Claude read provided documents and URLs to populate the regatta list for the year
 - [ ] Create backups
 - [ ] Explore DB survivability


### PR DESCRIPTION
## Summary
- Moved 6 non-sensitive values from GitHub Secrets to GitHub Variables (`vars.` instead of `secrets.`)
- **Variables:** `LIGHTSAIL_HOST`, `REPO_URL`, `DOMAIN_NAME`, `ROUTE53_ZONE_ID`, `MYSQL_DATABASE`, `MYSQL_USER`
- **Remaining secrets:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `LIGHTSAIL_SSH_PRIVATE_KEY`, `LIGHTSAIL_SSH_PUBLIC_KEY`, `SECRET_KEY`, `MYSQL_ROOT_PASSWORD`, `MYSQL_PASSWORD`
- Marked TODO item as complete

## Test plan
- [ ] Trigger deploy workflow and verify it succeeds
- [ ] Verify site responds at hulagirl.us

🤖 Generated with [Claude Code](https://claude.com/claude-code)