### PR TITLE
Rename project to Race Crew Network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 SECRET_KEY=change-me-to-a-random-string
-DATABASE_URL=mysql+pymysql://regatta:regatta@db:3306/regatta
+DATABASE_URL=mysql+pymysql://racecrew:racecrew@db:3306/racecrew
 UPLOAD_FOLDER=/app/uploads
 MYSQL_ROOT_PASSWORD=rootpassword
-MYSQL_DATABASE=regatta
-MYSQL_USER=regatta
-MYSQL_PASSWORD=regatta
+MYSQL_DATABASE=racecrew
+MYSQL_USER=racecrew
+MYSQL_PASSWORD=racecrew

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Thistle Regatta Schedule — Project Standards
+# Race Crew Network — Project Standards
 
 ## Python Standards
 - Python 3.11+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Thistle Regatta Schedule
+# Race Crew Network
 
-A simple web app for organizing Thistle sailboat regattas. Track dates, locations, NOR/SI documents, and crew availability with Yes/No/Maybe RSVPs.
+A simple web app for organizing sailboat regattas. Track dates, locations, NOR/SI documents, and crew availability with Yes/No/Maybe RSVPs.
 
 ## Features
 
@@ -32,7 +32,7 @@ A simple web app for organizing Thistle sailboat regattas. Track dates, location
 
 ```bash
 git clone <your-repo-url>
-cd thistle-regatta-schedule
+cd race-crew-network
 cp .env.example .env
 ```
 
@@ -103,7 +103,7 @@ personal or root AWS credentials.
 ### 1. Create IAM user
 
 ```bash
-aws iam create-user --user-name thistle-regatta-deploy
+aws iam create-user --user-name race-crew-deploy
 ```
 
 ### 2. Create IAM policy
@@ -130,8 +130,8 @@ The policy file (`iam-policy.json`) is included in the repo root:
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::thistle-regatta-tfstate",
-        "arn:aws:s3:::thistle-regatta-tfstate/*"
+        "arn:aws:s3:::race-crew-tfstate",
+        "arn:aws:s3:::race-crew-tfstate/*"
       ]
     }
   ]
@@ -142,7 +142,7 @@ Create the policy:
 
 ```bash
 aws iam create-policy \
-  --policy-name thistle-regatta-deploy \
+  --policy-name race-crew-deploy \
   --policy-document file://iam-policy.json
 ```
 
@@ -154,14 +154,14 @@ aws sts get-caller-identity --query Account --output text
 
 # Attach the policy (replace <ACCOUNT_ID> with the value above)
 aws iam attach-user-policy \
-  --user-name thistle-regatta-deploy \
-  --policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/thistle-regatta-deploy
+  --user-name race-crew-deploy \
+  --policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/race-crew-deploy
 ```
 
 ### 4. Generate access keys
 
 ```bash
-aws iam create-access-key --user-name thistle-regatta-deploy
+aws iam create-access-key --user-name race-crew-deploy
 ```
 
 Save the output — the `SecretAccessKey` is only shown once.
@@ -178,8 +178,8 @@ You'll be prompted to paste each value.
 ### Verify setup
 
 ```bash
-aws iam get-user --user-name thistle-regatta-deploy
-aws iam list-attached-user-policies --user-name thistle-regatta-deploy
+aws iam get-user --user-name race-crew-deploy
+aws iam list-attached-user-policies --user-name race-crew-deploy
 gh secret list
 ```
 
@@ -191,7 +191,7 @@ Infrastructure is managed with Terraform in the `terraform/` directory. Terrafor
 provisions a Lightsail instance running Amazon Linux 2023 with Docker Compose.
 
 **Resources provisioned:**
-- Lightsail instance (`micro_3_0` — $5/mo, 1GB RAM)
+- Lightsail instance (`small_3_0` — $10/mo, 2GB RAM)
 - Static IP address (free when attached)
 - Firewall rules (ports 22, 80, 443)
 - SSH key pair for deployment
@@ -204,15 +204,15 @@ Complete the [CI/CD Setup](#cicd-setup-github-actions--terraform) section above 
 
 ```bash
 aws s3api create-bucket \
