### PR TITLE
Allow Terraform apply on manual workflow dispatch

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -51,5 +51,5 @@ jobs:
         run: terraform plan -out=tfplan
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: terraform apply -auto-approve tfplan


### PR DESCRIPTION
## Summary
- Allow `terraform apply` to run on `workflow_dispatch` in addition to `push` events
- Enables manual Terraform apply when infrastructure changes need to be triggered without a terraform/ file change

## Context
After the project rename, Terraform needs to recreate infrastructure (new instance name, new DNS record) but the merge to master didn't change any `terraform/` files (net diff was zero), so the workflow wasn't triggered. This fix allows manual dispatch to also run apply.

## Test plan
- [ ] `gh workflow run terraform.yml` triggers plan AND apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)