### PR TITLE
Enable database and object storage backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ instance/
 uploads/*
 !uploads/.gitkeep
 .DS_Store
+*~lock~
 *.egg-info/
 dist/
 build/

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 0.30.0
+- Enable automated daily database backups with 7-day retention and point-in-time recovery
+- Set preferred backup window to 06:00–06:30 UTC (2:00–2:30 AM ET)
+- Add final snapshot on database deletion as a safety net
+- Enable versioning on Lightsail upload bucket to protect against accidental file deletion
+
 ## 0.29.0
 - Add SVG favicon with PNG fallbacks for all devices (16x16, 32x32, 180x180 apple-touch-icon, 192x192 and 512x512 android-chrome)
 - Remove legacy favicon.ico, consolidate all favicon assets into img/ directory

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,6 +45,11 @@ resource "aws_lightsail_database" "app" {
   bundle_id                = var.db_bundle_id
   publicly_accessible      = true
 
+  backup_retention_enabled = true
+  preferred_backup_window  = "06:00-06:30" # 2:00–2:30 AM ET
+  apply_immediately        = true
+  final_snapshot_name      = "${var.instance_name}-db-final-snapshot"
+
   tags = {
     Project = "race-crew-network"
   }
@@ -59,6 +64,18 @@ resource "aws_lightsail_bucket" "uploads" {
   tags = {
     Project = "race-crew-network"
   }
+}
+
+resource "null_resource" "bucket_versioning" {
+  triggers = {
+    bucket_name = aws_lightsail_bucket.uploads.name
+  }
+
+  provisioner "local-exec" {
+    command = "aws lightsail update-bucket --bucket-name ${aws_lightsail_bucket.uploads.name} --versioning Enabled --region ${var.aws_region}"
+  }
+
+  depends_on = [aws_lightsail_bucket.uploads]
 }
 
 resource "aws_lightsail_bucket_access_key" "app" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 
   backend "s3" {


### PR DESCRIPTION
## Summary
- Enable 7-day automated daily backups with point-in-time recovery on the Lightsail managed MySQL database
- Add final snapshot on `terraform destroy` as a safety net
- Enable versioning on the Lightsail upload bucket to protect NOR/SI documents against accidental deletion
- Add `hashicorp/null` provider for bucket versioning via AWS CLI `local-exec`
- $0 additional cost — backups included in Lightsail DB bundle, versioning free at current volume

## Test plan
- [ ] `terraform plan` shows DB updated in-place (backup params) and `null_resource.bucket_versioning` created
- [ ] After merge, confirm in AWS console: DB shows backup retention enabled
- [ ] After merge, confirm in AWS console: upload bucket shows versioning enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)