### PR TITLE
Recreate instance when SSH key pair changes

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,6 +18,10 @@ resource "aws_lightsail_instance" "app" {
   tags = {
     Project = "race-crew-network"
   }
+
+  lifecycle {
+    replace_triggered_by = [aws_lightsail_key_pair.deploy.id]
+  }
 }
 
 # Static IP so the address survives instance stop/start


### PR DESCRIPTION
## Summary
- Add `replace_triggered_by` on the Lightsail instance so it gets recreated when the SSH key pair changes
- Lightsail only injects public keys at boot time; rotating keys without this triggers a key pair update but leaves the instance with the old authorized_keys

## Test plan
- [ ] Terraform plan shows instance recreation triggered by key pair change
- [ ] After apply, SSH with new key succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)