-  --bucket thistle-regatta-tfstate \
+  --bucket race-crew-tfstate \
   --region us-east-1
 
 aws s3api put-bucket-versioning \
-  --bucket thistle-regatta-tfstate \
+  --bucket race-crew-tfstate \
   --versioning-configuration Status=Enabled
 
 aws s3api put-public-access-block \
-  --bucket thistle-regatta-tfstate \
+  --bucket race-crew-tfstate \
   --public-access-block-configuration \
     BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
 ```
@@ -220,16 +220,16 @@ aws s3api put-public-access-block \
 #### 2. Generate SSH key pair
 
 ```bash
-ssh-keygen -t ed25519 -C "thistle-regatta-deploy" \
-  -f ~/.ssh/thistle-regatta-deploy -N ""
+ssh-keygen -t ed25519 -C "race-crew-deploy" \
+  -f ~/.ssh/race-crew-deploy -N ""
 ```
 
 #### 3. Store secrets in GitHub
 
 ```bash
 # SSH keys
-gh secret set LIGHTSAIL_SSH_PRIVATE_KEY < ~/.ssh/thistle-regatta-deploy
-gh secret set LIGHTSAIL_SSH_PUBLIC_KEY < ~/.ssh/thistle-regatta-deploy.pub
+gh secret set LIGHTSAIL_SSH_PRIVATE_KEY < ~/.ssh/race-crew-deploy
+gh secret set LIGHTSAIL_SSH_PUBLIC_KEY < ~/.ssh/race-crew-deploy.pub
 
 # Repository URL
 gh secret set REPO_URL --body "https://github.com/<owner>/<repo>.git"
@@ -237,18 +237,18 @@ gh secret set REPO_URL --body "https://github.com/<owner>/<repo>.git"
 # App secrets
 gh secret set SECRET_KEY --body "$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
 gh secret set MYSQL_ROOT_PASSWORD --body "$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
-gh secret set MYSQL_DATABASE --body "regatta"
-gh secret set MYSQL_USER --body "regatta"
+gh secret set MYSQL_DATABASE --body "racecrew"
+gh secret set MYSQL_USER --body "racecrew"
 gh secret set MYSQL_PASSWORD --body "$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
 ```
 
 #### 4. Store GitHub Variables
 
 ```bash
-gh variable set DOMAIN_NAME --body "yourdomain.com"
+gh variable set DOMAIN_NAME --body "racecrew.net"
 gh variable set CERTBOT_EMAIL --body "you@example.com"
-gh variable set MYSQL_DATABASE --body "regatta"
-gh variable set MYSQL_USER --body "regatta"
+gh variable set MYSQL_DATABASE --body "racecrew"
+gh variable set MYSQL_USER --body "racecrew"
 ```
 
 #### 5. Run Terraform
@@ -257,7 +257,7 @@ gh variable set MYSQL_USER --body "regatta"
 cd terraform
 terraform init
 terraform apply \
-  -var "ssh_public_key=$(cat ~/.ssh/thistle-regatta-deploy.pub)" \
+  -var "ssh_public_key=$(cat ~/.ssh/race-crew-deploy.pub)" \
   -var "repo_url=https://github.com/<owner>/<repo>.git"
 ```
 
@@ -273,7 +273,7 @@ The instance takes ~3 minutes to install Docker via user-data. Then verify:
 
 ```bash
 STATIC_IP=$(terraform output -raw static_ip)
-ssh -i ~/.ssh/thistle-regatta-deploy ec2-user@$STATIC_IP \
+ssh -i ~/.ssh/race-crew-deploy ec2-user@$STATIC_IP \
   "docker --version && docker compose version && ls ~/app"
 ```
 
