### PR TITLE
Fix missing notes extraction and add document duplicate detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,11 @@ Semantic Versioning (SemVer): `MAJOR.MINOR.PATCH`
 - Check each PR for known security issues
 - When planning take security into consideration
 
+## Design
+- All pages and components must be responsive — designed to work on phones, tablets, and desktop screens
+- Use Bootstrap's responsive grid, breakpoints, and utility classes to ensure layouts adapt to all screen sizes
+- Test views at mobile (< 576px), tablet (768px), and desktop (1200px+) widths
+
 ## Documentation
 - Keep the README.md file up to date with each PR
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 0.34.2
+- Extract JSON-LD description, organizer, address, and URLs for richer AI extraction (fixes missing notes)
+- Duplicate detection on document discovery review page with yellow warning rows
+- Attaching a duplicate document replaces the existing one instead of creating a copy
+- Add responsive design requirement to CLAUDE.md
+
 ## 0.34.1
 - Fix detail_url fallback to apply to all regattas in multi-regatta imports (source_url was not being saved)
 - Fix flaky test cleanup with gc.collect() for SQLAlchemy identity map stale weakrefs

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.34.1"
+__version__ = "0.34.2"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -267,12 +267,43 @@ def _extract_jsonld_events(html: str) -> str:
     for ev in events:
         loc = ev.get("location", {})
         loc_name = loc.get("name", "") if isinstance(loc, dict) else ""
-        lines.append(
-            f"- {ev.get('name', 'Unknown')}"
-            f" | {ev.get('startDate', '')}"
-            f" - {ev.get('endDate', '')}"
-            f" | {loc_name}"
-        )
+        loc_addr = ""
+        if isinstance(loc, dict):
+            loc_addr = loc.get("address", "")
+            if isinstance(loc_addr, dict):
+                loc_addr = loc_addr.get("streetAddress", "")
+
+        parts = [
+            f"- {ev.get('name', 'Unknown')}",
+            f"  Dates: {ev.get('startDate', '')} - {ev.get('endDate', '')}",
+            f"  Location: {loc_name}",
+        ]
+        if loc_addr:
+            parts.append(f"  Address: {loc_addr}")
+
+        organizer = ev.get("organizer", {})
+        if isinstance(organizer, dict) and organizer.get("name"):
+            parts.append(f"  Organizer: {organizer['name']}")
+
+        offers = ev.get("offers", {})
+        if isinstance(offers, dict) and offers.get("url"):
+            parts.append(f"  URL: {offers['url']}")
+
+        url = ev.get("url", "")
+        if url and url != (offers.get("url") if isinstance(offers, dict) else ""):
+            parts.append(f"  URL: {url}")
+
+        desc = ev.get("description", "")
+        if desc:
+            # Clean up HTML entities and excessive whitespace
+            desc = re.sub(r"&nbsp;", " ", desc)
+            desc = re.sub(r"&amp;", "&", desc)
+            desc = re.sub(r"\s+", " ", desc).strip()
+            if len(desc) > 500:
+                desc = desc[:500] + "..."
+            parts.append(f"  Details: {desc}")
+
+        lines.append("\n".join(parts))
     return "\n".join(lines)
 
 
@@ -1191,10 +1222,15 @@ def review_documents_for_regatta(regatta_id: int):
         return redirect(url_for("regattas.edit", regatta_id=regatta_id))
 
     data = _discovery_results.pop(task_id)
+
+    # Build a map of existing doc URLs to doc_type for duplicate detection
+    existing_docs = {doc.url: doc.doc_type for doc in regatta.documents if doc.url}
+
     return render_template(
         "admin/regatta_discover_documents.html",
         regatta=regatta,
         documents=data["documents"],
+        existing_docs=existing_docs,
     )
 
 
@@ -1217,7 +1253,11 @@ def attach_documents_for_regatta(regatta_id: int):
     except ValueError:
         doc_count = 0
 
+    # Map existing doc URLs to their Document objects for replacement
+    existing_by_url = {doc.url: doc for doc in regatta.documents if doc.url}
+
     created = 0
+    replaced = 0
     for i in range(doc_count):
         checkbox = request.form.get(f"doc_{i}")
         if not checkbox:
