### PR TITLE
Fix Trivy vulnerability DB download failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,10 @@ jobs:
       contents: read
       security-events: write
 
+    env:
+      TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2
+      TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1
+
     steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.34.2

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.31.2
+- Use GHCR as Trivy vulnerability DB source instead of broken mirror.gcr.io default
+
 ## 0.31.1
 - Update trivy-action from 0.33.1 to 0.34.2 to fix binary install failure
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.31.1"
+__version__ = "0.31.2"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- The default Trivy DB mirror (`mirror.gcr.io/aquasec/trivy-db:2`) returns 404, likely fallout from the [March 1 security incident](https://github.com/aquasecurity/trivy/discussions/10265)
- Set `TRIVY_DB_REPOSITORY` and `TRIVY_JAVA_DB_REPOSITORY` env vars to pull directly from `ghcr.io/aquasecurity` instead

## Error from previous run
```
FATAL: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB:
  GET https://mirror.gcr.io/artifacts-downloads/.../trivy-db: unexpected status code 404 Not Found
```

## Test plan
- [ ] Merge and confirm Trivy downloads the vulnerability DB successfully
- [ ] Verify scan completes and results artifact is uploaded
- [ ] Confirm deploy proceeds (or blocks if real vulnerabilities found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)