@@ -288,7 +288,7 @@ gh workflow run deploy.yml
 The app auto-generates admin credentials on first boot:
 
 ```bash
-ssh -i ~/.ssh/thistle-regatta-deploy ec2-user@$STATIC_IP \
+ssh -i ~/.ssh/race-crew-deploy ec2-user@$STATIC_IP \
   "cd ~/app && docker compose logs web 2>&1 | grep -A 6 'INITIAL ADMIN'"
 ```
 
@@ -302,10 +302,10 @@ To make changes locally:
 ```bash
 cd terraform
 terraform plan \
-  -var "ssh_public_key=$(cat ~/.ssh/thistle-regatta-deploy.pub)" \
+  -var "ssh_public_key=$(cat ~/.ssh/race-crew-deploy.pub)" \
   -var "repo_url=https://github.com/<owner>/<repo>.git"
 terraform apply \
-  -var "ssh_public_key=$(cat ~/.ssh/thistle-regatta-deploy.pub)" \
+  -var "ssh_public_key=$(cat ~/.ssh/race-crew-deploy.pub)" \
   -var "repo_url=https://github.com/<owner>/<repo>.git"
 ```
 
@@ -314,7 +314,7 @@ To tear down everything:
 ```bash
 cd terraform
 terraform destroy \
-  -var "ssh_public_key=$(cat ~/.ssh/thistle-regatta-deploy.pub)" \
+  -var "ssh_public_key=$(cat ~/.ssh/race-crew-deploy.pub)" \
   -var "repo_url=https://github.com/<owner>/<repo>.git"
 ```
 
@@ -342,7 +342,7 @@ gh run list --workflow=deploy.yml
 ### SSH into the instance
 
 ```bash
-ssh -i ~/.ssh/thistle-regatta-deploy ec2-user@<STATIC_IP>
+ssh -i ~/.ssh/race-crew-deploy ec2-user@<STATIC_IP>
 cd ~/app
 docker compose ps
 docker compose logs web
@@ -378,10 +378,10 @@ every 60 days.
 
 ```bash
 # Dump database to file
-docker compose exec db mysqldump -u regatta -pregatta regatta > backup.sql
+docker compose exec db mysqldump -u racecrew -pracecrew racecrew > backup.sql
 
 # Restore from backup
