### PR TITLE
Upgrade Lightsail instance to 2GB RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,11 +364,11 @@ every 60 days.
 
 | Component | Monthly Cost |
 |-----------|-------------|
-| Lightsail instance (micro_3_0, 1GB RAM) | $5 |
+| Lightsail instance (small_3_0, 2GB RAM) | $10 |
 | Static IP (attached to instance) | $0 |
 | S3 state bucket | ~$0 |
 | GitHub Actions | $0 (free tier) |
-| **Total** | **~$5/mo** |
+| **Total** | **~$10/mo** |
 
 ---
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.15.1
+- Upgrade Lightsail instance from micro_3_0 (1GB) to small_3_0 (2GB) to resolve OOM issues
+
 ## 0.15.0
 - Add Let's Encrypt SSL/HTTPS via certbot Docker sidecar container
 - Automatic certificate renewal every 12 hours with nginx reload every 6 hours

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,7 +25,7 @@ variable "blueprint_id" {
 variable "bundle_id" {
   description = "Lightsail instance bundle (size/price)"
   type        = string
-  default     = "micro_3_0"
+  default     = "small_3_0"
 }
 
 variable "ssh_public_key" {


### PR DESCRIPTION
## Summary
- Upgrade Lightsail instance from micro_3_0 (1GB, $5/mo) to small_3_0 (2GB, $10/mo)
- Resolves OOM kills during deploys and SSH unresponsiveness

## Test plan
- [ ] Terraform plan shows instance replacement
- [ ] After apply, verify instance has 2GB RAM (`free -m`)
- [ ] Verify deploy workflow completes without OOM issues

**Note:** This will replace the instance. The static IP will reattach automatically, but a deploy will be needed to restore the app and containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)