### PR TITLE
Build and push Docker images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,11 @@ __pycache__
 *.pyc
 .DS_Store
 .claude
+.github
+terraform
+tests
+nginx
+scripts
+*.md
+TODO.md
+iam-policy.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,58 @@ concurrency:
 env:
   SSH_USER: ec2-user
   DEPLOY_BRANCH: ${{ inputs.branch || 'master' }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: chris-edwards-pub/race-crew-network
 
 jobs:
+  build-and-push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - name: Extract version from app/__init__.py
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=__version__ = ")[^"]+' app/__init__.py)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: build-and-push
 
     steps:
       - name: Configure SSH
@@ -46,14 +92,11 @@ jobs:
           git fetch origin "$BRANCH"
           git reset --hard "origin/$BRANCH"
 
-          # Stop running containers to free RAM for the build
-          docker compose down
+          # Pull pre-built image from GHCR
+          docker compose pull web
 
-          # Pre-pull base image to avoid buildx session timeout
-          docker pull python:3.11-slim
-
-          # Build and deploy
-          docker compose up -d --build --remove-orphans
+          # Deploy with new image
+          docker compose up -d --remove-orphans
 
           # Wait for containers to start
           echo "Waiting for containers..."

--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,8 @@
 - [ ] Explore DB survivability
 - [ ] Security scan containers
 - [ ] Use AWS federated tokens for auth
-- [ ] Store containers in GHCR or AWS ECR
+- [x] Store containers in GHCR or AWS ECR
 - [ ] Scan containers for vulnerabilities
 - [ ] GH Action change to manual deploy to AWS with specified version.
 - [ ] GH Action build containers with git push on any branch.
-- [ ] GH Action tag versions for master and for branches tag with banch name. ie: feature-thingy
+- [ ] GH Action tag versions for master and for branches tag with branch name. ie: feature-thingy

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.17.0
+- Build and push Docker images to GHCR via GitHub Actions
+- Deploy pulls pre-built images instead of building on server
+- Zero-downtime deploys (no more stopping containers to free RAM)
+- Images tagged with: latest, git SHA, semantic version
+- GHA build cache for fast subsequent builds
+- Trimmed .dockerignore to reduce build context size
+
 ## 0.16.1
 - Revert Lightsail instance_name default to avoid destroying deployed instance
 - Update IAM policy Route53 zone ID to racecrew.net hosted zone

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.16.1"
+__version__ = "0.17.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   web:
     build: .
+    image: ghcr.io/chris-edwards-pub/race-crew-network:latest
     env_file: .env
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- Add `build-and-push` job to deploy workflow that builds the web container image in GitHub Actions and pushes to GHCR with three tags (latest, git SHA, semantic version)
- Deploy job now pulls the pre-built image instead of building on the 2GB RAM Lightsail instance, eliminating the need to stop containers and enabling zero-downtime deploys
- Add `image:` directive to `docker-compose.yml` so `docker compose pull web` works on the server
- Trim `.dockerignore` to exclude `.github`, `terraform`, `tests`, `nginx`, `scripts`, `*.md`, and `iam-policy.json` from build context
- Bump version to 0.17.0

## Deploy flow change
**Before:** `docker compose down` → `docker pull python:3.11-slim` → `docker compose up -d --build` (downtime during build)
**After:** `docker compose pull web` → `docker compose up -d --remove-orphans` (zero-downtime)

## Fallback
The `build:` directive is still present in `docker-compose.yml`, so `docker compose up -d --build` on the server still works as a manual fallback.

## Test plan
- [ ] Verify `build-and-push` job succeeds in Actions tab
- [ ] Verify image appears at https://github.com/chris-edwards-pub/race-crew-network/pkgs/container/race-crew-network with all three tags
- [ ] Verify deploy job pulls the image and restarts without downtime
- [ ] Verify site is accessible after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)