### PR TITLE
Detect duplicate regattas during AI import preview

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,12 @@
 # Version History
 
+## 0.21.0
+- Detect duplicate regattas during AI import preview with warning badges
+- Case-insensitive duplicate matching (name + start date) against existing regattas
+- Duplicate rows highlighted in yellow and unchecked by default in preview table
+- Existing regatta details shown inline so admin can make informed decisions
+- Improved confirm-step duplicate check to be case-insensitive
+
 ## 0.20.2
 - Bulk delete regattas: admin can select multiple regattas via checkboxes and delete them at once
 - Select-all checkbox and confirmation dialog for both upcoming and past tables

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.20.2"
+__version__ = "0.21.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/templates/admin/import_schedule.html
+++ b/app/templates/admin/import_schedule.html
@@ -42,7 +42,7 @@
                     <thead class="table-light">
                         <tr>
                             <th style="width: 40px;">
-                                <input type="checkbox" id="select-all" checked>
+                                <input type="checkbox" id="select-all" {% if not regattas|selectattr('duplicate_of')|list %}checked{% endif %}>
                             </th>
                             <th>Name</th>
                             <th>Location</th>
@@ -53,12 +53,17 @@
                     </thead>
                     <tbody>
                         {% for r in regattas %}
-                        <tr>
+                        <tr{% if r.duplicate_of %} class="table-warning"{% endif %}>
                             <td class="text-center">
-                                <input type="checkbox" name="selected" value="{{ loop.index0 }}" checked>
+                                <input type="checkbox" name="selected" value="{{ loop.index0 }}" {% if not r.duplicate_of %}checked{% endif %}>
                             </td>
                             <td>
                                 <input type="text" class="form-control form-control-sm" name="name_{{ loop.index0 }}" value="{{ r.name or '' }}" required>
+                                {% if r.duplicate_of %}
+                                <small class="d-block mt-1" style="color: #856404;">
+                                    &#9888; Possible duplicate of: {{ r.duplicate_of.name }} ({{ r.duplicate_of.start_date }}{% if r.duplicate_of.location %} at {{ r.duplicate_of.location }}{% endif %})
+                                </small>
+                                {% endif %}
                             </td>
                             <td>
                                 <input type="text" class="form-control form-control-sm" name="location_{{ loop.index0 }}" value="{{ r.location or '' }}">


### PR DESCRIPTION
## Summary
- Surface potential duplicates in the import preview table with warning badges so admins can make informed decisions before confirming
- Case-insensitive name + start date matching against existing regattas via new `_find_duplicate()` helper
- Duplicate rows highlighted in yellow and unchecked by default; existing regatta details shown inline
- Improved confirm-step duplicate check to also be case-insensitive
- Version bump to 0.21.0

## Test plan
- [ ] Import a schedule containing a regatta that already exists in the DB — verify yellow warning row with existing regatta details
- [ ] Import a schedule with no duplicates — verify clean preview with all rows checked
- [ ] Verify duplicate rows are unchecked by default but can be re-checked and imported
- [ ] Verify case-insensitive matching (e.g. "REGATTA NAME" matches "Regatta Name")

🤖 Generated with [Claude Code](https://claude.com/claude-code)