-docker compose exec -T db mysql -u regatta -pregatta regatta < backup.sql
+docker compose exec -T db mysql -u racecrew -pracecrew racecrew < backup.sql
 ```
 
 ### Uploaded Documents

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-- [ ] Add a way to have Claude read provided documents and URLs to populate the regatta list for the year
+- [ ] Add a way to have Claude read provided documents and URLs to populate the schedule for the year
 - [ ] Create backups
 - [ ] Explore DB survivability
 - [ ] Security scan containers

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.16.0
+- Rename project from "Thistle Regatta Schedule" to "Race Crew Network"
+- Update all user-facing branding (templates, PDF, iCal, filenames)
+- Rename database/user from `regatta` to `racecrew`
+- Rename Terraform/AWS resources (S3 bucket, instance name, IAM user)
+- Update default admin email to `admin@racecrew.net`
+- Bump version to 0.16.0
+
 ## 0.15.1
 - Upgrade Lightsail instance from micro_3_0 (1GB) to small_3_0 (2GB) to resolve OOM issues
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/calendar/routes.py
+++ b/app/calendar/routes.py
@@ -34,17 +34,17 @@ def ical_feed(token: str):
     user = User.query.filter_by(calendar_token=token).first_or_404()
 
     cal = Calendar()
-    cal.add("prodid", "-//Thistle Regattas//EN")
+    cal.add("prodid", "-//Race Crew Network//EN")
     cal.add("version", "2.0")
     cal.add("calscale", "GREGORIAN")
-    cal.add("x-wr-calname", "Thistle Regattas")
+    cal.add("x-wr-calname", "Race Crew Network")
     cal.add("method", "PUBLISH")
 
     regattas = Regatta.query.order_by(Regatta.start_date).all()
 
     for regatta in regattas:
         event = Event()
-        event.add("uid", f"regatta-{regatta.id}@thistle-regattas")
+        event.add("uid", f"regatta-{regatta.id}@racecrew.net")
         event.add("summary", regatta.name)
         event.add("dtstart", regatta.start_date)
         # End date is exclusive in iCal, so add 1 day
@@ -82,5 +82,5 @@ def ical_feed(token: str):
         cal.add_component(event)
 
     response = Response(cal.to_ical(), mimetype="text/calendar")
-    response.headers["Content-Disposition"] = "attachment; filename=thistle-regattas.ics"
+    response.headers["Content-Disposition"] = "attachment; filename=race-crew-network.ics"
     return response

--- a/app/commands.py
+++ b/app/commands.py
@@ -26,7 +26,7 @@ def register_commands(app: Flask) -> None:
             return
 
         # Generate credentials
-        email = "admin@regattas.local"
+        email = "admin@racecrew.net"
         password = _generate_password()
         display_name = "Administrator"
         initials = "AD"

--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,7 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-change-me")
     SQLALCHEMY_DATABASE_URI = os.environ.get(
         "DATABASE_URL",
-        "mysql+pymysql://regatta:regatta@localhost:3306/regatta",
+        "mysql+pymysql://racecrew:racecrew@localhost:3306/racecrew",
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB max upload

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -54,7 +54,7 @@ def pdf():
     pdf_bytes = HTML(string=html_str).write_pdf()
     response = make_response(pdf_bytes)
     response.headers["Content-Type"] = "application/pdf"
-    response.headers["Content-Disposition"] = "inline; filename=thistle-schedule.pdf"
+    response.headers["Content-Disposition"] = "inline; filename=race-crew-schedule.pdf"
     return response
 
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,4 +1,4 @@
-/* Thistle Regatta Schedule */
+/* Race Crew Network */
 
 .rsvp-yes { color: #198754; font-weight: bold; }
 .rsvp-no { color: #dc3545; }

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Manage Crew — Thistle Regattas{% endblock %}
+{% block title %}Manage Crew — Race Crew Network{% endblock %}
 {% block content %}
 <h2 class="mb-4">Manage Crew</h2>
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}Thistle Regattas{% endblock %}</title>
+    <title>{% block title %}Race Crew Network{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
 </head>
 <body>
     <nav class="navbar navbar-expand-sm navbar-dark bg-dark">
         <div class="container">
-            <a class="navbar-brand" href="{{ url_for('regattas.index') }}">Thistle Regatta Schedule</a>
+            <a class="navbar-brand" href="{{ url_for('regattas.index') }}">Race Crew Network</a>
             {% if current_user.is_authenticated %}
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="{{ url_for('regattas.index') }}">Home</a>
@@ -47,7 +47,7 @@
     </div>
 
     <footer class="container mt-4 mb-3 text-center">
-        <small class="text-muted">Thistle Regatta Schedule v{{ app_version }}</small>
+        <small class="text-muted">Race Crew Network v{{ app_version }}</small>
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/app/templates/edit_user.html
+++ b/app/templates/edit_user.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Edit User — Thistle Regattas{% endblock %}
+{% block title %}Edit User — Race Crew Network{% endblock %}
 {% block content %}
 <div class="row justify-content-center mt-3">
     <div class="col-md-5">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Login — Thistle Regattas{% endblock %}
+{% block title %}Login — Race Crew Network{% endblock %}
 {% block content %}
 <div class="row justify-content-center mt-5">
     <div class="col-md-4">

--- a/app/templates/pdf_schedule.html
+++ b/app/templates/pdf_schedule.html
@@ -58,7 +58,7 @@
     </style>
 </head>
 <body>
-    <h1>Thistle Regatta Schedule</h1>
+    <h1>Race Crew Network</h1>
     <div class="subtitle">Generated {{ generated_date }}</div>
 
     {% macro regatta_rows(regattas) %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Profile — Thistle Regattas{% endblock %}
+{% block title %}Profile — Race Crew Network{% endblock %}
 {% block content %}
 <div class="row justify-content-center mt-3">
     <div class="col-md-5">

--- a/app/templates/regatta_form.html
+++ b/app/templates/regatta_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if regatta else "New" }} Regatta — Thistle Regattas{% endblock %}
+{% block title %}{{ "Edit" if regatta else "New" }} Regatta — Race Crew Network{% endblock %}
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-md-6">

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Join — Thistle Regattas{% endblock %}
+{% block title %}Join — Race Crew Network{% endblock %}
 {% block content %}
 <div class="row justify-content-center mt-5">
     <div class="col-md-4">

--- a/app/templates/view_profile.html
+++ b/app/templates/view_profile.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ user.display_name }} — Thistle Regattas{% endblock %}
+{% block title %}{{ user.display_name }} — Race Crew Network{% endblock %}
 {% block content %}
 <div class="row justify-content-center mt-3">
     <div class="col-md-5">

--- a/iam-policy.json
+++ b/iam-policy.json
@@ -31,8 +31,8 @@
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::thistle-regatta-tfstate",
-        "arn:aws:s3:::thistle-regatta-tfstate/*"
+        "arn:aws:s3:::race-crew-tfstate",
+        "arn:aws:s3:::race-crew-tfstate/*"
       ]
     }
   ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,7 +16,7 @@ resource "aws_lightsail_instance" "app" {
   })
 
   tags = {
-    Project = "thistle-regatta-schedule"
+    Project = "race-crew-network"
   }
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,7 +4,7 @@ output "instance_name" {
 }
 
 output "static_ip" {
-  description = "Static IP address — point hulagirl.us A record here"
+  description = "Static IP address — point racecrew.net A record here"
   value       = aws_lightsail_static_ip.app.ip_address
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "aws_region" {
 variable "instance_name" {
   description = "Name for the Lightsail instance"
   type        = string
-  default     = "thistle-regattas"
+  default     = "race-crew-network"
 }
 
 variable "availability_zone" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -9,7 +9,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket = "thistle-regatta-tfstate"
+    bucket = "race-crew-tfstate"
     key    = "lightsail/terraform.tfstate"
     region = "us-east-1"
   }


### PR DESCRIPTION
## Summary
- Rebrand from "Thistle Regatta Schedule" to "Race Crew Network" across all user-facing text, templates, PDF/iCal exports, and filenames
- Rename default DB credentials from `regatta` to `racecrew`, admin email to `admin@racecrew.net`
- Rename Terraform/AWS resources: S3 bucket (`race-crew-tfstate`), instance name (`race-crew-network`), IAM policy ARNs, project tags
- Update all documentation (README, CLAUDE.md, VERSIONS.md, TODO.md) and GitHub repo name
- Bump version 0.15.1 → 0.16.0

## Post-merge manual steps
1. Create S3 bucket `race-crew-tfstate` and migrate Terraform state from `thistle-regatta-tfstate`
2. Create/rename IAM user to `race-crew-deploy`
3. Set up Route53 hosted zone for `racecrew.net`
4. Update GitHub Variables/Secrets (`DOMAIN_NAME`, `REPO_URL`, `ROUTE53_ZONE_ID`, `MYSQL_DATABASE`, `MYSQL_USER`)
5. Delete old S3 bucket after verifying state migration

## Test plan
- [ ] `docker compose down -v && docker compose up --build` — verify app starts with new DB name
- [ ] Grep for remaining "thistle" references: `grep -ri "thistle" --include="*.py" --include="*.html" --include="*.md" --include="*.yml" --include="*.tf" --include="*.json" --include="*.css" .`
- [ ] Verify all pages render with "Race Crew Network" branding
- [ ] Verify PDF export shows new name
- [ ] Verify iCal export has new metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)