### PR TITLE
Update README with GHCR deployment docs

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.17.1
+- Update README with GHCR deployment docs, rollback instructions, and emergency fallback
+
 ## 0.17.0
 - Build and push Docker images to GHCR via GitHub Actions
 - Deploy pulls pre-built images instead of building on server

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Rewrite Deployment section to document the two-stage build-and-push → deploy workflow
- Add Container Images subsection with GHCR location and browse link
- Add rollback instructions (pull specific version tag)
- Add emergency fallback instructions (build on server if GHCR is unavailable)
- Add branch-specific manual deploy example
- Add GHCR to Tech Stack and Cost table
- Bump version to 0.17.1

## Test plan
- [ ] Review README renders correctly on GitHub
- [ ] Verify all links and code blocks are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)