### PR TITLE
Add versioning requirements, bump to 0.14.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ Semantic Versioning (SemVer): `MAJOR.MINOR.PATCH`
 - **MINOR:** new features (new page, new functionality)
 - **PATCH:** bug fixes, small tweaks
 - Version tracked in `app/__init__.py` as `__version__`
-- Current version: `0.1.0`
+- **Every `feature/` or `fix/` branch must bump the version and update `VERSIONS.md` before merging**
+  - `feature/` branches bump MINOR (e.g. 0.13.0 → 0.14.0)
+  - `fix/` branches bump PATCH (e.g. 0.14.0 → 0.14.1)
+- **After merging, tag the merge commit:** `git tag v<version>` and `git push origin --tags`
 
 ## Git Workflow
 - `master` branch is production-ready — **never push directly to master**

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,14 @@
 # Version History
 
+## 0.14.0
+- Migrated non-sensitive GitHub Secrets to GitHub Variables
+- Fixed deploy SSH timeout with keepalive settings
+- Fixed buildx session timeout by pre-pulling base image
+- Fixed deploy OOM by stopping containers before build
+- Increased deploy workflow timeout to 15 minutes
+- Added versioning requirements to CLAUDE.md
+- Added branching workflow rules to CLAUDE.md (never push directly to master)
+
 ## 0.13.0
 - Terraform infrastructure-as-code for AWS Lightsail (instance, static IP, firewall)
 - GitHub Actions deploy workflow: auto-deploys on push to master via SSH

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Added rule to CLAUDE.md: every feature/fix branch must bump version and update VERSIONS.md
- Bumped version to 0.14.0 covering recent deploy fixes and secrets migration
- Updated VERSIONS.md with changelog

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm version shows as 0.14.0 in app footer after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)