### PR TITLE
Fix Trivy binary install failure in scan-image job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: table
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run Trivy for SARIF output
         if: always()
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: sarif

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.31.1
+- Update trivy-action from 0.33.1 to 0.34.2 to fix binary install failure
+
 ## 0.31.0
 - Add container vulnerability scanning with Trivy between build and deploy stages
 - Block deployment of images with CRITICAL or HIGH severity vulnerabilities

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.31.0"
+__version__ = "0.31.1"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Update `aquasecurity/trivy-action` from `0.33.1` to `0.34.2` to fix binary download failure
- The previous version failed to install the Trivy binary, causing both scan steps to exit with code 1 before scanning
- v0.34.2 ships with Trivy v0.69.2 and includes post-security-incident fixes from March 2, 2026

## Test plan
- [ ] Merge and confirm the `scan-image` job installs Trivy successfully
- [ ] Verify scan results artifact is uploaded
- [ ] Verify SARIF results appear in the Security tab
- [ ] If scan passes, deploy proceeds; if vulnerabilities found, deploy is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)