### PR TITLE
Fix import for JS-rendered event pages, filter past events

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.20.1
+- Extract JSON-LD schema.org Event data from pages that load events via JavaScript
+- Automatically filter out past events from import results
+
 ## 0.20.0
 - AI-powered schedule import: admin page to paste text or URL, extract regattas via Claude API
 - Editable preview table with select/deselect before bulk import

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary

- Extract JSON-LD `schema.org/Event` data from `<script type="application/ld+json">` tags before stripping HTML, so pages that render events via JavaScript (e.g. j24class.org) now work
- Automatically filter out past events from import results, with a count shown to the user
- Version bump: 0.20.0 → 0.20.1

## Test plan
- [ ] Import from https://j24class.org/events/ — should find 5 events
- [ ] Import from https://thistleclass.com/regattas-and-events/ — should still work (plain text extraction)
- [ ] Verify past events are excluded from results
- [ ] `black . && isort . && flake8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)