@@ -1225,19 +1265,31 @@ def attach_documents_for_regatta(regatta_id: int):
         doc_type = request.form.get(f"doc_type_{i}", "").strip()
         doc_url = request.form.get(f"doc_url_{i}", "").strip()
         if doc_type and doc_url:
-            doc = Document(
-                regatta_id=regatta_id,
-                doc_type=doc_type,
-                url=doc_url,
-                uploaded_by=current_user.id,
-            )
-            db.session.add(doc)
-            created += 1
+            existing = existing_by_url.get(doc_url)
+            if existing:
+                existing.doc_type = doc_type
+                existing.uploaded_by = current_user.id
+                replaced += 1
+            else:
+                doc = Document(
+                    regatta_id=regatta_id,
+                    doc_type=doc_type,
+                    url=doc_url,
+                    uploaded_by=current_user.id,
+                )
+                db.session.add(doc)
+                existing_by_url[doc_url] = doc
+                created += 1
 
     db.session.commit()
 
+    parts = []
     if created:
-        flash(f"{created} document(s) attached.", "success")
+        parts.append(f"{created} document(s) attached")
+    if replaced:
+        parts.append(f"{replaced} existing document(s) updated")
+    if parts:
+        flash(". ".join(parts) + ".", "success")
     else:
         flash("No documents selected.", "warning")
 

--- a/app/templates/admin/regatta_discover_documents.html
+++ b/app/templates/admin/regatta_discover_documents.html
@@ -18,8 +18,9 @@
                 </div>
                 <div class="card-body">
                     {% for doc in documents %}
-                    <div class="form-check mb-2">
-                        <input class="form-check-input" type="checkbox" name="doc_{{ loop.index0 }}" value="1" checked>
+                    {% set is_dup = doc.url in existing_docs %}
+                    <div class="form-check mb-2 p-2 ps-4 rounded{% if is_dup %} bg-warning bg-opacity-25{% endif %}">
+                        <input class="form-check-input" type="checkbox" name="doc_{{ loop.index0 }}" value="1" {% if not is_dup %}checked{% endif %}>
                         <input type="hidden" name="doc_type_{{ loop.index0 }}" value="{{ doc.doc_type }}">
                         <input type="hidden" name="doc_url_{{ loop.index0 }}" value="{{ doc.url }}">
                         <label class="form-check-label">
@@ -27,6 +28,11 @@
                             {{ doc.label }}
                             — <a href="{{ doc.url }}" target="_blank" rel="noopener">{{ doc.url|truncate(60) }}</a>
                         </label>
+                        {% if is_dup %}
+                        <small class="d-block mt-1" style="color: #856404;">
+                            &#9888; Duplicate of existing {{ existing_docs[doc.url] }} document already attached to this regatta
+                        </small>
+                        {% endif %}
                     </div>
                     {% endfor %}
                 </div>

--- a/tests/test_admin_helpers.py
+++ b/tests/test_admin_helpers.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from bs4 import BeautifulSoup
 
