### PR TITLE
Force instance recreation for SSH key rotation

### DIFF
--- a/terraform/user-data.sh
+++ b/terraform/user-data.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 exec > >(tee /var/log/user-data.log) 2>&1
 
-echo "=== Starting user-data script ==="
+echo "=== Starting user-data script (race-crew-network) ==="
 
 # Update system packages
 dnf update -y


### PR DESCRIPTION
## Summary
- Trivial user-data change to force Lightsail instance recreation, picking up the new `race-crew-deploy` SSH key pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)