### PR TITLE
Add HTTPS redirect for naked domain via CloudFront

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,13 +15,12 @@ env:
   TF_VAR_db_password: ${{ secrets.MYSQL_PASSWORD }}
   TF_VAR_db_username: ${{ vars.MYSQL_USER }}
   TF_VAR_db_name: ${{ vars.MYSQL_DATABASE }}
-  TF_VAR_secret_key: ${{ secrets.SECRET_KEY }}
 
 jobs:
   terraform:
     name: Terraform
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     defaults:
       run:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.19.0
+- Add CloudFront distribution in front of S3 redirect bucket for apex domain HTTPS
+- ACM certificate for racecrew.net with DNS validation
+- Both https://racecrew.net and http://racecrew.net now redirect to https://www.racecrew.net
+- Add ACM and CloudFront permissions to IAM policy
+- Increase Terraform workflow timeout to 30 minutes for CloudFront deploys
+- Remove stale TF_VAR_secret_key from Terraform workflow
+
 ## 0.18.1
 - Require INIT_ADMIN_EMAIL and INIT_ADMIN_PASSWORD env vars for first deploy
 - Remove random password generation from init-admin command (Lightsail logs not accessible)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.18.1"
+__version__ = "0.19.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/iam-policy.json
+++ b/iam-policy.json
@@ -53,6 +53,35 @@
         "arn:aws:s3:::racecrew.net",
         "arn:aws:s3:::racecrew.net/*"
       ]
+    },
+    {
+      "Sid": "ACMCertificates",
+      "Effect": "Allow",
+      "Action": [
+        "acm:RequestCertificate",
+        "acm:DescribeCertificate",
+        "acm:DeleteCertificate",
+        "acm:ListCertificates",
+        "acm:ListTagsForCertificate",
+        "acm:AddTagsToCertificate",
+        "acm:GetCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudFrontDistribution",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:CreateDistribution",
+        "cloudfront:UpdateDistribution",
+        "cloudfront:DeleteDistribution",
+        "cloudfront:GetDistribution",
+        "cloudfront:ListDistributions",
+        "cloudfront:TagResource",
+        "cloudfront:ListTagsForResource",
+        "cloudfront:GetDistributionConfig"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -28,3 +28,8 @@ output "bucket_secret_access_key" {
   value       = aws_lightsail_bucket_access_key.app.secret_access_key
   sensitive   = true
 }
+
+output "cloudfront_distribution_domain" {
+  description = "CloudFront domain name for apex redirect"
+  value       = aws_cloudfront_distribution.apex_redirect.domain_name
+}


### PR DESCRIPTION
## Summary
- Add CloudFront distribution + ACM certificate in front of the S3 redirect bucket so `https://racecrew.net` terminates SSL and 301s to `https://www.racecrew.net`
- Add ACM and CloudFront permissions to IAM policy
- Increase Terraform workflow timeout to 30 min (CloudFront deploys can take 15-25 min), remove stale `TF_VAR_secret_key`
- Bump version to 0.19.0

## Pre-merge requirement
The IAM policy must be applied **before** Terraform runs, otherwise ACM/CloudFront API calls will be denied:
```bash
aws iam put-user-policy --user-name race-crew-deploy --policy-name race-crew-policy --policy-document file://iam-policy.json
```

## Test plan
- [ ] Apply IAM policy update to AWS
- [ ] `terraform plan` shows 4 new resources, 1 modified (apex record)
- [ ] `terraform apply` — ACM cert validates, CloudFront deploys, apex record updated
- [ ] `curl -I https://racecrew.net` → 301 to `https://www.racecrew.net`
- [ ] `curl -I http://racecrew.net` → 301 to `https://www.racecrew.net`
- [ ] `https://www.racecrew.net` continues working via Lightsail

🤖 Generated with [Claude Code](https://claude.com/claude-code)