### PR TITLE
Add container vulnerability scanning and upgrade to Python 3.13

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,11 +64,57 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  scan-image:
+    name: Scan Image for Vulnerabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build-and-push
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          format: table
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          output: trivy-results.txt
+
+      - name: Upload scan results as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-vulnerability-report
+          path: trivy-results.txt
+          retention-days: 30
+
+      - name: Run Trivy for SARIF output
+        if: always()
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: build-and-push
+    needs: scan-image
 
     steps:
       - name: Configure AWS credentials

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple web app for organizing sailboat regattas. Track dates, locations, NOR/S
 
 ## Tech Stack
 
-- Python 3.11, Flask, SQLAlchemy, Flask-Login
+- Python 3.13, Flask, SQLAlchemy, Flask-Login
 - MySQL 8 (Lightsail Managed Database in production)
 - Gunicorn
 - Docker Compose (local dev)
@@ -317,14 +317,18 @@ terraform destroy \
 ## Deployment
 
 Every push to `master` triggers automatic deployment via GitHub Actions. The
-workflow has two stages:
+workflow has three stages:
 
 1. **Build & Push** — Builds the Docker image in GitHub Actions using BuildKit
    with layer caching, then pushes to GHCR with three tags:
    - `latest` — for docker-compose simplicity
    - Git SHA (e.g. `065d419e...`) — for traceability and rollback
    - Semantic version (e.g. `0.18.0`) — for release tracking
-2. **Deploy** — Uses AWS CLI to create a new container service deployment with
+2. **Scan Image** — Runs Trivy vulnerability scanner against the pushed image.
+   Blocks deployment if CRITICAL or HIGH severity vulnerabilities are found
+   (unfixed CVEs are ignored). Results are uploaded as a GitHub Actions artifact
+   and to the GitHub Security tab in SARIF format.
+3. **Deploy** — Uses AWS CLI to create a new container service deployment with
    the SHA-tagged image and environment variables from GitHub Secrets/Variables.
 
 The container service handles HTTPS termination, health checks, and rolling

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,6 @@
 # TODO
 
-- [ ] Create backups
-- [ ] Explore DB survivability
-- [ ] Security scan containers
 - [ ] Use AWS federated tokens for auth
-- [ ] Scan containers for vulnerabilities
 - [ ] GH Action change to manual deploy to AWS with specified version
 - [ ] GH Action build containers with git push on any branch
 - [ ] GH Action tag versions for master and for branches tag with branch name. ie: feature-thingy

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 0.31.0
+- Add container vulnerability scanning with Trivy between build and deploy stages
+- Block deployment of images with CRITICAL or HIGH severity vulnerabilities
+- Scan results uploaded as GitHub Actions artifact and to GitHub Security tab (SARIF)
+- Upgrade base Docker image from python:3.11-slim to python:3.13-slim for fewer CVEs
+
 ## 0.30.0
 - Enable automated daily database backups with 7-day retention and point-in-time recovery
 - Set preferred backup window to 06:00–06:30 UTC (2:00–2:30 AM ET)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Insert a Trivy `scan-image` job between `build-and-push` and `deploy` that blocks deployment when CRITICAL or HIGH vulnerabilities are found (unfixed CVEs ignored)
- Scan results uploaded as a GitHub Actions artifact (30-day retention) and to the GitHub Security tab in SARIF format
- Upgrade Dockerfile base image from `python:3.11-slim` to `python:3.13-slim` for fewer CVEs and Python support through April 2029

## Pipeline
```
build-and-push  →  scan-image (NEW)  →  deploy
```

## Test plan
- [ ] Push branch and confirm `scan-image` job appears between build and deploy in Actions
- [ ] Verify Trivy results artifact is downloadable from the workflow run
- [ ] Check GitHub Security tab for SARIF findings
- [ ] Confirm deploy is skipped if scan fails, proceeds if scan passes
- [ ] Verify all 67 existing tests pass (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)