### PR TITLE
Remove stale hulagirl.us zone from IAM policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,8 @@ Semantic Versioning (SemVer): `MAJOR.MINOR.PATCH`
 - Local dev: `docker compose up --build`
 - Production: AWS Lightsail container service
 - 3 containers: web (Flask/Gunicorn), db (MySQL 8), nginx (reverse proxy)
+
+## Security
+- This is a public repo, store all sensitive information in GitHub secrets and variables
+- Check each PR for known security issues
+- When planning take security into consideration

--- a/iam-policy.json
+++ b/iam-policy.json
@@ -17,7 +17,6 @@
         "route53:GetChange"
       ],
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z08528331MMLNEIHD9QRS",
         "arn:aws:route53:::hostedzone/Z087459435NK1XH5B477J",
         "arn:aws:route53:::change/*"
       ]


### PR DESCRIPTION
## Summary
- Remove old hulagirl.us Route53 hosted zone ID from `iam-policy.json` (no longer needed after migration)
- Add security guidelines to CLAUDE.md for public repo practices

AWS IAM policy already updated to v5 to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)