### PR TITLE
Add site summary to login landing page

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 0.28.0
+- Add site summary with feature list to login page (two-column layout, stacks on mobile)
+- Serve login page at `/` for anonymous users instead of redirecting to `/login?next=%2F`
+- Remove Flask-Login "Please log in" flash message
+- Login form wrapped in a Bootstrap card with shadow for visual separation
+
 ## 0.27.0
 - Make website fully responsive for phone, tablet, and desktop
 - Add hamburger menu toggler and collapsible navbar (collapses below 768px)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,12 +4,13 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()
 login_manager.login_view = "auth.login"
+login_manager.login_message = None
 csrf = CSRFProtect()
 
 

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -14,8 +14,10 @@ from app.regattas import bp
 
 
 @bp.route("/")
-@login_required
 def index():
+    if not current_user.is_authenticated:
+        return render_template("login.html")
+
     today = date.today()
     upcoming = (
         Regatta.query.filter(Regatta.start_date >= today)

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,21 +1,40 @@
 {% extends "base.html" %}
 {% block title %}Login — Race Crew Network{% endblock %}
 {% block content %}
-<div class="row justify-content-center mt-5">
-    <div class="col-md-4">
-        <h2 class="mb-4">Login</h2>
-        <form method="POST">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <div class="mb-3">
-                <label for="email" class="form-label">Email</label>
-                <input type="email" class="form-control" id="email" name="email" required autofocus>
+<div class="row justify-content-center align-items-center mt-5">
+    <!-- Left: Site summary -->
+    <div class="col-md-6 col-lg-5 mb-4 mb-md-0 text-center text-md-start">
+        <h2>Organize your sailing crew</h2>
+        <p class="text-muted">
+            Race Crew Network helps sailing teams stay on top of their regatta season.
+        </p>
+        <ul class="list-unstyled text-muted">
+            <li class="mb-2">&#9993; Track regatta schedules and locations</li>
+            <li class="mb-2">&#128196; Manage NOR, SI, and race documents</li>
+            <li class="mb-2">&#9989; Coordinate crew with Yes / No / Maybe RSVPs</li>
+            <li class="mb-2">&#128279; Import schedules from URLs or pasted text</li>
+        </ul>
+        <small class="text-muted">Invite-only — ask your crew admin for access.</small>
+    </div>
+    <!-- Right: Login form -->
+    <div class="col-md-5 col-lg-4">
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <h4 class="card-title mb-3">Login</h4>
+                <form method="POST" action="{{ url_for('auth.login') }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="email" class="form-label">Email</label>
+                        <input type="email" class="form-control" id="email" name="email" required autofocus>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Password</label>
+                        <input type="password" class="form-control" id="password" name="password" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Login</button>
+                </form>
             </div>
-            <div class="mb-3">
-                <label for="password" class="form-label">Password</label>
-                <input type="password" class="form-control" id="password" name="password" required>
-            </div>
-            <button type="submit" class="btn btn-primary w-100">Login</button>
-        </form>
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add a welcoming site summary with feature list alongside the login form (two-column layout)
- Serve the login page directly at `/` for anonymous users instead of redirecting to `/login?next=%2F`
- Remove Flask-Login's default "Please log in to access this page" flash message
- Login form wrapped in a Bootstrap card with shadow for visual separation
- Responsive: columns stack on mobile, side-by-side on desktop

## Test plan
- [x] `pytest` — all 67 tests pass
- [ ] Verify at 375px (phone): summary stacks above login form
- [ ] Verify at 1200px (desktop): summary on left, login form on right
- [ ] Verify `/` shows login page when not authenticated
- [ ] Verify `/` shows regatta list when authenticated
- [ ] Verify login form submits correctly from `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)