### PR TITLE
Upgrade cryptography and weasyprint to fix HIGH vulnerabilities

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,6 @@
 # TODO
 
 - [ ] Use AWS federated tokens for auth
-- [ ] GH Action change to manual deploy to AWS with specified version
-- [ ] GH Action build containers with git push on any branch
-- [ ] GH Action tag versions for master and for branches tag with branch name. ie: feature-thingy
 - [ ] Setup email & SMS reminders
 - [ ] Can we cache any of the AI excepted regattas? AI could search internally first. Then allow me to force a second search on a URL in case more regattas were added.
 - [ ] Would saving the structure of a page visited and regattas found save on tokens?

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.32.1
+- Upgrade cryptography 44.0.0 → 46.0.5 (CVE-2026-26007, HIGH)
+- Upgrade weasyprint 63.1 → 68.1 (CVE-2025-68616, HIGH, SSRF)
+
 ## 0.32.0
 - Append Trivy vulnerability scan results to GitHub Actions job summary via $GITHUB_STEP_SUMMARY
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.32.0"
+__version__ = "0.32.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ Flask-Migrate==4.0.7
 Flask-WTF==1.2.2
 WTForms==3.2.1
 PyMySQL==1.1.1
-cryptography==44.0.0
+cryptography==46.0.5
 bcrypt==4.2.1
 gunicorn==23.0.0
 python-dotenv==1.0.1
 icalendar==6.1.3
-weasyprint==63.1
+weasyprint==68.1
 boto3>=1.35.0
 anthropic>=0.43.0
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- Upgrade **cryptography** 44.0.0 → 46.0.5 — fixes CVE-2026-26007 (HIGH, subgroup attack due to missing validation for SECT curves)
- Upgrade **weasyprint** 63.1 → 68.1 — fixes CVE-2025-68616 (HIGH, server-side request forgery)
- Both were flagged by the Trivy container vulnerability scan, blocking deployment

## Test plan
- [x] All 67 tests pass locally with upgraded packages
- [ ] Trivy scan passes with no CRITICAL/HIGH vulnerabilities
- [ ] Deploy proceeds after clean scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)