-from app.admin.routes import (_extract_data_attributes,
+from app.admin.routes import (_extract_data_attributes, _extract_jsonld_events,
                               _fetch_clubspot_documents, _is_private_ip,
                               _parse_clubspot_regatta_id)
 
@@ -95,6 +95,91 @@ class TestExtractDataAttributes:
         html = "<html><body data-broken='{\"unclosed: true'></body></html>"
         soup = BeautifulSoup(html, "html.parser")
         result = _extract_data_attributes(soup)
+        assert result == ""
+
+
+# --- _extract_jsonld_events ---
+
+
+class TestExtractJsonldEvents:
+    def test_extracts_basic_fields(self):
+        html = """<script type="application/ld+json">{
+            "@type": "Event",
+            "name": "Test Regatta",
+            "startDate": "2026-06-01",
+            "endDate": "2026-06-02",
+            "location": {"@type": "Place", "name": "Yacht Club"}
+        }</script>"""
+        result = _extract_jsonld_events(html)
+        assert "Test Regatta" in result
+        assert "2026-06-01" in result
+        assert "Yacht Club" in result
+
+    def test_includes_description(self):
+        html = """<script type="application/ld+json">{
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-06-01",
+            "description": "Entry fee $50. Contact: john@example.com"
+        }</script>"""
+        result = _extract_jsonld_events(html)
+        assert "Entry fee $50" in result
+        assert "john@example.com" in result
+
+    def test_includes_organizer(self):
+        html = """<script type="application/ld+json">{
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-06-01",
+            "organizer": {"@type": "Person", "name": "Jane Doe"}
+        }</script>"""
+        result = _extract_jsonld_events(html)
+        assert "Jane Doe" in result
+
+    def test_includes_address(self):
+        html = """<script type="application/ld+json">{
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-06-01",
+            "location": {
+                "@type": "Place",
+                "name": "Yacht Club",
+                "address": "123 Main St, Anytown, USA"
+            }
+        }</script>"""
+        result = _extract_jsonld_events(html)
+        assert "123 Main St" in result
+
+    def test_truncates_long_description(self):
+        long_desc = "A" * 600
+        html = f"""<script type="application/ld+json">{{
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-06-01",
+            "description": "{long_desc}"
+        }}</script>"""
+        result = _extract_jsonld_events(html)
+        assert "..." in result
+        # Description portion should be truncated to ~500 chars
+        assert long_desc[:500] in result
+        assert long_desc[:501] not in result
+
+    def test_includes_offers_url(self):
+        html = """<script type="application/ld+json">{
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-06-01",
+            "offers": {"url": "https://register.example.com/event/123"}
+        }</script>"""
+        result = _extract_jsonld_events(html)
+        assert "https://register.example.com/event/123" in result
+
+    def test_no_events_returns_empty(self):
+        html = """<script type="application/ld+json">{
+            "@type": "Organization",
+            "name": "Not an event"
+        }</script>"""
+        result = _extract_jsonld_events(html)
         assert result == ""
 
 

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -638,6 +638,51 @@ class TestAttachDocumentsForRegatta:
         )
         assert b"No documents selected" in resp.data
 
+    def test_attach_replaces_duplicates(self, app, logged_in_client, db, admin_user):
+        regatta = Regatta(
+            name="Dup Replace Test",
+            location="Test YC",
+            start_date=date(2026, 9, 30),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        # Pre-attach a document as NOR
+        existing = Document(
+            regatta_id=regatta.id,
+            doc_type="NOR",
+            url="https://example.com/nor.pdf",
+            uploaded_by=admin_user.id,
+        )
+        db.session.add(existing)
+        db.session.commit()
+        existing_id = existing.id
+
+        # Attach same URL (updated type) plus a new one
+        resp = logged_in_client.post(
+            f"/admin/regattas/{regatta.id}/attach-documents",
+            data={
+                "doc_count": "2",
+                "doc_0": "1",
+                "doc_type_0": "SI",
+                "doc_url_0": "https://example.com/nor.pdf",
+                "doc_1": "1",
+                "doc_type_1": "WWW",
+                "doc_url_1": "https://example.com/regatta",
+            },
+            follow_redirects=True,
+        )
+        assert b"1 document(s) attached" in resp.data
+        assert b"1 existing document(s) updated" in resp.data
+
+        docs = Document.query.filter_by(regatta_id=regatta.id).all()
+        assert len(docs) == 2  # updated existing + new WWW
+
+        # Verify the existing doc was updated in place
+        updated = db.session.get(Document, existing_id)
+        assert updated.doc_type == "SI"
+
     def test_regatta_not_found(self, logged_in_client):
         resp = logged_in_client.post(
             "/admin/regattas/99999/attach-documents",


### PR DESCRIPTION
## Summary
- Extract JSON-LD `description`, `organizer`, `address`, and `offers.url` in `_extract_jsonld_events()` so the AI receives rich event details for notes extraction. Previously only name/dates/location were passed, causing `notes=null` for all regattas on listing pages like thistleclass.com.
- Add duplicate detection to the "Find Documents" review page on regatta edit — duplicates show yellow warning rows (matching the import preview style) and are unchecked by default.
- Attaching a duplicate document replaces the existing record instead of creating a copy.
- Add responsive design section to CLAUDE.md.

## Test plan
- [x] 94 tests pass
- [x] Black, isort, flake8 clean
- [ ] Import from thistleclass.com with Force re-extract — verify notes are populated
- [ ] Find Documents on a regatta with existing docs — verify yellow duplicate warnings
- [ ] Attach a duplicate doc — verify it replaces instead of creating a second copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)