### PR TITLE
Prevent SARIF upload failures from blocking deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,7 @@ jobs:
 
       - name: Run Trivy for SARIF output
         if: always()
+        continue-on-error: true
         uses: aquasecurity/trivy-action@0.34.2
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
@@ -123,6 +124,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.32.2
+- Add continue-on-error to SARIF steps so transient GitHub outages don't block deployment
+
 ## 0.32.1
 - Upgrade cryptography 44.0.0 → 46.0.5 (CVE-2026-26007, HIGH)
 - Upgrade weasyprint 63.1 → 68.1 (CVE-2025-68616, HIGH, SSRF)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.32.1"
+__version__ = "0.32.2"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the SARIF Trivy scan and SARIF upload steps
- These are best-effort reporting steps for the GitHub Security tab — not the security gate
- The first Trivy scan step (with `exit-code: 1`) remains the actual deploy gate
- Fixes: a transient GitHub 500 on the Trivy repo clone caused the SARIF step to fail, which blocked deployment despite a **clean vulnerability scan** (zero CRITICAL/HIGH findings)

## Test plan
- [ ] Merge and confirm deploy proceeds through all three stages
- [ ] Verify SARIF upload succeeds when GitHub is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)