### PR TITLE
Add 10-day Flask training curriculum

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,4 @@
 - [ ] Allow Profile Pictures
 - [ ] Import schedule from PDF
 - [ ] Create a help section with instructions
+- [ ] Update lessons

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.35.0
+- Add 10-day Flask training curriculum (python-class/) with 12 text files
+- Training materials cover app architecture, models, auth, CRUD, RSVP, file uploads, iCal, Docker, and deployment
+- All lessons updated to reflect current codebase at v0.34.2 (Race Crew Network branding, 5 models, 4 blueprints, S3 storage, Lightsail deployment, CI/CD)
+
 ## 0.34.2
 - Extract JSON-LD description, organizer, address, and URLs for richer AI extraction (fixes missing notes)
 - Duplicate detection on document discovery review page with yellow warning rows

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 
-__version__ = "0.34.2"
+__version__ = "0.35.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/python-class/00-index.txt
+++ b/python-class/00-index.txt
@@ -1,0 +1,379 @@
+================================================================================
+        RACE CREW NETWORK - FLASK APPLICATION TRAINING
+                        10-DAY CURRICULUM
+================================================================================
+
+COURSE OVERVIEW
+--------------------------------------------------------------------------------
+This training program teaches you how to build and deploy a production-ready
+Flask web application through the study of the Race Crew Network app.
+Over 10 days, you'll learn Flask fundamentals, database management with
+SQLAlchemy, authentication, file uploads, calendar integration, AI-powered
+data import, cloud storage, and containerized cloud deployment.
+
+TARGET AUDIENCE
+--------------------------------------------------------------------------------
+IT professionals with:
+- Basic Python knowledge (variables, functions, classes)
+- Docker familiarity (containers, images, compose)
+- Interest in web application development
+- Little to no Flask experience (we'll teach you!)
+
+WHAT YOU'LL BUILD UNDERSTANDING OF
+--------------------------------------------------------------------------------
+A complete web application for managing sailing regatta events:
+- User authentication with role-based access (Admin/Crew)
+- Invite-based registration system
+- CRUD operations for regatta events
+- RSVP system with Yes/No/Maybe responses
+- Document upload and management (PDFs, external links)
+- AI-powered schedule import from URLs (Anthropic Claude API)
+- Document discovery with SSE streaming progress
+- iCal calendar feed integration
+- PDF schedule generation with WeasyPrint
+- S3-compatible cloud storage for file uploads
+- Production deployment with Docker on AWS Lightsail
+
+TECHNICAL STACK YOU'LL MASTER
+--------------------------------------------------------------------------------
+- Python 3.13 & Flask 3.1.0 web framework
+- SQLAlchemy ORM for database operations
+- Flask-Login for authentication
+- Flask-Migrate for database schema management
+- MySQL 8.0 database
+- Gunicorn WSGI server
+- Docker Compose orchestration (local dev)
+- AWS Lightsail Container Service (production)
+- S3-compatible object storage (Lightsail buckets)
+- Anthropic Claude API for AI-powered imports
+- WeasyPrint for PDF generation
+- Bootstrap 5 for responsive frontend
+
+PREREQUISITES
+--------------------------------------------------------------------------------
+Before starting, ensure you have:
+1. Docker and Docker Compose installed
+2. Text editor or IDE (VS Code, PyCharm, etc.)
+3. Terminal/command line access
+4. Git (optional, for version control)
+5. Web browser for testing
+
+DAILY SESSION STRUCTURE
+--------------------------------------------------------------------------------
+Each session includes:
+- Learning Objectives (what you'll achieve)
+- Concepts Covered (technical topics)
+- File Focus (which code files to examine)
+- Code Walkthrough (detailed explanations with line numbers)
+- Architecture Diagrams (visual representations)
+- Key Takeaways (summary and next steps)
+
+RECOMMENDED APPROACH
+--------------------------------------------------------------------------------
+1. Read each session sequentially (Day 1 → Day 10)
+2. Have the code repository open while reading
+3. Follow along by examining the referenced files
+4. Take notes on concepts that are new to you
+5. Pause to explore code sections in detail
+6. Return to earlier sessions as needed for review
+
+TIME COMMITMENT
+--------------------------------------------------------------------------------
+Each session: 1-2 hours of focused reading and code exploration
+Total course: ~15-20 hours spread over 10 workdays
+Best pace: One session per day with hands-on exploration
+
+================================================================================
+                            SESSION ROADMAP
+================================================================================
+
+DAY 1: INTRODUCTION & ENVIRONMENT SETUP
+File: 01-day1.txt
+Topics:
+  - Application overview and feature tour
+  - Docker Compose setup (web, db containers)
+  - Running the application locally
+  - Creating your first admin account
+  - Flask basics: routes, templates, blueprints
+
+DAY 2: FLASK APPLICATION FACTORY PATTERN
+File: 02-day2.txt
+Topics:
+  - The create_app() factory pattern
+  - Flask extensions initialization
+  - Configuration management with environment variables
+  - Blueprint registration and organization
+  - Application context and lifecycle
+
+DAY 3: DATABASE MODELS & SQLALCHEMY
+File: 03-day3.txt
+Topics:
+  - Object-Relational Mapping (ORM) concepts
+  - User, Regatta, Document, and RSVP models
+  - Database relationships and foreign keys
+  - Password hashing with bcrypt
+  - Database schema design
+
+DAY 4: AUTHENTICATION & USER MANAGEMENT
+File: 04-day4.txt
+Topics:
+  - Flask-Login integration
+  - Login/logout implementation
+  - Invite-based registration system
+  - Token generation for security
+  - User profile management
+  - Admin user administration
+
+DAY 5: REGATTA MANAGEMENT (CRUD OPERATIONS)
+File: 05-day5.txt
+Topics:
+  - RESTful route design in Flask
+  - Create, Read, Update, Delete operations
+  - Form processing and validation
+  - Date handling in Python
+  - Permission checks and admin-only routes
+  - Flash messages for user feedback
+
+DAY 6: RSVP SYSTEM & DATABASE RELATIONSHIPS
+File: 06-day6.txt
+Topics:
+  - Many-to-many relationships
+  - Upsert pattern (update or insert)
+  - SQLAlchemy lazy loading
+  - Custom Jinja2 template filters
+  - Status tracking and display
+
+DAY 7: DOCUMENT UPLOAD & FILE HANDLING
+File: 07-day7.txt
+Topics:
+  - File upload processing with Flask
+  - UUID-based secure filename generation
+  - Supporting both file uploads and external URLs
+  - S3-compatible cloud storage abstraction
+  - Presigned URLs for secure file downloads
+  - File size limits and validation
+
+DAY 8: CALENDAR INTEGRATION (ICAL FEEDS)
+File: 08-day8.txt
+Topics:
+  - iCalendar format (RFC 5545)
+  - icalendar Python library
+  - Token-based feed authentication
+  - Generating calendar events
+  - All-day event handling
+  - Calendar subscription URLs
+
+DAY 9: DOCKER & CONTAINERIZATION
+File: 09-day9.txt
+Topics:
+  - Dockerfile structure and best practices
+  - Multi-container orchestration with docker-compose
+  - Container networking and service discovery
+  - Volume persistence for data
+  - Health checks for dependencies
+  - Gunicorn production configuration
+  - GitHub Container Registry (GHCR)
+
+DAY 10: DATABASE MIGRATIONS & DEPLOYMENT
+File: 10-day10.txt
+Topics:
+  - Flask-Migrate and Alembic
+  - Creating and applying database migrations
+  - Automatic migration on startup
+  - AWS Lightsail Container Service deployment
+  - GitHub Actions CI/CD pipeline
+  - Environment variables in production
+  - Managed database and automated backups
+
+APPENDIX: QUICK REFERENCE
+File: 99-appendix.txt
+Topics:
+  - Flask routing patterns
+  - SQLAlchemy query examples
+  - Jinja2 template syntax
+  - Docker Compose commands
+  - Flask CLI commands
+  - Troubleshooting guide
+  - Security best practices
+  - Further reading resources
+
+================================================================================
+                        NAVIGATING THE MATERIALS
+================================================================================
+
+FILE NAMING CONVENTION
+--------------------------------------------------------------------------------
+00-index.txt       This file - course overview and roadmap
+01-day1.txt        Day 1 session
+02-day2.txt        Day 2 session
+...
+10-day10.txt       Day 10 session
+99-appendix.txt    Reference materials and cheat sheets
+
+READING THE CODE REFERENCES
+--------------------------------------------------------------------------------
+Throughout the materials, you'll see references like:
+
+  File: app/models.py:15-20
+
+This means "open the file app/models.py and look at lines 15 through 20."
+All file paths are relative to the thistle-regatta-schedule/ directory.
+
+ARCHITECTURE DIAGRAMS
+--------------------------------------------------------------------------------
+ASCII diagrams show system architecture and data flow. Read them carefully:
+
+  [Component A] ---> [Component B]
+       |                  ^
+       |                  |
+       +------------------+
+
+Arrows show direction of data flow or dependencies.
+
+CODE WALKTHROUGH FORMAT
+--------------------------------------------------------------------------------
+Code snippets are formatted as:
+
+  ```python
+  def example_function():
+      """This is example code from the application."""
+      return "Hello"
+  ```
+
+Explanation follows the code, connecting it to broader concepts.
+
+================================================================================
+                        GETTING STARTED
+================================================================================
+
+STEP 1: SET UP YOUR ENVIRONMENT
+--------------------------------------------------------------------------------
+1. Navigate to the thistle-regatta-schedule/ directory
+2. Copy .env.example to .env
+3. Generate a secret key:
+   python3 -c "import secrets; print(secrets.token_hex(32))"
+4. Update SECRET_KEY in .env with the generated value
+
+STEP 2: START THE APPLICATION
+--------------------------------------------------------------------------------
+1. Build and start containers:
+   docker compose up --build
+
+2. Wait for all services to be healthy
+3. Open a new terminal and create an admin account:
+   docker compose exec web flask create-admin
+
+4. Access the app at http://localhost
+
+STEP 3: BEGIN DAY 1
+--------------------------------------------------------------------------------
+Open 01-day1.txt and start your learning journey!
+
+================================================================================
+                        LEARNING OBJECTIVES
+================================================================================
+
+By the end of this 10-day program, you will understand:
+
+FLASK FUNDAMENTALS
+  ✓ Application factory pattern
+  ✓ Blueprint organization
+  ✓ Route handlers and HTTP methods
+  ✓ Template rendering with Jinja2
+  ✓ Form processing
+  ✓ Flash messages
+  ✓ Configuration management
+
+DATABASE & ORM
+  ✓ SQLAlchemy models and relationships
+  ✓ Database migrations with Alembic
+  ✓ Query patterns and filtering
+  ✓ Foreign keys and constraints
+  ✓ Transaction management
+
+AUTHENTICATION & SECURITY
+  ✓ Flask-Login integration
+  ✓ Password hashing with bcrypt
+  ✓ Token-based authentication
+  ✓ CSRF protection
+  ✓ Role-based access control
+  ✓ Secure file handling
+
+DOCKER & DEPLOYMENT
+  ✓ Multi-container applications
+  ✓ Container networking
+  ✓ Volume management
+  ✓ Production server configuration
+  ✓ Cloud deployment with AWS Lightsail
+  ✓ CI/CD with GitHub Actions
+
+ADVANCED FEATURES
+  ✓ File upload handling with S3 storage
+  ✓ iCalendar feed generation
+  ✓ AI-powered data import (Anthropic API)
+  ✓ PDF generation with WeasyPrint
+  ✓ Custom CLI commands
+  ✓ Database relationship patterns
+  ✓ Template filters
+
+================================================================================
+                            SUPPORT & TIPS
+================================================================================
+
+STUCK ON A CONCEPT?
+--------------------------------------------------------------------------------
+1. Re-read the relevant section slowly
+2. Open the referenced file and read the code
+3. Check the 99-appendix.txt for quick reference
+4. Search for the topic in Flask documentation
+5. Review earlier sessions for foundational concepts
+
+BEST PRACTICES FOR LEARNING
+--------------------------------------------------------------------------------
+- Don't rush - take time to understand each concept
+- Type out code examples yourself (don't just read)
+- Experiment with small changes to see what happens
+- Use print() statements to debug and explore
+- Keep a learning journal of new concepts
+- Draw your own diagrams to solidify understanding
+
+DOCKER TIPS
+--------------------------------------------------------------------------------
+- Keep Docker Desktop running while working
+- Use 'docker compose logs' to debug issues
+- Restart containers with 'docker compose restart'
+- Fresh start: 'docker compose down -v && docker compose up --build'
+
+TESTING YOUR UNDERSTANDING
+--------------------------------------------------------------------------------
+After each session, ask yourself:
+1. Can I explain this concept to someone else?
+2. Do I understand why the code is structured this way?
+3. Could I modify this feature or add a similar one?
+4. What security considerations does this code address?
+
+================================================================================
+                         READY TO BEGIN?
+================================================================================
+
+You now have everything you need to start your Flask learning journey!
+
+Open 01-day1.txt and let's build something great together.
+
+Happy coding!
+
+================================================================================
+                        COURSE INFORMATION
+================================================================================
+
+Application: Race Crew Network
+Version: 0.34.2
+Python: 3.13+
+Flask: 3.1.0
+Training Version: 2.0
+Last Updated: 2026-03
+
+Repository: thistle-regatta-schedule/
+Documentation: README.md, CLAUDE.md
+
+================================================================================

--- a/python-class/01-day1.txt
+++ b/python-class/01-day1.txt
@@ -1,0 +1,487 @@
+================================================================================
+                          DAY 1: INTRODUCTION & ENVIRONMENT SETUP
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- What the Race Crew Network application does and who uses it
+- The 2-container Docker architecture (web, db)
+- How to run the application locally with Docker Compose
+- Basic Flask concepts: routes, templates, and blueprints
+- How to create an admin user via Flask CLI commands
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- Web application architecture
+- Docker Compose multi-container orchestration
+- Flask framework overview
+- MVC (Model-View-Controller) pattern
+- RESTful routing
+- Flask CLI commands
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+For this session, examine these files:
+- thistle-regatta-schedule/README.md - Setup instructions
+- thistle-regatta-schedule/docker-compose.yml - Container orchestration
+- thistle-regatta-schedule/app/__init__.py - Flask app initialization
+- thistle-regatta-schedule/Dockerfile - Web container build instructions
+
+================================================================================
+                          PART 1: APPLICATION OVERVIEW
+================================================================================
+
+WHAT IS RACE CREW NETWORK?
+--------------------------------------------------------------------------------
+Race Crew Network is a specialized event management system for sailboat
+racing. It solves a common problem for sailing clubs: coordinating crew
+attendance across multiple regatta events.
+
+**Key Features:**
+- Centralized schedule of all regatta dates and locations
+- RSVP system (Yes/No/Maybe) to track crew availability
+- Document management for NOR (Notice of Race) and SI (Sailing Instructions)
+- AI-powered schedule import from regatta websites (Anthropic Claude API)
+- Automatic document discovery from regatta event pages
+- iCal calendar feed integration for personal calendars
+- PDF schedule generation with WeasyPrint
+- Invite-based user registration (no public sign-ups)
+- Role-based access (Admin vs Crew)
+
+**User Roles:**
+- **Admin**: Create/edit/delete regattas, upload documents, invite crew,
+  import schedules via AI, discover documents
+- **Crew**: View schedule, download documents, set RSVP status
+
+WHO USES IT?
+--------------------------------------------------------------------------------
+This app is designed for small to medium sailing clubs (5-50 members) that
+compete in multiple regattas per season. It replaces email chains and
+spreadsheets with a single source of truth.
+
+Example workflow:
+1. Admin creates a new regatta entry with date, location, and links
+2. Admin uploads the NOR and SI PDF documents
+3. Crew members visit the site and set their RSVP
+4. Admin can see at a glance who's attending each event
+5. Crew members subscribe to the calendar feed in their preferred app
+
+================================================================================
+                    PART 2: DOCKER ARCHITECTURE
+================================================================================
+
+TWO-CONTAINER DESIGN (LOCAL DEVELOPMENT)
+--------------------------------------------------------------------------------
+For local development, the application uses Docker Compose to orchestrate
+two containers:
+
+1. **web** - The Flask application running on Gunicorn (WSGI server)
+2. **db** - MySQL 8 database for persistent data storage
+
+In production, the app runs on AWS Lightsail Container Service with a
+managed MySQL database and S3-compatible object storage (see Day 10).
+
+ARCHITECTURE DIAGRAM
+--------------------------------------------------------------------------------
+
+    Browser
+       |
+       | Port 80 (mapped to 8000)
+       v
+  +---------+
+  |   web   |  (Python 3.13, Flask, Gunicorn)
+  +---------+
+       |
+       | MySQL connection
+       v
+  +---------+
+  |   db    |  (MySQL 8)
+  +---------+
+       |
+       v
+  [mysql_data]  (Persistent volume)
+  [uploads]     (Persistent volume)
+
+
+WHY THIS ARCHITECTURE?
+--------------------------------------------------------------------------------
+**Separation of Concerns**:
+- Gunicorn serves the Flask application directly
+- Flask focuses on application logic
+- MySQL manages data persistence
+
+**Security**:
+- Database communicates on Docker's internal network
+- Database is never directly accessible from outside
+
+**Scalability**:
+- Can swap MySQL for a managed database service
+- Production uses Lightsail Container Service with managed MySQL
+- File uploads use S3-compatible object storage in production
+
+DOCKER COMPOSE CONFIGURATION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/docker-compose.yml
+
+```yaml
+# Local development only -- production uses Lightsail Container Service
+services:
+  web:
+    build: .                              # Build from Dockerfile
+    image: ghcr.io/chris-edwards-pub/race-crew-network:latest
+    env_file: .env                        # Load environment variables
+    ports:
+      - "80:8000"                         # Expose Gunicorn to host
+    depends_on:
+      db:
+        condition: service_healthy        # Wait for DB health check
+    volumes:
+      - uploads:/app/uploads              # Persistent file storage
+    restart: unless-stopped               # Auto-restart on failure
+
+  db:
+    image: mysql:8.0                      # Official MySQL image
+    env_file: .env                        # DB credentials
+    volumes:
+      - mysql_data:/var/lib/mysql         # Persistent database
+    healthcheck:                          # Ensure DB is ready
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  mysql_data:                             # Named volume for database
+  uploads:                                # Named volume for uploads
+```
+
+KEY CONCEPTS:
+- **depends_on**: Controls startup order (db starts before web)
+- **service_healthy**: web waits for db to pass health check before starting
+- **volumes**: Named volumes persist data across container restarts
+- **env_file**: Loads secrets from .env (not committed to git)
+- **restart**: unless-stopped ensures high availability
+- **ports**: Maps host port 80 to Gunicorn's port 8000 inside the container
+
+================================================================================
+                    PART 3: RUNNING THE APPLICATION
+================================================================================
+
+PREREQUISITES
+--------------------------------------------------------------------------------
+You need Docker and Docker Compose installed on your system. If you don't have
+them, visit https://docs.docker.com/get-docker/
+
+STEP 1: CONFIGURE ENVIRONMENT
+--------------------------------------------------------------------------------
+The application uses environment variables for configuration. Copy the example
+file and customize it:
+
+```bash
+cd thistle-regatta-schedule
+cp .env.example .env
+```
+
+Generate a secure SECRET_KEY:
+
+```bash
+python3 -c "import secrets; print(secrets.token_hex(32))"
+```
+
+Edit .env and paste the generated key:
+
+```
+SECRET_KEY=your-generated-key-here
+DATABASE_URL=mysql+pymysql://racecrew:racecrew@db:3306/racecrew
+UPLOAD_FOLDER=/app/uploads
+MYSQL_ROOT_PASSWORD=rootpassword
+MYSQL_DATABASE=racecrew
+MYSQL_USER=racecrew
+MYSQL_PASSWORD=racecrew
+INIT_ADMIN_EMAIL=admin@example.com
+INIT_ADMIN_PASSWORD=changeme123
+```
+
+**Important**: The SECRET_KEY is used for session encryption and CSRF tokens.
+In production, also change the database passwords to something strong.
+INIT_ADMIN_EMAIL and INIT_ADMIN_PASSWORD are used to create the initial admin
+account automatically on first startup.
+
+STEP 2: START THE CONTAINERS
+--------------------------------------------------------------------------------
+```bash
+docker compose up --build
+```
+
+What happens:
+1. Docker builds the web container from the Dockerfile
+2. Docker downloads the mysql:8.0 image (if needed)
+3. Docker creates the mysql_data and uploads volumes
+4. MySQL starts and runs its health check
+5. Once MySQL is healthy, the web container starts
+6. The web container runs database migrations automatically (via entrypoint.sh)
+7. The entrypoint creates the initial admin account (if configured)
+8. Gunicorn starts and listens on port 8000 (mapped to host port 80)
+
+You'll see logs from both services. Watch for:
+- "Running database migrations..." from web
+- "Initializing admin account if needed..." from web
+- "Starting Gunicorn..." from web
+
+STEP 3: ADMIN ACCOUNT
+--------------------------------------------------------------------------------
+If you set INIT_ADMIN_EMAIL and INIT_ADMIN_PASSWORD in your .env file, the
+admin account is created automatically on first startup. The entrypoint script
+runs `flask init-admin` which reads these environment variables.
+
+Alternatively, you can create an admin account manually:
+
+```bash
+docker compose exec web flask create-admin
+```
+
+This runs the Flask CLI command inside the running web container.
+
+You'll be prompted for:
+- Email address (used for login)
+- Password (at least 8 characters)
+- Display name (shown in the app)
+- Initials (2-3 characters, displayed on RSVP badges)
+
+STEP 4: ACCESS THE APPLICATION
+--------------------------------------------------------------------------------
+Open your browser and navigate to http://localhost
+
+You should see the login page. Log in with the email and password you just
+created.
+
+After login, you'll see:
+- The main regatta schedule (empty initially)
+- Navbar with "Home", "iCal", "Crew", and "Import" links
+- A "+ New Regatta" button (admin only)
+
+STEP 5: EXPLORE THE INTERFACE
+--------------------------------------------------------------------------------
+Try creating your first regatta:
+
+1. Click "+ New Regatta" button
+2. Fill in:
+   - Name: "Mid-Winters Championship"
+   - Date: Pick a future date
+   - Location: "San Francisco, CA"
+   - Google Maps URL: (optional)
+   - Website URL: (optional)
+3. Click "Save"
+
+You'll be redirected to the main schedule. Notice:
+- The regatta appears in the table
+- Your RSVP dropdown shows "-" (not responded yet)
+- Edit and Delete buttons appear (admin only)
+
+Try setting your RSVP:
+- Change the dropdown from "-" to "Yes"
+- The page refreshes and your initials appear in green
+
+STEP 6: STOP THE APPLICATION
+--------------------------------------------------------------------------------
+In the terminal with running logs, press Ctrl+C. Then run:
+
+```bash
+docker compose down
+```
+
+This stops and removes all containers. Your data persists in the named volumes.
+
+To completely reset (delete database and uploads):
+
+```bash
+docker compose down -v
+```
+
+================================================================================
+                    PART 4: FLASK BASICS
+================================================================================
+
+WHAT IS FLASK?
+--------------------------------------------------------------------------------
+Flask is a Python web framework. It handles:
+- HTTP request/response cycle
+- Routing (mapping URLs to Python functions)
+- Template rendering (generating HTML with dynamic data)
+- Session management (keeping users logged in)
+- Form processing and validation
+
+Flask is "micro" because it provides the essentials and lets you add what you
+need via extensions (like SQLAlchemy for databases, Flask-Login for auth).
+
+THE APPLICATION FACTORY PATTERN
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/__init__.py:17-53
+
+Flask apps can be created in two ways:
+1. Direct instantiation: `app = Flask(__name__)` at module level
+2. Factory function: `create_app()` returns a configured app instance
+
+This application uses the factory pattern:
+
+```python
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object("app.config.Config")
+
+    # Initialize extensions
+    db.init_app(app)
+    migrate.init_app(app, db)
+    login_manager.init_app(app)
+    csrf.init_app(app)
+
+    # Register blueprints
+    from app.admin import bp as admin_bp
+    from app.auth import bp as auth_bp
+    from app.calendar import bp as calendar_bp
+    from app.regattas import bp as regattas_bp
+    app.register_blueprint(admin_bp)
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(calendar_bp)
+    app.register_blueprint(regattas_bp)
+
+    return app
+```
+
+**Why use a factory?**
+- Can create multiple app instances (useful for testing)
+- Extensions are initialized with the app context
+- Configuration can vary per instance (dev vs production)
+
+BLUEPRINTS: MODULAR ROUTING
+--------------------------------------------------------------------------------
+Blueprints organize routes into logical groups. This app has four:
+
+1. **admin** - AI-powered schedule import, document discovery
+2. **auth** - Login, logout, registration, user management
+3. **regattas** - Regatta CRUD, RSVP, document handling
+4. **calendar** - iCal feed generation
+
+Example: The auth blueprint (thistle-regatta-schedule/app/auth/routes.py)
+defines routes like:
+- /login
+- /logout
+- /register/<token>
+- /profile
+- /admin/users
+
+When registered, these become available as full routes. Flask automatically
+combines the blueprint's routes with the main app.
+
+ROUTES: MAPPING URLS TO FUNCTIONS
+--------------------------------------------------------------------------------
+A route connects a URL to a Python function:
+
+```python
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        # Process login form
+        email = request.form['email']
+        # ... validate and log in user
+    return render_template('login.html')
+```
+
+Key concepts:
+- **@app.route()**: Decorator that registers the function as a route handler
+- **methods**: List of HTTP methods the route accepts (GET, POST, etc.)
+- **request**: Global object containing form data, query params, headers
+- **render_template()**: Renders a Jinja2 template with context data
+
+TEMPLATES: GENERATING HTML
+--------------------------------------------------------------------------------
+Flask uses Jinja2 for templating. Templates are HTML files with special syntax
+for inserting Python expressions and control flow:
+
+```html
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Welcome, {{ current_user.display_name }}!</h1>
+<ul>
+{% for regatta in regattas %}
+    <li>{{ regatta.name }} - {{ regatta.date }}</li>
+{% endfor %}
+</ul>
+{% endblock %}
+```
+
+Key features:
+- **{% extends %}**: Template inheritance (DRY principle)
+- **{% block %}**: Define sections that child templates can override
+- **{{ variable }}**: Output a Python variable value
+- **{% for %}**: Loop over iterables
+
+EXTENSIONS: ADDING FUNCTIONALITY
+--------------------------------------------------------------------------------
+Flask extensions add features. This app uses:
+
+- **Flask-SQLAlchemy**: ORM for database operations (Day 3)
+- **Flask-Login**: User session management (Day 4)
+- **Flask-Migrate**: Database schema migrations (Day 10)
+- **Flask-WTF**: CSRF protection (Day 4)
+
+Extensions are initialized at the module level, then attached to the app in
+the factory:
+
+```python
+db = SQLAlchemy()                # Create extension instance
+
+def create_app():
+    app = Flask(__name__)
+    db.init_app(app)             # Attach to app
+    return app
+```
+
+This two-step process is required for the factory pattern to work.
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **Docker Compose orchestrates two containers** for local development:
+   web (Flask/Gunicorn) and db (MySQL). Production uses AWS Lightsail.
+
+2. **The application factory pattern** (`create_app()`) creates a configured
+   Flask instance. This enables testing and multiple configurations.
+
+3. **Blueprints organize routes** into logical modules. This keeps code
+   organized as the application grows.
+
+4. **Flask handles the HTTP request/response cycle**. Routes map URLs to
+   Python functions. Templates render HTML with dynamic data.
+
+5. **Docker volumes persist data** across container restarts. The mysql_data
+   volume stores the database, and uploads stores user files locally.
+   In production, file uploads use S3-compatible object storage.
+
+6. **Flask CLI commands** (like `flask create-admin`) extend the framework
+   with custom administrative tasks.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 2, we'll dive deep into the application factory pattern and understand
+how Flask extensions are initialized. We'll explore configuration management
+with environment variables and see how the app bootstraps itself on startup.
+
+You now have a running Flask application! Before moving on, try:
+- Creating a few more regattas
+- Changing your RSVP status
+- Exploring the Crew page (invite management)
+- Viewing the application logs in the terminal
+
+Questions to ponder:
+- How does Flask know which function to call for a given URL?
+- Where is the HTML for the login page stored?
+- How does the web container know when MySQL is ready?
+
+See you in Day 2!
+
+================================================================================

--- a/python-class/02-day2.txt
+++ b/python-class/02-day2.txt
@@ -1,0 +1,543 @@
+================================================================================
+                   DAY 2: FLASK APPLICATION FACTORY PATTERN
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- The application factory pattern and why it's used
+- How Flask extensions are initialized and attached to the app
+- Configuration management with environment variables
+- Blueprint registration and organization
+- The application lifecycle from startup to serving requests
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- Application factory pattern
+- Flask extensions (SQLAlchemy, Flask-Login, Flask-Migrate, CSRF)
+- Configuration classes and environment variables
+- Blueprint registration
+- WSGI (Web Server Gateway Interface)
+- Context processors and template filters
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+For this session, examine these files:
+- thistle-regatta-schedule/app/__init__.py - Application factory
+- thistle-regatta-schedule/app/config.py - Configuration class
+- thistle-regatta-schedule/wsgi.py - WSGI entry point
+- thistle-regatta-schedule/entrypoint.sh - Container startup script
+- thistle-regatta-schedule/.env.example - Environment variable template
+
+================================================================================
+                    PART 1: THE APPLICATION FACTORY
+================================================================================
+
+WHAT IS THE FACTORY PATTERN?
+--------------------------------------------------------------------------------
+The factory pattern is a design pattern where a function creates and returns a
+configured object. In Flask, this means using a create_app() function instead
+of creating the app instance at module level.
+
+**Without Factory (simple approach):**
+```python
+from flask import Flask
+
+app = Flask(__name__)  # Created at import time
+
+@app.route('/')
+def index():
+    return "Hello"
+```
+
+**With Factory (this application's approach):**
+```python
+from flask import Flask
+
+def create_app():
+    app = Flask(__name__)
+    # ... configuration and setup
+    return app
+```
+
+WHY USE A FACTORY?
+--------------------------------------------------------------------------------
+1. **Testing**: Create separate app instances for tests with different configs
+2. **Multiple Instances**: Run dev and production apps simultaneously
+3. **Extension Initialization**: Extensions need the app context to work
+4. **Deferred Configuration**: Load config based on environment at runtime
+5. **Circular Imports**: Avoid import issues when models need db and db needs app
+
+THE CREATE_APP FUNCTION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/__init__.py:17-53
+
+```python
+def create_app(test_config=None):
+    app = Flask(__name__)
+    app.config.from_object("app.config.Config")
+    if test_config:
+        app.config.update(test_config)
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+    login_manager.init_app(app)
+    csrf.init_app(app)
+
+    from app.admin import bp as admin_bp
+    from app.auth import bp as auth_bp
+    from app.calendar import bp as calendar_bp
+    from app.regattas import bp as regattas_bp
+
+    app.register_blueprint(admin_bp)
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(calendar_bp)
+    app.register_blueprint(regattas_bp)
+
+    from app.commands import register_commands
+    register_commands(app)
+
+    @app.context_processor
+    def inject_version():
+        return {"app_version": __version__}
+
+    @app.template_filter("sort_rsvps")
+    def sort_rsvps(rsvps):
+        order = {"yes": 0, "no": 1, "maybe": 2}
+        return sorted(rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name))
+
+    return app
+```
+
+STEP-BY-STEP BREAKDOWN
+--------------------------------------------------------------------------------
+
+**Step 1: Create Flask instance**
+```python
+app = Flask(__name__)
+```
+Creates the Flask application object. __name__ helps Flask locate templates
+and static files relative to this module.
+
+**Step 2: Load configuration**
+```python
+app.config.from_object("app.config.Config")
+```
+Loads all UPPERCASE attributes from the Config class as configuration values.
+This is Flask's recommended way to manage settings.
+
+**Step 3: Initialize extensions**
+```python
+db.init_app(app)
+migrate.init_app(app, db)
+login_manager.init_app(app)
+csrf.init_app(app)
+```
+Each extension was created at module level (lines 9-14), but they need to be
+attached to the app instance. This two-step initialization is required for
+the factory pattern.
+
+**Step 4: Register blueprints**
+```python
+app.register_blueprint(admin_bp)
+app.register_blueprint(auth_bp)
+app.register_blueprint(calendar_bp)
+app.register_blueprint(regattas_bp)
+```
+Imports and registers all four route blueprints. This makes their routes
+available in the application.
+
+**Step 5: Register CLI commands**
+```python
+register_commands(app)
+```
+Adds custom Flask CLI commands like `flask create-admin`.
+
+**Step 6: Add context processors**
+```python
+@app.context_processor
+def inject_version():
+    return {"app_version": __version__}
+```
+Context processors add variables to every template render. This makes
+app_version available in all templates without passing it explicitly.
+
+**Step 7: Add template filters**
+```python
+@app.template_filter("sort_rsvps")
+def sort_rsvps(rsvps):
+    # ... sorting logic
+```
+Template filters transform data in templates. This custom filter sorts RSVPs
+by status (yes, no, maybe) and then by user name.
+
+**Step 8: Return the configured app**
+```python
+return app
+```
+The fully configured app is returned and ready to handle requests.
+
+================================================================================
+                    PART 2: CONFIGURATION MANAGEMENT
+================================================================================
+
+THE CONFIG CLASS
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/config.py
+
+```python
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-change-me")
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DATABASE_URL",
+        "mysql+pymysql://racecrew:racecrew@localhost:3306/racecrew",
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB max upload
+    UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "uploads")
+    BUCKET_NAME = os.environ.get("BUCKET_NAME", "")
+    AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+    ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+```
+
+CONFIGURATION PATTERN
+--------------------------------------------------------------------------------
+Each setting follows the pattern:
+```python
+SETTING = os.environ.get("ENV_VAR_NAME", "default_value")
+```
+
+This reads from environment variables with fallback defaults. Benefits:
+- **Security**: Secrets not hardcoded in source code
+- **Flexibility**: Change config without code changes
+- **Environment-specific**: Different values for dev/staging/production
+
+KEY CONFIGURATION VALUES
+--------------------------------------------------------------------------------
+
+**SECRET_KEY**:
+Used for cryptographic signing of session cookies, CSRF tokens, and other
+security features. Must be random and secret. Generate with:
+```python
+python3 -c "import secrets; print(secrets.token_hex(32))"
+```
+
+**SQLALCHEMY_DATABASE_URI**:
+Database connection string format:
+```
+mysql+pymysql://username:password@host:port/database
+```
+- mysql+pymysql: SQLAlchemy dialect + driver
+- racecrew:racecrew: username and password
+- @db:3306: host (Docker service name) and port
+- /racecrew: database name
+
+**BUCKET_NAME**:
+S3-compatible bucket for file uploads in production (Lightsail Object Storage).
+Empty string for local development (uses local file system).
+
+**ANTHROPIC_API_KEY**:
+API key for the Anthropic Claude API, used for AI-powered schedule import
+and document discovery features.
+
+**SQLALCHEMY_TRACK_MODIFICATIONS**:
+Set to False to disable SQLAlchemy's event system that tracks object changes.
+This reduces memory overhead and is recommended unless you need it.
+
+**MAX_CONTENT_LENGTH**:
+Limits HTTP request body size to 10MB. Prevents users from uploading huge
+files that could fill disk space or cause memory issues.
+
+**UPLOAD_FOLDER**:
+Directory path where uploaded files are stored. Must be writable by the app.
+
+ENVIRONMENT VARIABLES
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/.env.example
+
+```
+SECRET_KEY=change-me-to-a-random-string
+DATABASE_URL=mysql+pymysql://racecrew:racecrew@db:3306/racecrew
+UPLOAD_FOLDER=/app/uploads
+MYSQL_ROOT_PASSWORD=rootpassword
+MYSQL_DATABASE=racecrew
+MYSQL_USER=racecrew
+MYSQL_PASSWORD=racecrew
+INIT_ADMIN_EMAIL=admin@example.com
+INIT_ADMIN_PASSWORD=changeme123
+```
+
+The .env file is loaded by Docker Compose (via env_file: .env). These
+variables are available to both the web and db containers.
+
+**Important**: .env is in .gitignore and never committed. Each environment
+(dev, staging, production) has its own .env file.
+
+================================================================================
+                    PART 3: FLASK EXTENSIONS
+================================================================================
+
+WHAT ARE EXTENSIONS?
+--------------------------------------------------------------------------------
+Flask extensions add functionality to the core framework. This app uses four:
+
+1. **Flask-SQLAlchemy**: Database ORM (Object-Relational Mapping)
+2. **Flask-Login**: User authentication and session management
+3. **Flask-Migrate**: Database schema migrations (Alembic wrapper)
+4. **Flask-WTF**: CSRF protection and form handling
+
+TWO-STEP INITIALIZATION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/__init__.py:9-14
+
+```python
+db = SQLAlchemy()
+migrate = Migrate()
+login_manager = LoginManager()
+login_manager.login_view = "auth.login"
+csrf = CSRFProtect()
+```
+
+Extensions are created at module level without an app instance. They're
+initialized later in create_app():
+
+```python
+db.init_app(app)
+migrate.init_app(app, db)
+login_manager.init_app(app)
+csrf.init_app(app)
+```
+
+This pattern allows the extensions to be imported anywhere while ensuring they
+work with the correct app context.
+
+FLASK-SQLALCHEMY (db)
+--------------------------------------------------------------------------------
+Provides a clean API for database operations:
+```python
+# Query
+user = db.session.query(User).filter_by(email='test@example.com').first()
+
+# Create
+new_regatta = Regatta(name="Mid-Winters", date=date(2024, 1, 15))
+db.session.add(new_regatta)
+db.session.commit()
+
+# Update
+regatta.name = "Mid-Winters Championship"
+db.session.commit()
+
+# Delete
+db.session.delete(regatta)
+db.session.commit()
+```
+
+We'll explore this deeply in Day 3 (Database Models).
+
+FLASK-LOGIN (login_manager)
+--------------------------------------------------------------------------------
+Manages user sessions:
+- Stores user ID in encrypted session cookie
+- Provides @login_required decorator for protected routes
+- Makes current_user available in routes and templates
+- Handles login/logout
+
+Configuration:
+```python
+login_manager.login_view = "auth.login"
+```
+Sets the route to redirect to when @login_required fails. "auth.login" refers
+to the login function in the auth blueprint.
+
+We'll explore this in Day 4 (Authentication).
+
+FLASK-MIGRATE (migrate)
+--------------------------------------------------------------------------------
+Manages database schema changes:
+```bash
+flask db migrate -m "Add calendar_token to users"
+flask db upgrade
+```
+
+Generates migration scripts when models change, and applies them to the
+database. We'll cover this in Day 10 (Migrations & Deployment).
+
+FLASK-WTF (csrf)
+--------------------------------------------------------------------------------
+Protects against Cross-Site Request Forgery attacks by:
+- Generating unique tokens for each session
+- Validating tokens on POST/PUT/DELETE requests
+- Automatically rejecting requests with invalid tokens
+
+Templates must include {{ csrf_token() }} in forms for this to work.
+
+================================================================================
+                    PART 4: APPLICATION LIFECYCLE
+================================================================================
+
+FROM CONTAINER START TO HANDLING REQUESTS
+--------------------------------------------------------------------------------
+
+STARTUP SEQUENCE DIAGRAM
+--------------------------------------------------------------------------------
+
+  [Docker Compose Start]
+           |
+           v
+  [entrypoint.sh executes]
+           |
+           +---> flask db upgrade (apply migrations)
+           |
+           +---> gunicorn -c gunicorn.conf.py wsgi:app
+                       |
+                       v
+              [wsgi.py loads]
+                       |
+                       v
+              from app import create_app
+              app = create_app()
+                       |
+                       v
+              [create_app() runs]
+                       |
+                       +---> Load config
+                       +---> Initialize extensions
+                       +---> Register blueprints
+                       +---> Add context processors
+                       |
+                       v
+              [Gunicorn workers start]
+                       |
+                       v
+              [App ready for requests]
+
+
+ENTRYPOINT SCRIPT
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/entrypoint.sh
+
+```bash
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+flask db upgrade
+
+echo "Initializing admin account if needed..."
+flask init-admin
+
+echo "Starting Gunicorn..."
+exec gunicorn -c gunicorn.conf.py wsgi:app
+```
+
+**set -e**: Exit immediately if any command fails
+**flask db upgrade**: Apply pending database migrations
+**flask init-admin**: Creates admin user from INIT_ADMIN_EMAIL/PASSWORD env vars
+**exec**: Replace shell with Gunicorn (proper signal handling)
+
+This ensures the database schema is current and admin user exists before the
+app starts.
+
+WSGI ENTRY POINT
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/wsgi.py
+
+```python
+from app import create_app
+
+app = create_app()
+```
+
+WSGI (Web Server Gateway Interface) is Python's standard for web servers
+(Gunicorn) to communicate with web apps (Flask).
+
+Gunicorn imports wsgi.py and calls the app object for each request.
+
+REQUEST HANDLING FLOW
+--------------------------------------------------------------------------------
+
+1. **Client sends HTTP request** → host port 80
+2. **Docker maps port 80** → web container port 8000
+3. **Gunicorn receives request** → picks a worker process
+4. **Worker calls Flask app** → WSGI interface (wsgi:app)
+5. **Flask routes request** → matches URL to blueprint route
+6. **Route function executes** → accesses database, renders template
+7. **Response returned** → Gunicorn → client
+
+BLUEPRINTS IN DEPTH
+--------------------------------------------------------------------------------
+Blueprints organize routes into modules. This app has four:
+
+**admin** (thistle-regatta-schedule/app/admin/__init__.py):
+```python
+from flask import Blueprint
+
+bp = Blueprint("admin", __name__)
+
+from app.admin import routes
+```
+Routes: /admin/import-schedule, /admin/import-single, /admin/regattas/discover
+
+**auth** (thistle-regatta-schedule/app/auth/__init__.py):
+```python
+from flask import Blueprint
+
+bp = Blueprint("auth", __name__)
+
+from app.auth import routes  # Import after to avoid circular imports
+```
+Routes: /login, /logout, /register/<token>, /profile, /admin/users
+
+**Registration in create_app()**:
+```python
+from app.admin import bp as admin_bp
+from app.auth import bp as auth_bp
+app.register_blueprint(admin_bp)
+app.register_blueprint(auth_bp)
+```
+
+This makes all blueprint routes available. Flask automatically combines
+blueprint route prefixes with route paths.
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **The application factory pattern** uses a create_app() function to build a
+   configured Flask instance. This enables testing, multiple configs, and
+   proper extension initialization.
+
+2. **Configuration is loaded from environment variables** via a Config class.
+   This keeps secrets out of source code and allows per-environment settings.
+
+3. **Flask extensions are initialized in two steps**: Create at module level,
+   then attach to app in create_app() with init_app(). This supports the
+   factory pattern.
+
+4. **Blueprints organize routes** into logical modules (admin, auth, regattas,
+   calendar). They keep code organized and promote reusability.
+
+5. **The application lifecycle** starts with entrypoint.sh running migrations,
+   then Gunicorn loading wsgi.py which calls create_app(). The configured app
+   then handles requests via WSGI.
+
+6. **Context processors and template filters** customize template rendering.
+   Context processors add variables to all templates. Filters transform data.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 3, we'll explore the database layer with SQLAlchemy. You'll learn how
+Python classes (models) map to database tables, and how to define
+relationships between data. We'll examine all five models in this application:
+User, Regatta, Document, RSVP, and ImportCache.
+
+Questions to ponder:
+- Why does Flask use a two-step initialization for extensions?
+- What would happen if SECRET_KEY changed between server restarts?
+- How does Flask know which blueprint a route belongs to?
+
+See you in Day 3!
+
+================================================================================

--- a/python-class/03-day3.txt
+++ b/python-class/03-day3.txt
@@ -1,0 +1,483 @@
+================================================================================
+                   DAY 3: DATABASE MODELS & SQLALCHEMY ORM
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- Object-Relational Mapping (ORM) concepts
+- How Python classes map to database tables
+- The five models in this application: User, Regatta, Document, RSVP, ImportCache
+- Database relationships and foreign keys
+- Password hashing with bcrypt
+- Database schema design patterns
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- SQLAlchemy ORM
+- Model classes and columns
+- Primary keys and foreign keys
+- One-to-many relationships
+- Many-to-many relationships (via join model)
+- Password hashing and security
+- Unique constraints
+- Cascade deletes
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+For this session, examine:
+- thistle-regatta-schedule/app/models.py - All five models
+
+================================================================================
+                    PART 1: WHAT IS AN ORM?
+================================================================================
+
+OBJECT-RELATIONAL MAPPING
+--------------------------------------------------------------------------------
+An ORM bridges the gap between Python objects and database tables. Instead of
+writing SQL queries, you work with Python classes and objects.
+
+**Without ORM (raw SQL)**:
+```python
+cursor.execute("SELECT * FROM users WHERE email = %s", (email,))
+row = cursor.fetchone()
+user_dict = {"id": row[0], "email": row[1], ...}
+```
+
+**With ORM (SQLAlchemy)**:
+```python
+user = User.query.filter_by(email=email).first()
+# user.id, user.email, etc. are directly accessible
+```
+
+BENEFITS OF ORM
+--------------------------------------------------------------------------------
+- **Type safety**: Python attributes instead of string column names
+- **Relationships**: Navigate between related objects easily
+- **Database agnostic**: Same code works with MySQL, PostgreSQL, SQLite
+- **Migration support**: Track schema changes over time
+- **Security**: Automatic SQL injection prevention
+
+SQLALCHEMY BASICS
+--------------------------------------------------------------------------------
+SQLAlchemy is Python's most popular ORM. In Flask, we use Flask-SQLAlchemy
+which integrates it with the Flask application.
+
+Key concepts:
+- **Model**: A Python class that maps to a database table
+- **Column**: A class attribute that maps to a table column
+- **Session**: Manages database transactions and object lifecycle
+- **Relationship**: Defines connections between models
+
+================================================================================
+                    PART 2: THE USER MODEL
+================================================================================
+
+USER MODEL DEFINITION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:9-39
+
+```python
+class User(UserMixin, db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    password_hash = db.Column(db.String(255), nullable=False)
+    display_name = db.Column(db.String(100), nullable=False)
+    initials = db.Column(db.String(5), nullable=False)
+    is_admin = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    invite_token = db.Column(db.String(64), unique=True, nullable=True)
+    calendar_token = db.Column(db.String(64), unique=True, nullable=True)
+    phone = db.Column(db.String(20), nullable=True)
+
+    rsvps = db.relationship("RSVP", backref="user", lazy="dynamic")
+    documents = db.relationship("Document", backref="uploaded_by_user", lazy="dynamic")
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt()
+        ).decode("utf-8")
+
+    def check_password(self, password: str) -> bool:
+        return bcrypt.checkpw(
+            password.encode("utf-8"), self.password_hash.encode("utf-8")
+        )
+```
+
+COLUMN DEFINITIONS
+--------------------------------------------------------------------------------
+Each column has:
+- **Type**: db.Integer, db.String(length), db.Boolean, db.DateTime, etc.
+- **Constraints**: primary_key, unique, nullable
+- **Defaults**: default= sets initial value
+
+**Primary Key**:
+```python
+id = db.Column(db.Integer, primary_key=True)
+```
+Auto-incrementing integer that uniquely identifies each row.
+
+**Unique Constraint**:
+```python
+email = db.Column(db.String(255), unique=True, nullable=False)
+```
+Ensures no two users can have the same email. Database enforces this.
+
+**Boolean with Default**:
+```python
+is_admin = db.Column(db.Boolean, default=False, nullable=False)
+```
+New users are not admins by default.
+
+**DateTime with Lambda Default**:
+```python
+created_at = db.Column(
+    db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+)
+```
+The lambda ensures the function is called when the row is created, not when
+the module loads.
+
+**Nullable Fields**:
+```python
+phone = db.Column(db.String(20), nullable=True)
+```
+nullable=True allows NULL in the database (optional field).
+
+PASSWORD HASHING WITH BCRYPT
+--------------------------------------------------------------------------------
+**Never store passwords in plain text!** This app uses bcrypt, a slow hashing
+algorithm designed for passwords.
+
+**Setting a password**:
+```python
+def set_password(self, password: str) -> None:
+    self.password_hash = bcrypt.hashpw(
+        password.encode("utf-8"), bcrypt.gensalt()
+    ).decode("utf-8")
+```
+
+Process:
+1. password.encode("utf-8") → convert string to bytes
+2. bcrypt.gensalt() → generate random salt
+3. bcrypt.hashpw() → hash password with salt
+4. .decode("utf-8") → convert bytes back to string for storage
+
+**Verifying a password**:
+```python
+def check_password(self, password: str) -> bool:
+    return bcrypt.checkpw(
+        password.encode("utf-8"), self.password_hash.encode("utf-8")
+    )
+```
+
+bcrypt.checkpw() hashes the input password with the same salt and compares.
+
+USERMIXIN FROM FLASK-LOGIN
+--------------------------------------------------------------------------------
+```python
+class User(UserMixin, db.Model):
+```
+
+UserMixin provides required methods for Flask-Login:
+- get_id(): Returns user ID as string
+- is_authenticated: Always True for logged-in users
+- is_active: True if account is active
+- is_anonymous: False for real users
+
+USER LOADER FUNCTION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:42-44 (current line numbers)
+
+```python
+@login_manager.user_loader
+def load_user(user_id: str):
+    return db.session.get(User, int(user_id))
+```
+
+Flask-Login calls this function to load the user from the session cookie.
+It receives the user ID and must return the User object or None.
+
+================================================================================
+                    PART 3: THE REGATTA MODEL
+================================================================================
+
+REGATTA MODEL DEFINITION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:47-78
+
+```python
+class Regatta(db.Model):
+    __tablename__ = "regattas"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    boat_class = db.Column(db.String(100), nullable=False, default="TBD")
+    location = db.Column(db.String(200), nullable=False)
+    location_url = db.Column(db.String(500), nullable=True)
+    start_date = db.Column(db.Date, nullable=False)
+    end_date = db.Column(db.Date, nullable=True)
+    notes = db.Column(db.Text, nullable=True)
+    source_url = db.Column(db.String(500), nullable=True)
+    created_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc)
+    )
+
+    documents = db.relationship("Document", backref="regatta", lazy="dynamic",
+                                cascade="all, delete-orphan")
+    rsvps = db.relationship("RSVP", backref="regatta", lazy="dynamic",
+                           cascade="all, delete-orphan")
+    creator = db.relationship("User", backref="created_regattas",
+                             foreign_keys=[created_by])
+```
+
+NEW FIELDS:
+- **boat_class**: Free text field for the class of boat (e.g., "Thistle",
+  "Lightning"). Defaults to "TBD". Used in iCal event summaries and display.
+- **source_url**: URL of the regatta's event page, persisted during AI import.
+  Allows admins to re-discover documents later from the edit page.
+
+FOREIGN KEY
+--------------------------------------------------------------------------------
+```python
+created_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+```
+
+A foreign key references another table's primary key. This creates a
+relationship: each regatta is created by one user.
+
+Format: db.ForeignKey("tablename.column")
+
+ONUPDATE COLUMN
+--------------------------------------------------------------------------------
+```python
+updated_at = db.Column(
+    db.DateTime,
+    default=lambda: datetime.now(timezone.utc),
+    onupdate=lambda: datetime.now(timezone.utc)
+)
+```
+
+The onupdate parameter automatically updates the timestamp whenever the row is
+modified. Useful for tracking last edit time.
+
+DATE VS DATETIME
+--------------------------------------------------------------------------------
+- **db.Date**: Stores only the date (2024-01-15)
+- **db.DateTime**: Stores date and time (2024-01-15 14:30:00)
+
+Use Date for events that don't have specific times.
+
+RELATIONSHIPS
+--------------------------------------------------------------------------------
+Relationships define how models connect:
+
+**One-to-Many (Regatta → Documents)**:
+```python
+documents = db.relationship("Document", backref="regatta", lazy="dynamic",
+                           cascade="all, delete-orphan")
+```
+
+- One regatta has many documents
+- backref="regatta" creates Document.regatta attribute automatically
+- lazy="dynamic" returns a query object instead of loading all at once
+- cascade="all, delete-orphan" deletes documents when regatta is deleted
+
+**One-to-Many (User → Regattas)**:
+```python
+creator = db.relationship("User", backref="created_regattas",
+                         foreign_keys=[created_by])
+```
+
+- foreign_keys=[created_by] is needed because User has multiple relationships
+- backref="created_regattas" creates user.created_regattas attribute
+
+================================================================================
+                    PART 4: DOCUMENT AND RSVP MODELS
+================================================================================
+
+DOCUMENT MODEL
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:81-93
+
+The Document model supports both file uploads and external URLs:
+
+```python
+class Document(db.Model):
+    __tablename__ = "documents"
+
+    id = db.Column(db.Integer, primary_key=True)
+    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"))
+    doc_type = db.Column(db.String(20), nullable=False)  # NOR, SI, WWW
+    original_filename = db.Column(db.String(255), nullable=True)
+    stored_filename = db.Column(db.String(255), nullable=True)
+    url = db.Column(db.String(500), nullable=True)
+    uploaded_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    uploaded_by = db.Column(db.Integer, db.ForeignKey("users.id"))
+```
+
+Either stored_filename OR url will be set, never both.
+
+RSVP MODEL
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:96-112
+
+The RSVP model tracks crew availability:
+
+```python
+class RSVP(db.Model):
+    __tablename__ = "rsvps"
+
+    id = db.Column(db.Integer, primary_key=True)
+    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"))
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    status = db.Column(db.String(10), nullable=False)  # yes, no, maybe
+    updated_at = db.Column(db.DateTime,
+                          default=lambda: datetime.now(timezone.utc),
+                          onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        db.UniqueConstraint("regatta_id", "user_id", name="uq_rsvp_regatta_user"),
+    )
+```
+
+UNIQUE CONSTRAINT
+--------------------------------------------------------------------------------
+```python
+__table_args__ = (
+    db.UniqueConstraint("regatta_id", "user_id"),
+)
+```
+
+Ensures one user can only have one RSVP per regatta. The database enforces
+this at the table level.
+
+IMPORTCACHE MODEL
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:115-128
+
+The ImportCache model caches AI extraction results to avoid redundant API calls:
+
+```python
+class ImportCache(db.Model):
+    __tablename__ = "import_cache"
+
+    id = db.Column(db.Integer, primary_key=True)
+    url = db.Column(db.String(500), nullable=False, unique=True)
+    year = db.Column(db.Integer, nullable=False)
+    results_json = db.Column(db.Text, nullable=False)
+    regatta_count = db.Column(db.Integer, nullable=False, default=0)
+    extracted_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+```
+
+KEY DESIGN CHOICES:
+- **url**: Unique constraint ensures one cache entry per URL
+- **results_json**: Stores the full AI extraction result as JSON text
+- **regatta_count**: Quick access to how many regattas were found
+- **extracted_at**: Timestamp for cache freshness decisions
+- No foreign keys — standalone cache table, not related to other models
+
+================================================================================
+                    PART 5: DATABASE SCHEMA
+================================================================================
+
+ENTITY RELATIONSHIP DIAGRAM
+--------------------------------------------------------------------------------
+
+  +-------------+
+  |    User     |
+  +-------------+
+  | id (PK)     |
+  | email       |
+  | password_   |
+  | display_    |
+  | is_admin    |
+  +-------------+
+        |
+        | 1:N (created_by)
+        |
+  +-------------+
+  |  Regatta    |
+  +-------------+
+  | id (PK)     |
+  | name        |
+  | boat_class  |
+  | start_date  |
+  | source_url  |
+  | created_by  |--------+
+  +-------------+        |
+        |                |
+        | 1:N            | N:1
+        |                |
+  +-------------+  +-------------+
+  |  Document   |  |    RSVP     |
+  +-------------+  +-------------+
+  | id (PK)     |  | id (PK)     |
+  | regatta_id  |  | regatta_id  |
+  | doc_type    |  | user_id     |
+  | filename    |  | status      |
+  | uploaded_by |  +-------------+
+  +-------------+        |
+                        | N:1
+                        |
+                  +-------------+
+                  |    User     |
+                  +-------------+
+
+  +----------------+
+  |  ImportCache   |  (standalone, no FK relationships)
+  +----------------+
+  | id (PK)        |
+  | url (unique)   |
+  | year           |
+  | results_json   |
+  | regatta_count  |
+  | extracted_at   |
+  +----------------+
+
+
+RELATIONSHIPS SUMMARY
+--------------------------------------------------------------------------------
+- User → Regatta (1:N): One user creates many regattas
+- Regatta → Document (1:N): One regatta has many documents
+- Regatta → RSVP (1:N): One regatta has many RSVPs
+- User → RSVP (1:N): One user has many RSVPs
+- User ↔ Regatta (N:M): Many-to-many via RSVP join table
+- ImportCache: Standalone table — caches AI extraction results per URL
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **ORM maps Python classes to database tables**. Each class attribute
+   becomes a column, and each instance represents a row.
+
+2. **Foreign keys create relationships** between tables. Use db.ForeignKey()
+   to reference another table's primary key.
+
+3. **Passwords must be hashed** before storage. bcrypt provides secure,
+   slow hashing designed for passwords.
+
+4. **Relationships are defined with db.relationship()** on one side and
+   backref creates the reverse. Use cascade to control delete behavior.
+
+5. **Unique constraints** prevent duplicate data. Use unique=True for single
+   columns or UniqueConstraint for multiple columns.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 4, we'll explore authentication with Flask-Login. You'll see how the
+User model integrates with login/logout functionality and how the app manages
+user sessions.
+
+================================================================================

--- a/python-class/04-day4.txt
+++ b/python-class/04-day4.txt
@@ -1,0 +1,503 @@
+================================================================================
+                   DAY 4: AUTHENTICATION & USER MANAGEMENT
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- Flask-Login integration and how user sessions work
+- Login and logout implementation
+- The invite-based registration system with tokens
+- User profile management
+- Admin user administration features
+- Authorization patterns (@login_required, role checks)
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- Flask-Login and session management
+- User authentication flow
+- Token-based invite system
+- Form validation and flash messages
+- Authorization vs authentication
+- Admin-only routes
+- Password change functionality
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+For this session, examine:
+- thistle-regatta-schedule/app/auth/routes.py - All authentication routes
+- thistle-regatta-schedule/app/models.py:9-44 - User model and user_loader
+
+================================================================================
+                    PART 1: FLASK-LOGIN OVERVIEW
+================================================================================
+
+WHAT IS FLASK-LOGIN?
+--------------------------------------------------------------------------------
+Flask-Login manages user sessions. It handles:
+- Storing user ID in encrypted session cookies
+- Loading user from database on each request
+- Protecting routes with @login_required
+- Providing current_user in routes and templates
+
+SETUP AND CONFIGURATION
+--------------------------------------------------------------------------------
+From app/__init__.py:
+```python
+login_manager = LoginManager()
+login_manager.login_view = "auth.login"
+```
+
+login_view sets the route to redirect to when authentication is required.
+
+USER LOADER FUNCTION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:42-44 (current line numbers)
+
+```python
+@login_manager.user_loader
+def load_user(user_id: str):
+    return db.session.get(User, int(user_id))
+```
+
+Flask-Login calls this on every request to load the user from the session
+cookie. The user_id is stored in the cookie; this function retrieves the full
+User object from the database.
+
+CURRENT_USER OBJECT
+--------------------------------------------------------------------------------
+Flask-Login provides current_user, a proxy to the logged-in user:
+
+```python
+from flask_login import current_user
+
+if current_user.is_authenticated:
+    print(f"Logged in as {current_user.display_name}")
+else:
+    print("Not logged in")
+```
+
+Available everywhere after login_manager is initialized.
+
+================================================================================
+                    PART 2: LOGIN AND LOGOUT
+================================================================================
+
+LOGIN ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:9-26 (current line numbers)
+
+```python
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if current_user.is_authenticated:
+        return redirect(url_for("regattas.index"))
+
+    if request.method == "POST":
+        email = request.form.get("email", "").strip().lower()
+        password = request.form.get("password", "")
+        user = User.query.filter_by(email=email).first()
+
+        if user and user.invite_token is None and user.check_password(password):
+            login_user(user)
+            next_page = request.args.get("next")
+            return redirect(next_page or url_for("regattas.index"))
+
+        flash("Invalid email or password.", "error")
+
+    return render_template("login.html")
+```
+
+STEP-BY-STEP LOGIN FLOW
+--------------------------------------------------------------------------------
+
+1. **Check if already logged in**:
+   ```python
+   if current_user.is_authenticated:
+       return redirect(url_for("regattas.index"))
+   ```
+   If already authenticated, send to main page.
+
+2. **Handle POST request** (form submission):
+   ```python
+   if request.method == "POST":
+   ```
+   GET shows the form, POST processes it.
+
+3. **Extract form data**:
+   ```python
+   email = request.form.get("email", "").strip().lower()
+   password = request.form.get("password", "")
+   ```
+   Normalize email to lowercase for case-insensitive matching.
+
+4. **Find user by email**:
+   ```python
+   user = User.query.filter_by(email=email).first()
+   ```
+   Returns User object or None.
+
+5. **Validate credentials**:
+   ```python
+   if user and user.invite_token is None and user.check_password(password):
+   ```
+   Three checks:
+   - user exists
+   - invite_token is None (registration complete)
+   - password matches
+
+6. **Log in the user**:
+   ```python
+   login_user(user)
+   ```
+   Creates session cookie with encrypted user ID.
+
+7. **Redirect to next page**:
+   ```python
+   next_page = request.args.get("next")
+   return redirect(next_page or url_for("regattas.index"))
+   ```
+   If user was redirected to login from a protected page, return them there.
+   Otherwise go to main page.
+
+8. **Show error on failure**:
+   ```python
+   flash("Invalid email or password.", "error")
+   ```
+   Flash message appears on next page render.
+
+LOGOUT ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:29-33 (current line numbers)
+
+```python
+@bp.route("/logout")
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for("auth.login"))
+```
+
+@login_required ensures only authenticated users can logout. logout_user()
+clears the session cookie.
+
+================================================================================
+                    PART 3: INVITE-BASED REGISTRATION
+================================================================================
+
+WHY INVITE-BASED?
+--------------------------------------------------------------------------------
+This app doesn't have public registration. Admins must invite users by email.
+This prevents spam accounts and keeps the app private.
+
+INVITE FLOW
+--------------------------------------------------------------------------------
+1. Admin enters email on /admin/users page
+2. System creates User with invite_token set
+3. Admin copies invite link and sends to person
+4. Person visits link, sets name/initials/password
+5. invite_token is cleared, marking registration complete
+
+CREATING AN INVITE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:122-153 (current line numbers)
+
+```python
+@bp.route("/admin/users/invite", methods=["POST"])
+@login_required
+def invite_user():
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    import secrets
+
+    email = request.form.get("email", "").strip().lower()
+    if not email:
+        flash("Email is required.", "error")
+        return redirect(url_for("auth.admin_users"))
+
+    if User.query.filter_by(email=email).first():
+        flash("A user with that email already exists.", "error")
+        return redirect(url_for("auth.admin_users"))
+
+    token = secrets.token_urlsafe(32)
+    user = User(
+        email=email,
+        password_hash="pending",
+        display_name=email,
+        initials="??",
+        invite_token=token,
+    )
+    db.session.add(user)
+    db.session.commit()
+
+    invite_url = url_for("auth.register", token=token, _external=True)
+    flash(f"Invite link: {invite_url}", "success")
+    return redirect(url_for("auth.admin_users"))
+```
+
+KEY POINTS:
+- **Admin check**: Only admins can invite
+- **Token generation**: secrets.token_urlsafe(32) creates a random 32-byte token
+- **Placeholder data**: User created with temporary values
+- **_external=True**: Generates full URL with domain
+
+COMPLETING REGISTRATION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:36-64 (current line numbers)
+
+```python
+@bp.route("/register/<token>", methods=["GET", "POST"])
+def register(token: str):
+    user = User.query.filter_by(invite_token=token).first_or_404()
+
+    if request.method == "POST":
+        display_name = request.form.get("display_name", "").strip()
+        initials = request.form.get("initials", "").strip().upper()
+        password = request.form.get("password", "")
+        password2 = request.form.get("password2", "")
+
+        if not display_name or not initials:
+            flash("Name and initials are required.", "error")
+        elif len(initials) < 2 or len(initials) > 3:
+            flash("Initials must be 2-3 characters.", "error")
+        elif len(password) < 6:
+            flash("Password must be at least 6 characters.", "error")
+        elif password != password2:
+            flash("Passwords do not match.", "error")
+        else:
+            user.display_name = display_name
+            user.initials = initials
+            user.set_password(password)
+            user.invite_token = None  # Mark registration complete
+            db.session.commit()
+            login_user(user)
+            flash("Welcome aboard!", "success")
+            return redirect(url_for("regattas.index"))
+
+    return render_template("register.html", user=user)
+```
+
+VALIDATION CHAIN:
+1. Find user by token (404 if not found)
+2. Validate all required fields present
+3. Validate initials length (2-3 characters)
+4. Validate password length (minimum 6)
+5. Validate passwords match
+6. Update user and clear invite_token
+7. Log user in automatically
+8. Redirect to main page
+
+================================================================================
+                    PART 4: USER PROFILE MANAGEMENT
+================================================================================
+
+PROFILE EDITING
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:67-98 (current line numbers)
+
+Users can edit their own profile. Key features:
+- Change display name, initials, email
+- Optional password change
+- Optional phone number
+- Email uniqueness validation
+
+```python
+@bp.route("/profile", methods=["GET", "POST"])
+@login_required
+def profile():
+    if request.method == "POST":
+        # ... validation ...
+
+        current_user.display_name = display_name
+        current_user.initials = initials
+        current_user.email = email
+        current_user.phone = request.form.get("phone", "").strip() or None
+
+        if password:
+            current_user.set_password(password)
+
+        db.session.commit()
+        flash("Profile updated.", "success")
+        return redirect(url_for("auth.profile"))
+
+    return render_template("profile.html")
+```
+
+OPTIONAL PASSWORD CHANGE:
+```python
+if password:
+    current_user.set_password(password)
+```
+Password only updated if provided. Allows users to change other fields without
+changing password.
+
+EMAIL UNIQUENESS CHECK:
+```python
+elif email != current_user.email and User.query.filter_by(email=email).first():
+    flash("That email is already in use.", "error")
+```
+Only check if email changed. Allows user to submit form without changing email.
+
+================================================================================
+                    PART 5: ADMIN USER MANAGEMENT
+================================================================================
+
+ADMIN-ONLY ROUTES
+--------------------------------------------------------------------------------
+All admin routes start with the same authorization check:
+
+```python
+if not current_user.is_admin:
+    flash("Access denied.", "error")
+    return redirect(url_for("regattas.index"))
+```
+
+This is manual authorization checking. Some frameworks have decorators for
+this, but explicit checks work fine for small apps.
+
+USER LISTING
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:111-119 (current line numbers)
+
+```python
+@bp.route("/admin/users")
+@login_required
+def admin_users():
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    users = User.query.order_by(User.display_name).all()
+    return render_template("admin_users.html", users=users)
+```
+
+Shows all users sorted by name. Includes pending invites (invite_token set).
+
+EDITING OTHER USERS
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:156-195 (current line numbers)
+
+Admins can:
+- Change any user's name, initials, email
+- Toggle admin status
+- Reset passwords
+- Cannot delete themselves
+
+```python
+user.is_admin = is_admin
+```
+This allows admins to promote/demote users.
+
+DELETING USERS
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/auth/routes.py:198-215 (current line numbers)
+
+```python
+@bp.route("/admin/users/<int:user_id>/delete", methods=["POST"])
+@login_required
+def delete_user(user_id: int):
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    user = db.session.get(User, user_id)
+    if not user:
+        flash("User not found.", "error")
+    elif user.id == current_user.id:
+        flash("You cannot delete yourself.", "error")
+    else:
+        db.session.delete(user)
+        db.session.commit()
+        flash(f"User {user.display_name} deleted.", "success")
+
+    return redirect(url_for("auth.admin_users"))
+```
+
+SAFETY CHECK:
+```python
+elif user.id == current_user.id:
+    flash("You cannot delete yourself.", "error")
+```
+Prevents admins from accidentally locking themselves out.
+
+================================================================================
+                    PART 6: AUTHENTICATION VS AUTHORIZATION
+================================================================================
+
+AUTHENTICATION
+--------------------------------------------------------------------------------
+**Who are you?** Proving identity via login credentials.
+
+In this app:
+- Flask-Login manages sessions
+- login_user() creates session
+- current_user provides identity
+- @login_required ensures authentication
+
+AUTHORIZATION
+--------------------------------------------------------------------------------
+**What can you do?** Determining permissions based on identity.
+
+In this app:
+- is_admin boolean on User model
+- Manual checks: `if not current_user.is_admin`
+- Two roles: Admin (full access) and Crew (view + RSVP)
+
+PROTECTION PATTERNS
+--------------------------------------------------------------------------------
+
+**Require login**:
+```python
+@login_required
+def some_route():
+    # Only authenticated users
+```
+
+**Require admin**:
+```python
+@login_required
+def admin_route():
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+    # Only admins past this point
+```
+
+**Owner-only access**:
+```python
+if resource.owner_id != current_user.id:
+    flash("Access denied.", "error")
+    return redirect(...)
+```
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **Flask-Login manages user sessions** via encrypted cookies. The user_loader
+   function retrieves the full User object on each request.
+
+2. **Login validates three things**: user exists, registration is complete
+   (invite_token is None), and password matches.
+
+3. **Invite-based registration** uses random tokens to prevent public sign-ups.
+   Admins create User with token, invitee completes registration via link.
+
+4. **Flash messages provide feedback** to users. They persist across one
+   redirect and then disappear.
+
+5. **Authorization is separate from authentication**. @login_required handles
+   authentication, manual checks handle authorization.
+
+6. **Password changes are optional** in profile editing. Only update password
+   if provided.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 5, we'll explore regatta management with full CRUD operations. You'll
+see how to create, read, update, and delete regattas, with form processing
+and date handling.
+
+================================================================================

--- a/python-class/05-day5.txt
+++ b/python-class/05-day5.txt
@@ -1,0 +1,341 @@
+================================================================================
+                   DAY 5: REGATTA MANAGEMENT (CRUD OPERATIONS)
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- RESTful route design in Flask
+- Create, Read, Update, Delete (CRUD) operations
+- Form processing with request.form
+- Date handling in Python
+- Permission checks for admin-only routes
+- Flash messages for user feedback
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- CRUD pattern
+- RESTful routing
+- Form validation
+- Date parsing with fromisoformat()
+- Conditional logic in save operations
+- URL generation with url_for()
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+For this session, examine:
+- thistle-regatta-schedule/app/regattas/routes.py - CRUD operations
+
+================================================================================
+                    PART 1: RESTful ROUTING
+================================================================================
+
+CRUD OPERATIONS
+--------------------------------------------------------------------------------
+**Create**: Add new regatta
+**Read**: View regatta list
+**Update**: Edit existing regatta
+**Delete**: Remove regatta
+
+ROUTES IN THIS APP
+--------------------------------------------------------------------------------
+| Operation    | HTTP Method | Route                    | Function      |
+|--------------|-------------|--------------------------|---------------|
+| Read         | GET         | /                        | index()       |
+| PDF          | GET         | /schedule.pdf            | pdf()         |
+| Create       | GET         | /regattas/new            | create()      |
+| Create       | POST        | /regattas/new            | create()      |
+| Update       | GET         | /regattas/<id>/edit      | edit()        |
+| Update       | POST        | /regattas/<id>/edit      | edit()        |
+| Delete       | POST        | /regattas/<id>/delete    | delete()      |
+| Bulk Delete  | POST        | /regattas/bulk-delete    | bulk_delete() |
+
+GET shows forms, POST processes them.
+
+================================================================================
+                    PART 2: READ (INDEX)
+================================================================================
+
+INDEX ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:16-35
+
+```python
+@bp.route("/")
+def index():
+    if not current_user.is_authenticated:
+        return render_template("login.html")
+
+    today = date.today()
+    upcoming = (
+        Regatta.query.filter(Regatta.start_date >= today)
+        .order_by(Regatta.start_date)
+        .all()
+    )
+    past = (
+        Regatta.query.filter(Regatta.start_date < today)
+        .order_by(Regatta.start_date.desc())
+        .all()
+    )
+    users = User.query.filter(User.invite_token.is_(None)).order_by(User.display_name).all()
+    return render_template("index.html", upcoming=upcoming, past=past, users=users)
+```
+
+NOTE: The index route serves the login page for anonymous users instead of
+redirecting. This avoids an ugly /login?next=%2F URL and provides a cleaner
+user experience.
+
+QUERYING PATTERNS:
+- **filter()**: WHERE clause conditions
+- **order_by()**: Sort results
+- **.desc()**: Descending order
+- **.all()**: Execute and return list
+
+SPLITTING UPCOMING AND PAST:
+```python
+today = date.today()
+upcoming = Regatta.query.filter(Regatta.start_date >= today)...
+past = Regatta.query.filter(Regatta.start_date < today)...
+```
+
+Past regattas show most recent first (.desc()), upcoming show nearest first.
+
+================================================================================
+                    PART 3: CREATE
+================================================================================
+
+CREATE ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:65-75
+
+```python
+@bp.route("/regattas/new", methods=["GET", "POST"])
+@login_required
+def create():
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if request.method == "POST":
+        return _save_regatta(None)
+
+    return render_template("regatta_form.html", regatta=None)
+```
+
+PATTERN:
+- GET: Show empty form (regatta=None)
+- POST: Process form via _save_regatta()
+- Admin check at top
+
+SAVE FUNCTION
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:250-293
+
+```python
+def _save_regatta(regatta: Regatta | None):
+    name = request.form.get("name", "").strip()
+    boat_class = request.form.get("boat_class", "").strip() or "TBD"
+    location = request.form.get("location", "").strip()
+    location_url = request.form.get("location_url", "").strip()
+    start_date_str = request.form.get("start_date", "")
+    end_date_str = request.form.get("end_date", "")
+    notes = request.form.get("notes", "").strip()
+    source_url = request.form.get("source_url", "").strip()
+
+    if not name or not location or not start_date_str:
+        flash("Name, location, and start date are required.", "error")
+        return render_template("regatta_form.html", regatta=regatta)
+
+    try:
+        start_date = date.fromisoformat(start_date_str)
+        end_date = date.fromisoformat(end_date_str) if end_date_str else None
+    except ValueError:
+        flash("Invalid date format.", "error")
+        return render_template("regatta_form.html", regatta=regatta)
+
+    if regatta is None:
+        regatta = Regatta(created_by=current_user.id)
+        db.session.add(regatta)
+
+    regatta.name = name
+    regatta.boat_class = boat_class
+    regatta.location = location
+    if location_url:
+        regatta.location_url = location_url
+    else:
+        regatta.location_url = f"https://www.google.com/maps/search/{quote_plus(location)}"
+    regatta.start_date = start_date
+    regatta.end_date = end_date
+    regatta.notes = notes or None
+    regatta.source_url = source_url or None
+
+    db.session.commit()
+    flash(f"Regatta '{name}' saved.", "success")
+    return redirect(url_for("regattas.index"))
+```
+
+FORM EXTRACTION:
+```python
+name = request.form.get("name", "").strip()
+```
+request.form is a dict-like object with form data. .get() with default avoids KeyError.
+
+DATE PARSING:
+```python
+start_date = date.fromisoformat(start_date_str)
+```
+Converts "2024-01-15" to date object. Raises ValueError if invalid.
+
+CREATE VS UPDATE:
+```python
+if regatta is None:
+    regatta = Regatta(created_by=current_user.id)
+    db.session.add(regatta)
+```
+If None, create new. Otherwise update existing.
+
+AUTO-GENERATED GOOGLE MAPS:
+```python
+if location_url:
+    regatta.location_url = location_url
+else:
+    regatta.location_url = f"https://www.google.com/maps/search/{quote_plus(location)}"
+```
+If no URL provided, generate Google Maps search link.
+
+================================================================================
+                    PART 4: UPDATE
+================================================================================
+
+EDIT ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:78-93
+
+```python
+@bp.route("/regattas/<int:regatta_id>/edit", methods=["GET", "POST"])
+@login_required
+def edit(regatta_id: int):
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta:
+        flash("Regatta not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if request.method == "POST":
+        return _save_regatta(regatta)
+
+    return render_template("regatta_form.html", regatta=regatta)
+```
+
+KEY DIFFERENCE FROM CREATE:
+- Loads existing regatta: `db.session.get(Regatta, regatta_id)`
+- Passes to _save_regatta(regatta) instead of None
+- Same form template handles both create and edit
+
+================================================================================
+                    PART 5: DELETE
+================================================================================
+
+DELETE ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:96-108
+
+```python
+@bp.route("/regattas/<int:regatta_id>/delete", methods=["POST"])
+@login_required
+def delete(regatta_id: int):
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    regatta = db.session.get(Regatta, regatta_id)
+    if regatta:
+        db.session.delete(regatta)
+        db.session.commit()
+        flash(f"Regatta '{regatta.name}' deleted.", "success")
+    return redirect(url_for("regattas.index"))
+```
+
+DELETE CASCADE:
+Remember from Day 3, Regatta has:
+```python
+documents = db.relationship(..., cascade="all, delete-orphan")
+rsvps = db.relationship(..., cascade="all, delete-orphan")
+```
+Deleting a regatta automatically deletes its documents and RSVPs.
+
+================================================================================
+                    PART 6: PDF GENERATION & BULK DELETE
+================================================================================
+
+PDF SCHEDULE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:38-62
+
+```python
+@bp.route("/schedule.pdf")
+@login_required
+def pdf():
+    today = date.today()
+    upcoming = Regatta.query.filter(Regatta.start_date >= today)...
+    past = Regatta.query.filter(Regatta.start_date < today)...
+    html_str = render_template("pdf_schedule.html", upcoming=upcoming, past=past, ...)
+    pdf_bytes = HTML(string=html_str).write_pdf()
+    response = make_response(pdf_bytes)
+    response.headers["Content-Type"] = "application/pdf"
+    return response
+```
+
+This uses WeasyPrint to render an HTML template to PDF. The same query logic
+as the index route provides upcoming/past regattas for the PDF layout.
+
+BULK DELETE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:111-136
+
+Admins can select multiple regattas via checkboxes and delete them at once:
+
+```python
+@bp.route("/regattas/bulk-delete", methods=["POST"])
+@login_required
+def bulk_delete():
+    selected = request.form.getlist("selected")
+    ...
+    for regatta_id in selected:
+        regatta = db.session.get(Regatta, int(regatta_id))
+        if regatta:
+            db.session.delete(regatta)
+            count += 1
+    db.session.commit()
+```
+
+request.form.getlist() returns all values for checkboxes with the same name
+attribute, enabling multi-select operations.
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **CRUD operations follow consistent patterns**: GET shows forms, POST
+   processes them. Shared logic in helper functions.
+
+2. **Form data comes from request.form**, a dict-like object. Always provide
+   defaults with .get() to handle missing fields.
+
+3. **Date parsing with fromisoformat()** converts ISO format strings
+   ("2024-01-15") to date objects. Wrap in try/except for validation.
+
+4. **Flash messages provide feedback** to users after operations. They persist
+   across one redirect.
+
+5. **Admin checks protect routes**. Manual checks work well for small apps.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 6, we'll explore the RSVP system and many-to-many relationships through
+the join table pattern.
+
+================================================================================

--- a/python-class/06-day6.txt
+++ b/python-class/06-day6.txt
@@ -1,0 +1,190 @@
+================================================================================
+                   DAY 6: RSVP SYSTEM & DATABASE RELATIONSHIPS
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- Many-to-many relationships via join tables
+- Upsert pattern (update or insert)
+- SQLAlchemy lazy loading strategies
+- Custom Jinja2 template filters
+- Status tracking and display logic
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- Many-to-many relationships
+- Join table pattern
+- Upsert operations
+- Template filters
+- Query optimization
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+- thistle-regatta-schedule/app/regattas/routes.py:139-159 - RSVP route
+- thistle-regatta-schedule/app/models.py:96-112 - RSVP model
+- thistle-regatta-schedule/app/__init__.py:46-51 - sort_rsvps filter
+
+================================================================================
+                    PART 1: MANY-TO-MANY RELATIONSHIPS
+================================================================================
+
+THE RELATIONSHIP
+--------------------------------------------------------------------------------
+Users and Regattas have a many-to-many relationship:
+- One user can RSVP to many regattas
+- One regatta can have RSVPs from many users
+
+This requires a join table: RSVP.
+
+RSVP MODEL REVIEW
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:96-112
+
+```python
+class RSVP(db.Model):
+    __tablename__ = "rsvps"
+
+    id = db.Column(db.Integer, primary_key=True)
+    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"))
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    status = db.Column(db.String(10), nullable=False)  # yes, no, maybe
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        db.UniqueConstraint("regatta_id", "user_id"),
+    )
+```
+
+TWO FOREIGN KEYS:
+- regatta_id → links to Regatta
+- user_id → links to User
+
+UNIQUE CONSTRAINT:
+Ensures one user can only have one RSVP per regatta.
+
+================================================================================
+                    PART 2: RSVP ROUTE (UPSERT PATTERN)
+================================================================================
+
+RSVP ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:139-159
+
+```python
+@bp.route("/regattas/<int:regatta_id>/rsvp", methods=["POST"])
+@login_required
+def rsvp(regatta_id: int):
+    status = request.form.get("status", "").lower()
+    if status not in ("yes", "no", "maybe"):
+        flash("Invalid RSVP status.", "error")
+        return redirect(url_for("regattas.index"))
+
+    existing = RSVP.query.filter_by(
+        regatta_id=regatta_id, user_id=current_user.id
+    ).first()
+
+    if existing:
+        existing.status = status
+    else:
+        db.session.add(
+            RSVP(regatta_id=regatta_id, user_id=current_user.id, status=status)
+        )
+
+    db.session.commit()
+    return redirect(url_for("regattas.index"))
+```
+
+UPSERT PATTERN:
+```python
+existing = RSVP.query.filter_by(...).first()
+
+if existing:
+    existing.status = status      # UPDATE
+else:
+    db.session.add(RSVP(...))    # INSERT
+```
+
+This is "upsert": update if exists, insert if not.
+
+WHY UPSERT?
+The unique constraint prevents duplicate RSVPs. Upsert allows users to change
+their status without creating duplicate entries.
+
+================================================================================
+                    PART 3: TEMPLATE FILTER
+================================================================================
+
+SORT_RSVPS FILTER
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/__init__.py:46-51
+
+```python
+@app.template_filter("sort_rsvps")
+def sort_rsvps(rsvps):
+    order = {"yes": 0, "no": 1, "maybe": 2}
+    return sorted(rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name))
+```
+
+USAGE IN TEMPLATES:
+```html
+{% for rsvp in regatta.rsvps|sort_rsvps %}
+    <span>{{ rsvp.user.initials }}</span>
+{% endfor %}
+```
+
+SORTING LOGIC:
+1. Primary sort: status (yes=0, no=1, maybe=2)
+2. Secondary sort: user display_name alphabetically
+
+Result: "Yes" responses first, then "No", then "Maybe", each group
+alphabetically.
+
+================================================================================
+                    PART 4: LAZY LOADING
+================================================================================
+
+RELATIONSHIP LOADING
+--------------------------------------------------------------------------------
+From Regatta model:
+```python
+rsvps = db.relationship("RSVP", backref="regatta", lazy="dynamic")
+```
+
+lazy="dynamic" returns a query object instead of loading all RSVPs immediately.
+
+LAZY LOADING OPTIONS:
+- **select** (default): Load when accessed (N+1 query problem)
+- **dynamic**: Return query object (can filter further)
+- **joined**: Load with JOIN (single query)
+- **subquery**: Load with subquery
+
+DYNAMIC EXAMPLE:
+```python
+regatta.rsvps                    # Returns query object
+regatta.rsvps.count()            # SELECT COUNT(*)
+regatta.rsvps.filter_by(status='yes').all()  # Can add filters
+```
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **Many-to-many relationships** require a join table with two foreign keys.
+   RSVP connects Users and Regattas.
+
+2. **Upsert pattern** (update or insert) is common for unique relationships.
+   Check if exists, update if yes, insert if no.
+
+3. **Template filters** transform data in templates. Register with
+   @app.template_filter() decorator.
+
+4. **Lazy loading strategies** control when related objects are loaded.
+   lazy="dynamic" provides maximum flexibility.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 7, we'll explore document uploads and file handling with secure UUID
+filenames and Docker volume management.
+
+================================================================================

--- a/python-class/07-day7.txt
+++ b/python-class/07-day7.txt
@@ -1,0 +1,299 @@
+================================================================================
+                   DAY 7: DOCUMENT UPLOAD & FILE HANDLING
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- File upload processing in Flask
+- UUID-based secure filename generation
+- Supporting both file uploads and external URLs
+- S3-compatible cloud storage abstraction
+- Presigned URLs for secure file downloads
+- File deletion and cleanup
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- File uploads with request.files
+- UUID for unique filenames
+- Storage abstraction layer (local vs S3)
+- Presigned URLs for secure downloads
+- boto3 S3 client
+- File size limits
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+- thistle-regatta-schedule/app/regattas/routes.py:162-247 - Upload/download
+- thistle-regatta-schedule/app/storage.py - S3 storage abstraction
+- thistle-regatta-schedule/app/models.py:81-93 - Document model
+- thistle-regatta-schedule/app/config.py - MAX_CONTENT_LENGTH, BUCKET_NAME
+
+================================================================================
+                    PART 1: DOCUMENT MODEL
+================================================================================
+
+DUAL-MODE DOCUMENTS
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/models.py:81-93
+
+```python
+class Document(db.Model):
+    __tablename__ = "documents"
+
+    id = db.Column(db.Integer, primary_key=True)
+    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"))
+    doc_type = db.Column(db.String(20), nullable=False)  # NOR, SI, WWW
+    original_filename = db.Column(db.String(255), nullable=True)
+    stored_filename = db.Column(db.String(255), nullable=True)
+    url = db.Column(db.String(500), nullable=True)
+    uploaded_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    uploaded_by = db.Column(db.Integer, db.ForeignKey("users.id"))
+```
+
+TWO MODES:
+- **File upload**: stored_filename set, url is None
+- **External link**: url set, stored_filename is None
+
+================================================================================
+                    PART 2: FILE UPLOAD
+================================================================================
+
+UPLOAD ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:176-223
+
+```python
+@bp.route("/regattas/<int:regatta_id>/upload", methods=["POST"])
+@login_required
+def upload_doc(regatta_id: int):
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    doc_type = request.form.get("doc_type", "Other")
+    doc_url = request.form.get("doc_url", "").strip()
+    file = request.files.get("file")
+
+    if doc_url:
+        # URL-based document
+        doc = Document(
+            regatta_id=regatta_id,
+            doc_type=doc_type,
+            url=doc_url,
+            uploaded_by=current_user.id,
+        )
+        db.session.add(doc)
+        db.session.commit()
+        flash(f"{doc_type} link added.", "success")
+    elif file and file.filename:
+        # File-based document
+        ext = os.path.splitext(file.filename)[1].lower()
+        stored_filename = f"{uuid.uuid4().hex}{ext}"
+
+        storage.upload_file(file, stored_filename)
+
+        doc = Document(
+            regatta_id=regatta_id,
+            doc_type=doc_type,
+            original_filename=file.filename,
+            stored_filename=stored_filename,
+            uploaded_by=current_user.id,
+        )
+        db.session.add(doc)
+        db.session.commit()
+        flash(f"{doc_type} uploaded.", "success")
+    else:
+        flash("Provide either a URL or a file.", "error")
+
+    return redirect(url_for("regattas.edit", regatta_id=regatta_id))
+```
+
+FILE EXTRACTION:
+```python
+file = request.files.get("file")
+```
+request.files contains uploaded files as FileStorage objects.
+
+UUID FILENAME:
+```python
+ext = os.path.splitext(file.filename)[1].lower()
+stored_filename = f"{uuid.uuid4().hex}{ext}"
+```
+
+Why UUID?
+- Prevents filename collisions
+- Prevents path traversal attacks (../../../etc/passwd)
+- Keeps original filename separate for display
+
+STORAGE ABSTRACTION:
+```python
+storage.upload_file(file, stored_filename)
+```
+
+Instead of saving directly to disk, the app uses a storage module that
+uploads to S3-compatible object storage (Lightsail bucket in production).
+See the Storage Module section below for details.
+
+================================================================================
+                    PART 3: FILE DOWNLOAD
+================================================================================
+
+DOWNLOAD ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:162-173
+
+```python
+@bp.route("/docs/<int:doc_id>")
+@login_required
+def download_doc(doc_id: int):
+    doc = db.session.get(Document, doc_id)
+    if not doc:
+        flash("Document not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if doc.url:
+        return redirect(doc.url)
+
+    return redirect(storage.get_file_url(doc.stored_filename))
+```
+
+PRESIGNED URL:
+```python
+return redirect(storage.get_file_url(doc.stored_filename))
+```
+Instead of serving files directly from the Flask process, the storage module
+generates a time-limited presigned URL. The browser is redirected to download
+directly from S3, which offloads bandwidth from the application server.
+
+URL VS FILE:
+```python
+if doc.url:
+    return redirect(doc.url)
+```
+If URL-based, redirect to external site.
+
+================================================================================
+                    PART 4: FILE DELETION
+================================================================================
+
+DELETE ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/regattas/routes.py:226-247
+
+```python
+@bp.route("/docs/<int:doc_id>/delete", methods=["POST"])
+@login_required
+def delete_doc(doc_id: int):
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    doc = db.session.get(Document, doc_id)
+    if not doc:
+        flash("Document not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    regatta_id = doc.regatta_id
+
+    # Delete file from S3 if it's a file-based document
+    if doc.stored_filename:
+        storage.delete_file(doc.stored_filename)
+
+    db.session.delete(doc)
+    db.session.commit()
+    flash("Document removed.", "success")
+    return redirect(url_for("regattas.edit", regatta_id=regatta_id))
+```
+
+CLEANUP PATTERN:
+1. If file-based, delete from S3 storage
+2. Delete database record
+3. storage.delete_file() silently ignores missing files (no error)
+
+================================================================================
+                    PART 5: STORAGE MODULE
+================================================================================
+
+S3-COMPATIBLE STORAGE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/storage.py
+
+In production, file uploads go to Lightsail Object Storage (S3-compatible).
+The storage module abstracts this behind three simple functions:
+
+```python
+import boto3
+
+def upload_file(file, stored_filename: str) -> None:
+    """Upload a file-like object to the S3 bucket."""
+    bucket = current_app.config["BUCKET_NAME"]
+    client = _get_client()
+    client.upload_fileobj(file, bucket, stored_filename)
+
+def get_file_url(stored_filename: str) -> str:
+    """Return a presigned URL (valid 1 hour) for downloading a file."""
+    bucket = current_app.config["BUCKET_NAME"]
+    client = _get_client()
+    return client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": stored_filename},
+        ExpiresIn=3600,
+    )
+
+def delete_file(stored_filename: str) -> None:
+    """Delete a file from the S3 bucket. Silently ignores missing files."""
+    bucket = current_app.config["BUCKET_NAME"]
+    client = _get_client()
+    client.delete_object(Bucket=bucket, Key=stored_filename)
+```
+
+KEY DESIGN PATTERNS:
+- **Abstraction**: Routes call storage.upload_file() instead of S3 directly
+- **Presigned URLs**: Downloads bypass Flask entirely — browser fetches from S3
+- **Time-limited access**: Presigned URLs expire after 1 hour (security)
+- **Silent delete**: Missing files don't cause errors (idempotent)
+- **boto3**: AWS SDK for Python, works with any S3-compatible service
+
+LOCAL DEVELOPMENT:
+For local development, the BUCKET_NAME config is empty. Files are stored in
+a Docker volume (uploads:/app/uploads) using the same interface.
+
+================================================================================
+                    PART 6: FILE SIZE LIMITS
+================================================================================
+
+MAX_CONTENT_LENGTH
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/config.py
+
+```python
+MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB
+```
+
+Flask automatically rejects requests larger than this. In production, the
+Lightsail Container Service also enforces request size limits.
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **UUID filenames** prevent collisions and security issues. Store original
+   filename separately for display.
+
+2. **Presigned URLs** let the browser download directly from S3, offloading
+   bandwidth from the application server. They expire after a set time.
+
+3. **Storage abstraction** (app/storage.py) hides S3 details behind simple
+   functions. Routes call storage.upload_file() without knowing about boto3.
+
+4. **Two-mode documents** (file or URL) provide flexibility without separate
+   models or tables.
+
+5. **File cleanup** requires deleting both database record and S3 object.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 8, we'll explore calendar integration with iCal format and the
+icalendar library for generating .ics feeds.
+
+================================================================================

--- a/python-class/08-day8.txt
+++ b/python-class/08-day8.txt
@@ -1,0 +1,303 @@
+================================================================================
+                   DAY 8: CALENDAR INTEGRATION (ICAL FEEDS)
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- iCalendar format and RFC 5545 standard
+- Using the icalendar Python library
+- Token-based feed authentication
+- Generating calendar events
+- All-day event handling
+- Calendar subscription URLs
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- iCal (.ics) format
+- Calendar feed generation
+- Token authentication for public feeds
+- All-day events vs timed events
+- MIME types and Content-Disposition headers
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+- thistle-regatta-schedule/app/calendar/routes.py - Calendar feed generation
+
+================================================================================
+                    PART 1: ICALENDAR FORMAT
+================================================================================
+
+WHAT IS ICAL?
+--------------------------------------------------------------------------------
+iCalendar (.ics) is a standard format for calendar data (RFC 5545). It's
+supported by:
+- Google Calendar
+- Apple Calendar
+- Outlook
+- Most calendar applications
+
+SUBSCRIPTION VS IMPORT:
+- **Import**: One-time copy (no updates)
+- **Subscribe**: Live feed (updates automatically)
+
+This app provides subscription feeds.
+
+================================================================================
+                    PART 2: TOKEN AUTHENTICATION
+================================================================================
+
+CALENDAR TOKEN
+--------------------------------------------------------------------------------
+From User model:
+```python
+calendar_token = db.Column(db.String(64), unique=True, nullable=True)
+```
+
+Each user gets a unique token for their calendar feed. Token is generated on
+first subscription request.
+
+SUBSCRIBE ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/calendar/routes.py:14-31
+
+```python
+@bp.route("/calendar/subscribe")
+@login_required
+def subscribe():
+    if not current_user.calendar_token:
+        current_user.calendar_token = secrets.token_urlsafe(32)
+        db.session.commit()
+
+    feed_url = url_for(
+        "calendar.ical_feed", token=current_user.calendar_token, _external=True
+    )
+    flash(Markup(
+        f'Subscribe to this URL in your calendar app: <a href="{feed_url}" class="alert-link">{feed_url}</a>'
+    ), "success")
+    return redirect(url_for("regattas.index"))
+```
+
+LAZY TOKEN GENERATION:
+Token only created when user requests feed URL. Most users never subscribe, so
+this saves database space.
+
+_EXTERNAL=TRUE:
+```python
+url_for("calendar.ical_feed", token=token, _external=True)
+```
+
+Generates full URL with domain:
+`https://example.com/calendar/abc123.ics`
+
+Calendar apps need full URLs to subscribe.
+
+================================================================================
+                    PART 3: FEED GENERATION
+================================================================================
+
+ICAL FEED ROUTE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/app/calendar/routes.py:34-92
+
+```python
+@bp.route("/calendar/<token>.ics")
+def ical_feed(token: str):
+    user = User.query.filter_by(calendar_token=token).first_or_404()
+
+    cal = Calendar()
+    cal.add("prodid", "-//Race Crew Network//EN")
+    cal.add("version", "2.0")
+    cal.add("calscale", "GREGORIAN")
+    cal.add("x-wr-calname", "Race Crew Network")
+    cal.add("method", "PUBLISH")
+
+    regattas = Regatta.query.order_by(Regatta.start_date).all()
+
+    for regatta in regattas:
+        event = Event()
+        event.add("uid", f"regatta-{regatta.id}@racecrew.net")
+        if regatta.boat_class and regatta.boat_class != "TBD":
+            event.add("summary", f"{regatta.boat_class} — {regatta.name}")
+        else:
+            event.add("summary", regatta.name)
+        event.add("dtstart", regatta.start_date)
+        end = (regatta.end_date or regatta.start_date) + timedelta(days=1)
+        event.add("dtend", end)
+        event.add("location", regatta.location)
+
+        if regatta.location_url:
+            event.add("url", regatta.location_url)
+
+        # Build description with RSVPs
+        lines = []
+        if regatta.notes:
+            lines.append(regatta.notes)
+
+        rsvps = regatta.rsvps.all()
+        if rsvps:
+            crew_lines = [f"  {r.user.initials}: {r.status}" for r in rsvps]
+            lines.append("Crew:\n" + "\n".join(crew_lines))
+
+        my_rsvp = RSVP.query.filter_by(
+            regatta_id=regatta.id, user_id=user.id
+        ).first()
+        if my_rsvp:
+            lines.append(f"Your RSVP: {my_rsvp.status.capitalize()}")
+
+        if lines:
+            event.add("description", "\n\n".join(lines))
+
+        cal.add_component(event)
+
+    response = Response(cal.to_ical(), mimetype="text/calendar")
+    response.headers["Content-Disposition"] = (
+        "attachment; filename=race-crew-network.ics"
+    )
+    return response
+```
+
+CALENDAR METADATA:
+```python
+cal.add("prodid", "-//Race Crew Network//EN")
+cal.add("version", "2.0")
+cal.add("x-wr-calname", "Race Crew Network")
+```
+
+Standard iCal properties identifying the calendar.
+
+EVENT PROPERTIES:
+- **uid**: Unique identifier (used for updates)
+- **summary**: Event title (includes boat class when set, e.g. "Thistle — Midwinters")
+- **dtstart**: Start date
+- **dtend**: End date
+- **location**: Location text
+- **url**: Associated URL
+- **description**: Event details
+
+BOAT CLASS IN SUMMARY:
+```python
+if regatta.boat_class and regatta.boat_class != "TBD":
+    event.add("summary", f"{regatta.boat_class} — {regatta.name}")
+else:
+    event.add("summary", regatta.name)
+```
+When a boat class is specified, it's prepended to the event title so
+calendar entries clearly show what class the regatta is for.
+
+ALL-DAY EVENTS:
+```python
+event.add("dtstart", regatta.start_date)
+```
+
+When you pass a date object (not datetime), it's treated as all-day event.
+
+END DATE HANDLING:
+```python
+end = (regatta.end_date or regatta.start_date) + timedelta(days=1)
+event.add("dtend", end)
+```
+
+iCal end dates are EXCLUSIVE. A one-day event from Jan 1 has:
+- dtstart: Jan 1
+- dtend: Jan 2
+
+Adding timedelta(days=1) makes the math correct.
+
+================================================================================
+                    PART 4: BUILDING DESCRIPTIONS
+================================================================================
+
+DESCRIPTION WITH RSVPs
+--------------------------------------------------------------------------------
+```python
+lines = []
+if regatta.notes:
+    lines.append(regatta.notes)
+
+rsvps = regatta.rsvps.all()
+if rsvps:
+    crew_lines = [f"  {r.user.initials}: {r.status}" for r in rsvps]
+    lines.append("Crew:\n" + "\n".join(crew_lines))
+
+my_rsvp = RSVP.query.filter_by(regatta_id=regatta.id, user_id=user.id).first()
+if my_rsvp:
+    lines.append(f"Your RSVP: {my_rsvp.status.capitalize()}")
+
+if lines:
+    event.add("description", "\n\n".join(lines))
+```
+
+PERSONALIZATION:
+Each user's feed includes their own RSVP status in the description. This makes
+the calendar feed personal to each user.
+
+================================================================================
+                    PART 5: RESPONSE FORMAT
+================================================================================
+
+ICAL RESPONSE
+--------------------------------------------------------------------------------
+```python
+response = Response(cal.to_ical(), mimetype="text/calendar")
+response.headers["Content-Disposition"] = "attachment; filename=race-crew-network.ics"
+return response
+```
+
+MIME TYPE:
+`text/calendar` tells browsers and calendar apps this is iCal data.
+
+CONTENT-DISPOSITION:
+`attachment; filename=race-crew-network.ics` suggests a download filename.
+
+TO_ICAL():
+The icalendar library's method to serialize Calendar object to iCal format.
+
+================================================================================
+                    PART 6: SECURITY CONSIDERATIONS
+================================================================================
+
+PUBLIC BUT SECRET
+--------------------------------------------------------------------------------
+The feed URL is:
+- **Public**: No authentication required (calendar apps can't login)
+- **Secret**: URL contains unguessable token
+
+This is standard practice for calendar feeds. Anyone with the URL can access
+it, but the URL itself is the secret.
+
+TOKEN PROPERTIES:
+- 32 bytes from secrets.token_urlsafe()
+- URL-safe characters only
+- Cryptographically random
+
+REVOKING ACCESS:
+To revoke a user's calendar access:
+1. Set calendar_token to NULL
+2. Generate new token on next subscription request
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **iCal format (RFC 5545)** is the standard for calendar data. The
+   icalendar library handles formatting details.
+
+2. **Token-based authentication** allows public access without login. The
+   token itself is the secret.
+
+3. **All-day events** use date objects (not datetime). End dates are
+   EXCLUSIVE in iCal format.
+
+4. **Personalized feeds** include user-specific data (their RSVP status)
+   without exposing other private information.
+
+5. **Calendar subscriptions** update automatically. Users see changes without
+   re-importing.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 9, we'll explore Docker and containerization in depth, covering the
+Dockerfile, docker-compose orchestration, Gunicorn, and GHCR publishing.
+
+================================================================================

--- a/python-class/09-day9.txt
+++ b/python-class/09-day9.txt
@@ -1,0 +1,340 @@
+================================================================================
+                   DAY 9: DOCKER & CONTAINERIZATION
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- Dockerfile structure and best practices
+- Multi-container orchestration with docker-compose
+- Container networking and service discovery
+- Volume persistence for data
+- Health checks for dependencies
+- Gunicorn production configuration
+- GitHub Container Registry (GHCR)
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- Docker images and containers
+- Multi-stage builds (not used here, but good to know)
+- Docker networking
+- Named volumes
+- Service dependencies
+- WSGI servers (Gunicorn)
+- Container registries (GHCR)
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+- thistle-regatta-schedule/Dockerfile - Web container build
+- thistle-regatta-schedule/docker-compose.yml - Local dev orchestration
+- thistle-regatta-schedule/gunicorn.conf.py - WSGI server config
+
+================================================================================
+                    PART 1: DOCKERFILE
+================================================================================
+
+DOCKERFILE
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/Dockerfile
+
+```dockerfile
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    default-libmysqlclient-dev gcc pkg-config \
+    libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+    libffi-dev libcairo2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN mkdir -p /app/uploads
+
+EXPOSE 8000
+
+CMD ["./entrypoint.sh"]
+```
+
+STEP-BY-STEP:
+
+**1. Base Image**:
+```dockerfile
+FROM python:3.13-slim
+```
+Official Python 3.13 slim image (Debian-based, minimal packages). Using
+the latest Python version reduces CVE exposure in the base image.
+
+**2. Working Directory**:
+```dockerfile
+WORKDIR /app
+```
+All subsequent commands run in /app.
+
+**3. System Dependencies**:
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    default-libmysqlclient-dev gcc pkg-config \
+    libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+    libffi-dev libcairo2 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+- default-libmysqlclient-dev: MySQL client libraries
+- gcc: C compiler (needed for some Python packages)
+- pkg-config: Package configuration helper
+- libpango, libcairo, etc.: Required by WeasyPrint for PDF generation
+- rm -rf /var/lib/apt/lists/*: Clean up to reduce image size
+
+**4. Install Python Dependencies**:
+```dockerfile
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+```
+
+Copy requirements first (before copying app code) for better caching. If code
+changes but requirements don't, Docker reuses this layer.
+
+**5. Copy Application**:
+```dockerfile
+COPY . .
+```
+
+Copy entire application directory to /app in container.
+
+**6. Create Upload Directory**:
+```dockerfile
+RUN mkdir -p /app/uploads
+```
+
+Ensure directory exists (though volume will override this).
+
+**7. Expose Port**:
+```dockerfile
+EXPOSE 8000
+```
+
+Documentation that container listens on port 8000. Doesn't actually publish.
+
+**8. Default Command**:
+```dockerfile
+CMD ["./entrypoint.sh"]
+```
+
+Run entrypoint script on container start.
+
+================================================================================
+                    PART 2: DOCKER COMPOSE
+================================================================================
+
+DOCKER-COMPOSE.YML REVIEW
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/docker-compose.yml (from Day 1)
+
+Two services: web, db (local development only)
+Two volumes: mysql_data, uploads
+
+Note: nginx was removed from the local setup. In production, the Lightsail
+Container Service handles HTTPS termination and load balancing.
+
+SERVICE DISCOVERY:
+Docker creates a network where services can reach each other by name:
+- web can connect to mysql://db:3306
+
+DEPENDS_ON:
+```yaml
+web:
+  depends_on:
+    db:
+      condition: service_healthy
+```
+
+web waits for db to pass health check before starting.
+
+HEALTH CHECKS:
+```yaml
+db:
+  healthcheck:
+    test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+    interval: 5s
+    timeout: 5s
+    retries: 10
+```
+
+Docker repeatedly runs health check until it passes (or retries exhausted).
+
+VOLUMES:
+```yaml
+volumes:
+  - mysql_data:/var/lib/mysql
+  - uploads:/app/uploads
+```
+
+Named volumes persist across container recreations.
+
+RESTART POLICY:
+```yaml
+restart: unless-stopped
+```
+
+Container restarts automatically unless manually stopped.
+
+================================================================================
+                    PART 3: GUNICORN CONFIGURATION
+================================================================================
+
+WHAT IS GUNICORN?
+--------------------------------------------------------------------------------
+Gunicorn (Green Unicorn) is a Python WSGI HTTP server. It:
+- Runs Flask in production (never use `flask run` in production)
+- Manages multiple worker processes
+- Handles concurrent requests
+- Provides process supervision
+
+GUNICORN CONFIG
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/gunicorn.conf.py
+
+```python
+bind = "0.0.0.0:8000"
+workers = 2
+accesslog = "-"
+errorlog = "-"
+```
+
+**bind**:
+Listen on all interfaces (0.0.0.0) port 8000. Inside Docker, this is necessary
+for the port mapping to work.
+
+**workers**:
+Number of worker processes. Rule of thumb: 2-4 x CPU cores. Two is fine for
+small traffic.
+
+**accesslog / errorlog**:
+"-" means stdout/stderr. Docker captures container output.
+
+WSGI ENTRY POINT:
+```bash
+gunicorn -c gunicorn.conf.py wsgi:app
+```
+
+This loads gunicorn.conf.py for settings, then imports `app` from wsgi.py.
+
+================================================================================
+                    PART 4: GITHUB CONTAINER REGISTRY (GHCR)
+================================================================================
+
+CONTAINER IMAGE PUBLISHING
+--------------------------------------------------------------------------------
+Docker images are built and published to GitHub Container Registry (GHCR)
+via GitHub Actions. This means production deployments pull pre-built images
+instead of building on the server.
+
+IMAGE TAGS:
+Each build produces images tagged with:
+- **latest**: Always points to the most recent build
+- **git SHA**: Specific commit (e.g., ghcr.io/chris-edwards-pub/race-crew-network:abc1234)
+- **semantic version**: Release tag (e.g., :v0.34.2)
+
+DOCKER-COMPOSE.YML REFERENCE:
+```yaml
+web:
+  build: .
+  image: ghcr.io/chris-edwards-pub/race-crew-network:latest
+```
+
+The `build` directive builds locally for development. The `image` directive
+names the image so it can be pulled from GHCR in production.
+
+BENEFITS:
+- **Zero-downtime deploys**: No building on server (no stopping containers to free RAM)
+- **Reproducible**: Same image in staging and production
+- **Fast rollback**: Previous image tags are always available
+- **Build caching**: GitHub Actions caches Docker layers for fast builds
+
+================================================================================
+                    PART 5: REQUEST FLOW
+================================================================================
+
+FULL REQUEST PATH (LOCAL DEVELOPMENT)
+--------------------------------------------------------------------------------
+
+  Client (Browser)
+    |
+    | HTTP request on port 80
+    v
+  Docker port mapping (80 → 8000)
+    |
+    v
+  Gunicorn (web container)
+    |
+    | WSGI interface
+    v
+  Flask application
+    |
+    | Query database
+    v
+  MySQL (db container) on port 3306
+    |
+    v
+  Flask renders template
+    |
+    v
+  Gunicorn returns response to client
+
+NETWORK ISOLATION:
+- Only the web container's port 8000 is mapped to host port 80
+- db communicates on Docker's internal network
+- Database is never exposed to the internet
+
+PRODUCTION REQUEST PATH:
+In production (Lightsail Container Service), the path is:
+  Client → Lightsail HTTPS endpoint → Gunicorn → Flask → Managed MySQL
+
+================================================================================
+                    PART 6: PRODUCTION ENHANCEMENTS
+================================================================================
+
+PRODUCTION ARCHITECTURE (AWS LIGHTSAIL):
+
+This app uses Lightsail Container Service for production:
+- **Container Service**: Manages the web container (auto-restart, scaling)
+- **Managed MySQL**: Lightsail database with automated backups
+- **Object Storage**: S3-compatible bucket for file uploads
+- **HTTPS**: Lightsail handles SSL certificate and termination
+- **Custom Domain**: SSL cert provisioned for racecrew.net
+
+No nginx container needed in production — Lightsail's load balancer
+handles HTTPS termination and routes traffic to the Gunicorn container.
+
+See Day 10 for full deployment details and CI/CD pipeline.
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **Docker Compose orchestrates multiple containers**. Service names provide
+   DNS for inter-container communication.
+
+2. **Gunicorn is the production WSGI server** for Flask. It manages worker
+   processes and handles concurrent requests.
+
+3. **GHCR stores pre-built Docker images**. Production deployments pull
+   images instead of building on the server, enabling fast rollbacks.
+
+4. **Named volumes persist data** across container recreations. Critical for
+   database and uploaded files in local development.
+
+5. **Health checks ensure startup order**. web waits for db to be ready
+   before starting.
+
+WHAT'S NEXT?
+--------------------------------------------------------------------------------
+In Day 10, we'll explore database migrations with Flask-Migrate and Alembic,
+and discuss production deployment strategies.
+
+================================================================================

--- a/python-class/10-day10.txt
+++ b/python-class/10-day10.txt
@@ -1,0 +1,406 @@
+================================================================================
+                   DAY 10: DATABASE MIGRATIONS & DEPLOYMENT
+================================================================================
+
+LEARNING OBJECTIVES
+--------------------------------------------------------------------------------
+By the end of this session, you will understand:
+- Flask-Migrate and Alembic for database migrations
+- Creating and applying migrations
+- Automatic migration on startup
+- AWS Lightsail Container Service deployment
+- GitHub Actions CI/CD pipeline
+- Environment variable management
+- Managed database and automated backups
+
+CONCEPTS COVERED
+--------------------------------------------------------------------------------
+- Database schema versioning
+- Migration generation
+- Upgrade and downgrade functions
+- CI/CD pipelines with GitHub Actions
+- Container registries (GHCR)
+- Managed cloud services
+- Infrastructure as Code (Terraform)
+
+FILE FOCUS
+--------------------------------------------------------------------------------
+- thistle-regatta-schedule/migrations/versions/* - Migration files
+- thistle-regatta-schedule/entrypoint.sh - Auto-migration on startup
+
+================================================================================
+                    PART 1: WHAT ARE DATABASE MIGRATIONS?
+================================================================================
+
+THE PROBLEM
+--------------------------------------------------------------------------------
+Your database schema changes as your app evolves:
+- Add new tables
+- Add/remove columns
+- Change column types
+- Add indexes
+
+How do you apply these changes to existing databases without data loss?
+
+THE SOLUTION: MIGRATIONS
+--------------------------------------------------------------------------------
+Migrations are scripts that transform database schema from one version to the
+next. Each migration has:
+- **upgrade()**: Apply the change
+- **downgrade()**: Undo the change
+
+Migrations form a version chain. You can upgrade or downgrade to any version.
+
+ALEMBIC
+--------------------------------------------------------------------------------
+Alembic is Python's database migration tool. Flask-Migrate wraps it for Flask
+apps.
+
+================================================================================
+                    PART 2: MIGRATION FILE STRUCTURE
+================================================================================
+
+EXAMPLE MIGRATION
+--------------------------------------------------------------------------------
+File: migrations/versions/c82d4c9ce2d5_add_calendar_token_to_users.py
+
+```python
+"""Add calendar_token to users
+
+Revision ID: c82d4c9ce2d5
+Revises: b741dd3b02c6
+Create Date: 2026-02-15 13:42:23.880068
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'c82d4c9ce2d5'
+down_revision = 'b741dd3b02c6'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('calendar_token', sa.String(length=64), nullable=True))
+        batch_op.create_unique_constraint(None, ['calendar_token'])
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_='unique')
+        batch_op.drop_column('calendar_token')
+```
+
+KEY ELEMENTS:
+
+**Revision Chain**:
+```python
+revision = 'c82d4c9ce2d5'  # This migration's ID
+down_revision = 'b741dd3b02c6'  # Previous migration
+```
+
+Alembic uses this to track version order.
+
+**upgrade()**:
+Applies the change:
+```python
+batch_op.add_column(sa.Column('calendar_token', sa.String(length=64), nullable=True))
+batch_op.create_unique_constraint(None, ['calendar_token'])
+```
+
+**downgrade()**:
+Reverses the change:
+```python
+batch_op.drop_constraint(None, type_='unique')
+batch_op.drop_column('calendar_token')
+```
+
+BATCH MODE:
+```python
+with op.batch_alter_table('users', schema=None) as batch_op:
+```
+
+Required for SQLite (which doesn't support ALTER TABLE directly). Works with
+all databases.
+
+================================================================================
+                    PART 3: CREATING MIGRATIONS
+================================================================================
+
+WORKFLOW
+--------------------------------------------------------------------------------
+
+1. **Modify models.py**:
+   Add/change model definitions.
+
+2. **Generate migration**:
+   ```bash
+   flask db migrate -m "Add calendar_token to users"
+   ```
+
+   This compares models.py to database and generates migration script.
+
+3. **Review migration**:
+   Check migrations/versions/*.py file. Alembic isn't perfect; you may need
+   to edit.
+
+4. **Apply migration**:
+   ```bash
+   flask db upgrade
+   ```
+
+   Applies pending migrations to database.
+
+INITIAL MIGRATION:
+```bash
+flask db init       # One-time: creates migrations/ directory
+flask db migrate -m "Initial schema"
+flask db upgrade
+```
+
+CHECKING STATUS:
+```bash
+flask db current    # Show current version
+flask db history    # Show migration history
+```
+
+DOWNGRADING:
+```bash
+flask db downgrade  # Undo last migration
+flask db downgrade <revision>  # Downgrade to specific version
+```
+
+================================================================================
+                    PART 4: AUTOMATIC MIGRATIONS ON STARTUP
+================================================================================
+
+ENTRYPOINT SCRIPT REVIEW
+--------------------------------------------------------------------------------
+File: thistle-regatta-schedule/entrypoint.sh
+
+```bash
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+flask db upgrade
+
+echo "Initializing admin account if needed..."
+flask init-admin
+
+echo "Starting Gunicorn..."
+exec gunicorn -c gunicorn.conf.py wsgi:app
+```
+
+**flask db upgrade**:
+Runs before starting Gunicorn. Ensures database schema is current.
+
+**flask init-admin**:
+Creates the initial admin user from INIT_ADMIN_EMAIL and INIT_ADMIN_PASSWORD
+environment variables. Safe to run repeatedly — skips if admin already exists.
+
+WHY THIS IS SAFE:
+- Migrations are idempotent (running twice doesn't break anything)
+- Alembic tracks applied migrations in alembic_version table
+- Already-applied migrations are skipped
+
+BENEFITS:
+- No manual migration step during deployment
+- Can deploy new version with `docker compose up --build`
+- Database always matches code
+
+================================================================================
+                    PART 5: PRODUCTION DEPLOYMENT
+================================================================================
+
+AWS LIGHTSAIL CONTAINER SERVICE
+--------------------------------------------------------------------------------
+This application is deployed on AWS Lightsail Container Service, which provides:
+- **Managed containers**: Auto-restart, health monitoring
+- **HTTPS endpoint**: SSL certificate provisioned and renewed automatically
+- **Custom domain**: racecrew.net with DNS via Route53
+- **Managed MySQL**: Lightsail database with automated daily backups
+- **Object Storage**: S3-compatible bucket for file uploads
+
+ARCHITECTURE:
+
+  Internet
+    |
+    | HTTPS (port 443)
+    v
+  Lightsail Container Service
+    |
+    | Routes to Gunicorn (port 8000)
+    v
+  Web Container (from GHCR image)
+    |
+    +---> Lightsail Managed MySQL
+    |
+    +---> Lightsail Object Storage (S3)
+
+GITHUB ACTIONS CI/CD
+--------------------------------------------------------------------------------
+The deployment pipeline runs automatically on push to master:
+
+1. **Build**: Docker image built with GitHub Actions
+2. **Scan**: Trivy scans image for CRITICAL/HIGH vulnerabilities
+3. **Push**: Image pushed to GHCR with SHA and version tags
+4. **Deploy**: AWS CLI deploys new image to Lightsail Container Service
+
+The pipeline blocks deployment if Trivy finds serious vulnerabilities.
+
+INFRASTRUCTURE AS CODE (TERRAFORM)
+--------------------------------------------------------------------------------
+All AWS resources are managed with Terraform:
+- Lightsail Container Service
+- Managed MySQL database
+- Object Storage bucket
+- SSL certificate
+- Route53 DNS records
+
+Terraform state stored in S3 with versioning. Changes are planned on PR and
+applied on merge to master via GitHub Actions.
+
+ENVIRONMENT VARIABLES
+--------------------------------------------------------------------------------
+Production environment variables are stored in GitHub Secrets and passed to
+the Lightsail Container Service:
+
+```
+SECRET_KEY=<64-character-random-string>
+DATABASE_URL=mysql+pymysql://user:pass@host:3306/dbname
+BUCKET_NAME=<lightsail-bucket-name>
+AWS_REGION=us-east-1
+ANTHROPIC_API_KEY=<api-key>
+INIT_ADMIN_EMAIL=admin@racecrew.net
+INIT_ADMIN_PASSWORD=<strong-password>
+```
+
+**Generate SECRET_KEY**:
+```bash
+python3 -c "import secrets; print(secrets.token_hex(32))"
+```
+
+================================================================================
+                    PART 6: BACKUP STRATEGIES
+================================================================================
+
+DATABASE BACKUP (PRODUCTION)
+--------------------------------------------------------------------------------
+Lightsail Managed MySQL provides automated backups:
+- **Daily snapshots**: Retained for 7 days
+- **Preferred window**: 06:00-06:30 UTC (2:00-2:30 AM ET)
+- **Point-in-time recovery**: Restore to any second within retention period
+- **Final snapshot**: Created automatically on database deletion
+
+No manual backup scripts needed for production.
+
+DATABASE BACKUP (LOCAL DEVELOPMENT)
+--------------------------------------------------------------------------------
+**Manual Backup**:
+```bash
+docker compose exec db mysqldump -u racecrew -pracecrew racecrew > backup.sql
+```
+
+**Restore**:
+```bash
+docker compose exec -T db mysql -u racecrew -pracecrew racecrew < backup.sql
+```
+
+FILE BACKUP
+--------------------------------------------------------------------------------
+File uploads are stored in Lightsail Object Storage (S3-compatible) with
+**versioning enabled**. This protects against accidental deletion — previous
+versions of objects are retained.
+
+DISASTER RECOVERY
+--------------------------------------------------------------------------------
+To restore from scratch:
+1. Provision infrastructure with Terraform
+2. Restore database from Lightsail snapshot
+3. File uploads are already in Object Storage (versioned)
+4. Deploy container via GitHub Actions (or manual AWS CLI deploy)
+5. Admin account is created automatically from env vars on first start
+
+================================================================================
+                    PART 7: MIGRATION BEST PRACTICES
+================================================================================
+
+DO:
+- Review generated migrations before applying
+- Test migrations on dev database first
+- Backup before migrating production
+- Use descriptive migration messages
+- Keep migrations small and focused
+
+DON'T:
+- Edit applied migrations (create new ones instead)
+- Delete migration files
+- Manually modify alembic_version table
+- Skip downgrade() implementation
+
+COMMON MIGRATION TASKS:
+
+**Add column**:
+```python
+batch_op.add_column(sa.Column('new_field', sa.String(100), nullable=True))
+```
+
+**Remove column**:
+```python
+batch_op.drop_column('old_field')
+```
+
+**Change column type**:
+```python
+batch_op.alter_column('field_name', type_=sa.String(255))
+```
+
+**Add index**:
+```python
+batch_op.create_index('idx_email', ['email'])
+```
+
+================================================================================
+                          KEY TAKEAWAYS
+================================================================================
+
+1. **Migrations version database schema**. Each migration transforms schema
+   from one version to the next.
+
+2. **Flask-Migrate wraps Alembic** for Flask apps. Use `flask db` commands
+   to manage migrations.
+
+3. **Automatic migration on startup** ensures database matches code. The
+   entrypoint script runs `flask db upgrade` before starting Gunicorn.
+
+4. **CI/CD automates deployment**. GitHub Actions builds images, scans for
+   vulnerabilities, and deploys to Lightsail on every push to master.
+
+5. **Managed services reduce operations burden**. Lightsail handles HTTPS
+   certificates, database backups, and container health monitoring.
+
+6. **Infrastructure as Code** (Terraform) makes infrastructure reproducible
+   and version-controlled alongside application code.
+
+CONGRATULATIONS!
+--------------------------------------------------------------------------------
+You've completed the 10-day Flask training! You now understand:
+- Flask application architecture (factory pattern, blueprints)
+- Database modeling with SQLAlchemy (5 models, relationships)
+- Authentication and authorization (Flask-Login, invite system)
+- File uploads with S3 cloud storage
+- iCal calendar feeds
+- Docker containerization and GHCR
+- CI/CD with GitHub Actions
+- Production deployment on AWS Lightsail
+
+NEXT STEPS:
+- Deploy your own instance
+- Customize features for your needs
+- Explore the appendix for quick references
+- Review earlier sessions as needed
+
+See you in the appendix for quick reference materials!
+
+================================================================================

--- a/python-class/99-appendix.txt
+++ b/python-class/99-appendix.txt
@@ -1,0 +1,567 @@
+================================================================================
+                          APPENDIX: QUICK REFERENCE
+================================================================================
+
+This appendix provides quick reference materials for Flask, SQLAlchemy, Jinja2,
+Docker, and common troubleshooting scenarios.
+
+================================================================================
+                    FLASK ROUTING REFERENCE
+================================================================================
+
+BASIC ROUTES
+--------------------------------------------------------------------------------
+```python
+@app.route("/")
+def index():
+    return "Hello"
+
+@app.route("/about")
+def about():
+    return render_template("about.html")
+```
+
+HTTP METHODS
+--------------------------------------------------------------------------------
+```python
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        # Process form
+        pass
+    return render_template("login.html")
+```
+
+URL PARAMETERS
+--------------------------------------------------------------------------------
+```python
+@app.route("/user/<int:user_id>")
+def user_profile(user_id: int):
+    user = User.query.get_or_404(user_id)
+    return render_template("profile.html", user=user)
+
+@app.route("/search")
+def search():
+    query = request.args.get("q", "")  # /search?q=flask
+    return f"Searching for {query}"
+```
+
+REDIRECTS AND URL_FOR
+--------------------------------------------------------------------------------
+```python
+from flask import redirect, url_for
+
+@app.route("/old-path")
+def old():
+    return redirect(url_for("new_path"))
+
+@app.route("/new-path")
+def new_path():
+    return "New location"
+```
+
+FLASH MESSAGES
+--------------------------------------------------------------------------------
+```python
+from flask import flash
+
+flash("Operation successful!", "success")
+flash("An error occurred.", "error")
+flash("Please note...", "info")
+```
+
+DECORATORS
+--------------------------------------------------------------------------------
+```python
+from flask_login import login_required
+
+@app.route("/protected")
+@login_required
+def protected():
+    return "Only logged-in users see this"
+```
+
+================================================================================
+                    SQLALCHEMY QUERY REFERENCE
+================================================================================
+
+BASIC QUERIES
+--------------------------------------------------------------------------------
+```python
+# Get all
+users = User.query.all()
+
+# Get one
+user = User.query.first()
+user = User.query.get(1)  # By primary key
+user = User.query.get_or_404(1)  # Or 404 error
+
+# Filter
+users = User.query.filter_by(is_admin=True).all()
+users = User.query.filter(User.email.like("%@example.com")).all()
+
+# Order
+users = User.query.order_by(User.display_name).all()
+users = User.query.order_by(User.created_at.desc()).all()
+
+# Limit
+users = User.query.limit(10).all()
+
+# Count
+count = User.query.count()
+```
+
+FILTERING
+--------------------------------------------------------------------------------
+```python
+# Equals
+User.query.filter_by(email=email)
+User.query.filter(User.email == email)
+
+# Not equals
+User.query.filter(User.email != email)
+
+# Greater than / Less than
+Regatta.query.filter(Regatta.start_date >= today)
+
+# IN list
+User.query.filter(User.id.in_([1, 2, 3]))
+
+# LIKE pattern
+User.query.filter(User.email.like("%@example.com"))
+
+# IS NULL
+User.query.filter(User.invite_token.is_(None))
+User.query.filter(User.invite_token.isnot(None))
+
+# AND (multiple filters)
+User.query.filter_by(is_admin=True).filter_by(email=email)
+User.query.filter((User.is_admin == True) & (User.email == email))
+
+# OR
+from sqlalchemy import or_
+User.query.filter(or_(User.is_admin == True, User.email == email))
+```
+
+RELATIONSHIPS
+--------------------------------------------------------------------------------
+```python
+# Access related objects
+user = User.query.first()
+regattas = user.created_regattas  # One-to-many
+rsvps = user.rsvps  # One-to-many
+
+regatta = Regatta.query.first()
+creator = regatta.creator  # Many-to-one (backref)
+documents = regatta.documents  # One-to-many
+```
+
+CREATE, UPDATE, DELETE
+--------------------------------------------------------------------------------
+```python
+# Create
+user = User(email="test@example.com", display_name="Test")
+db.session.add(user)
+db.session.commit()
+
+# Update
+user.display_name = "New Name"
+db.session.commit()
+
+# Delete
+db.session.delete(user)
+db.session.commit()
+
+# Rollback on error
+try:
+    db.session.commit()
+except:
+    db.session.rollback()
+    raise
+```
+
+================================================================================
+                    JINJA2 TEMPLATE REFERENCE
+================================================================================
+
+VARIABLES
+--------------------------------------------------------------------------------
+```html
+{{ variable }}
+{{ user.display_name }}
+{{ regatta.start_date.strftime('%B %d, %Y') }}
+```
+
+FILTERS
+--------------------------------------------------------------------------------
+```html
+{{ name|upper }}
+{{ text|truncate(100) }}
+{{ price|round(2) }}
+{{ items|length }}
+{{ rsvps|sort_rsvps }}  <!-- Custom filter -->
+```
+
+CONTROL FLOW
+--------------------------------------------------------------------------------
+```html
+{% if current_user.is_admin %}
+    <a href="/admin">Admin Panel</a>
+{% elif current_user.is_authenticated %}
+    <p>Welcome, {{ current_user.display_name }}</p>
+{% else %}
+    <a href="/login">Login</a>
+{% endif %}
+
+{% for regatta in regattas %}
+    <li>{{ regatta.name }}</li>
+{% else %}
+    <li>No regattas found.</li>
+{% endfor %}
+```
+
+TEMPLATE INHERITANCE
+--------------------------------------------------------------------------------
+```html
+<!-- base.html -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}Default Title{% endblock %}</title>
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>
+
+<!-- page.html -->
+{% extends "base.html" %}
+
+{% block title %}My Page{% endblock %}
+
+{% block content %}
+    <h1>Page Content</h1>
+{% endblock %}
+```
+
+INCLUDE
+--------------------------------------------------------------------------------
+```html
+{% include "navbar.html" %}
+```
+
+FORMS
+--------------------------------------------------------------------------------
+```html
+<form method="post">
+    {{ csrf_token() }}
+    <input type="text" name="name" value="{{ regatta.name if regatta }}">
+    <button type="submit">Save</button>
+</form>
+```
+
+URL GENERATION
+--------------------------------------------------------------------------------
+```html
+<a href="{{ url_for('auth.login') }}">Login</a>
+<a href="{{ url_for('regattas.edit', regatta_id=regatta.id) }}">Edit</a>
+<a href="{{ url_for('static', filename='css/style.css') }}">CSS</a>
+```
+
+================================================================================
+                    DOCKER COMPOSE REFERENCE
+================================================================================
+
+BASIC COMMANDS
+--------------------------------------------------------------------------------
+```bash
+# Start services
+docker compose up
+
+# Start in background
+docker compose up -d
+
+# Rebuild and start
+docker compose up --build
+
+# Stop services
+docker compose down
+
+# Stop and remove volumes
+docker compose down -v
+
+# View logs
+docker compose logs
+docker compose logs -f web  # Follow logs for web service
+
+# Restart a service
+docker compose restart web
+
+# Execute command in container
+docker compose exec web flask create-admin
+docker compose exec db mysql -u racecrew -p
+
+# View running containers
+docker compose ps
+```
+
+BUILDING AND CLEANING
+--------------------------------------------------------------------------------
+```bash
+# Build images without starting
+docker compose build
+
+# Remove all stopped containers
+docker compose down --remove-orphans
+
+# Remove images
+docker compose down --rmi all
+
+# Prune unused Docker resources
+docker system prune
+docker volume prune
+```
+
+================================================================================
+                    FLASK CLI REFERENCE
+================================================================================
+
+CUSTOM COMMANDS (THIS APP)
+--------------------------------------------------------------------------------
+```bash
+flask create-admin          # Create admin user interactively
+flask init-admin            # Create admin from env vars (INIT_ADMIN_EMAIL/PASSWORD)
+```
+
+MIGRATION COMMANDS
+--------------------------------------------------------------------------------
+```bash
+flask db init               # Initialize migrations directory
+flask db migrate -m "msg"   # Generate migration
+flask db upgrade            # Apply migrations
+flask db downgrade          # Undo last migration
+flask db current            # Show current version
+flask db history            # Show migration history
+```
+
+FLASK DEVELOPMENT
+--------------------------------------------------------------------------------
+```bash
+flask run                   # Start development server (don't use in production!)
+flask run --host=0.0.0.0    # Listen on all interfaces
+flask run --port=5001       # Custom port
+flask shell                 # Interactive Python shell with app context
+```
+
+================================================================================
+                    TROUBLESHOOTING GUIDE
+================================================================================
+
+PROBLEM: Can't connect to localhost
+--------------------------------------------------------------------------------
+**Symptoms**: Browser shows "can't connect" or "connection refused"
+
+**Solutions**:
+1. Check containers are running:
+   ```bash
+   docker compose ps
+   ```
+
+2. Check logs for errors:
+   ```bash
+   docker compose logs
+   ```
+
+3. Verify port 80 isn't already in use:
+   ```bash
+   lsof -i :80  # On Mac/Linux
+   ```
+
+4. Restart containers:
+   ```bash
+   docker compose restart
+   ```
+
+PROBLEM: Database connection errors
+--------------------------------------------------------------------------------
+**Symptoms**: "Can't connect to MySQL server" or "Unknown database"
+
+**Solutions**:
+1. Check db container is healthy:
+   ```bash
+   docker compose ps
+   ```
+
+2. Verify DATABASE_URL in .env:
+   ```
+   DATABASE_URL=mysql+pymysql://racecrew:racecrew@db:3306/racecrew
+   ```
+
+3. Check db health check:
+   ```bash
+   docker compose logs db
+   ```
+
+4. Recreate database volume:
+   ```bash
+   docker compose down -v
+   docker compose up --build
+   ```
+
+PROBLEM: Permission errors
+--------------------------------------------------------------------------------
+**Symptoms**: "Permission denied" when writing files
+
+**Solutions**:
+1. Check upload directory permissions:
+   ```bash
+   docker compose exec web ls -la /app/uploads
+   ```
+
+2. Create directory if missing:
+   ```bash
+   docker compose exec web mkdir -p /app/uploads
+   ```
+
+PROBLEM: Migration errors
+--------------------------------------------------------------------------------
+**Symptoms**: "Can't locate revision" or "Multiple heads detected"
+
+**Solutions**:
+1. Check migration history:
+   ```bash
+   docker compose exec web flask db current
+   docker compose exec web flask db history
+   ```
+
+2. If database is corrupted, start fresh:
+   ```bash
+   docker compose down -v
+   docker compose up --build
+   ```
+
+PROBLEM: Static files not loading
+--------------------------------------------------------------------------------
+**Symptoms**: CSS not applied, images not showing
+
+**Solutions**:
+1. Check browser console for 404 errors
+2. Verify file paths in templates
+3. Clear browser cache
+4. Check web container logs:
+   ```bash
+   docker compose logs web
+   ```
+
+PROBLEM: Session cookie not persisting
+--------------------------------------------------------------------------------
+**Symptoms**: Logged out after every page refresh
+
+**Solutions**:
+1. Check SECRET_KEY is set in .env
+2. Ensure .env file is being loaded:
+   ```bash
+   docker compose exec web env | grep SECRET
+   ```
+3. Generate new SECRET_KEY if needed
+
+================================================================================
+                    SECURITY BEST PRACTICES
+================================================================================
+
+PASSWORDS
+--------------------------------------------------------------------------------
+- Never hardcode passwords in source code
+- Use environment variables for all secrets
+- Generate strong SECRET_KEY (64+ characters)
+- Use bcrypt for password hashing (already implemented)
+- Enforce minimum password length (6+ characters minimum)
+
+FILE UPLOADS
+--------------------------------------------------------------------------------
+- Validate file types before accepting
+- Use UUID filenames (already implemented)
+- Set MAX_CONTENT_LENGTH (already set to 10MB)
+- Store uploads outside web root
+- Use send_from_directory() for serving (already implemented)
+
+DATABASE
+--------------------------------------------------------------------------------
+- Use parameterized queries (SQLAlchemy does this)
+- Validate and sanitize all user input
+- Use foreign key constraints
+- Regular backups (see Day 10)
+
+AUTHENTICATION
+--------------------------------------------------------------------------------
+- Use CSRF protection (already implemented with Flask-WTF)
+- Implement rate limiting for login attempts (not implemented)
+- Use HTTPS in production (see Day 10)
+- Set secure cookie flags in production
+
+GENERAL
+--------------------------------------------------------------------------------
+- Keep dependencies updated:
+  ```bash
+  pip list --outdated
+  pip install --upgrade package-name
+  ```
+
+- Don't expose debug mode in production:
+  ```python
+  # NEVER do this in production:
+  app.run(debug=True)
+  ```
+
+- Review Flask security docs:
+  https://flask.palletsprojects.com/security/
+
+================================================================================
+                    FURTHER READING
+================================================================================
+
+FLASK
+--------------------------------------------------------------------------------
+- Official Documentation: https://flask.palletsprojects.com/
+- Flask Mega-Tutorial: https://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-i-hello-world
+- Real Python Flask: https://realpython.com/tutorials/flask/
+
+SQLALCHEMY
+--------------------------------------------------------------------------------
+- Official Documentation: https://docs.sqlalchemy.org/
+- SQLAlchemy ORM Tutorial: https://docs.sqlalchemy.org/orm/tutorial.html
+
+DOCKER
+--------------------------------------------------------------------------------
+- Official Documentation: https://docs.docker.com/
+- Docker Compose: https://docs.docker.com/compose/
+- Best Practices: https://docs.docker.com/develop/dev-best-practices/
+
+PYTHON
+--------------------------------------------------------------------------------
+- Python Documentation: https://docs.python.org/3/
+- PEP 8 Style Guide: https://peps.python.org/pep-0008/
+
+WEB DEVELOPMENT
+--------------------------------------------------------------------------------
+- MDN Web Docs: https://developer.mozilla.org/
+- HTTP Status Codes: https://httpstatuses.com/
+- RESTful API Design: https://restfulapi.net/
+
+SECURITY
+--------------------------------------------------------------------------------
+- OWASP Top 10: https://owasp.org/www-project-top-ten/
+- Flask Security: https://flask.palletsprojects.com/security/
+- Let's Encrypt: https://letsencrypt.org/
+
+================================================================================
+                          END OF APPENDIX
+================================================================================
+
+You now have a complete reference for Flask development with this application.
+Return to this appendix whenever you need a quick reminder of syntax or
+commands.
+
+Good luck with your Flask journey!
+
+================================================================================

--- a/python-class/plan.txt
+++ b/python-class/plan.txt
@@ -1,0 +1,227 @@
+   Overview
+
+     Create a 10-day training curriculum for an IT professional with Python/Docker experience but no Flask knowledge. The curriculum will explain the Race Crew Network Regatta Schedule Flask application through 12 text files.
+
+     User Requirements
+
+     - Target Audience: IT professional with Python and Docker knowledge, zero Flask experience
+     - Format: Text files with index and appendix
+     - Code Display: Hybrid (key snippets included, longer sections referenced by file path)
+     - Style: Explanation-focused (no exercises, just understanding existing code)
+     - Focus: Flask patterns and Docker deployment (minimal Python basics)
+     - Lesson Length: Concise 30-60 min sessions (~1500-2500 words)
+
+     Files to Create
+
+     Index File
+
+     Path: 00-index.txt
+     Status: ✅ Already created
+     Contents: Course overview, prerequisites, roadmap, navigation guide
+
+     Daily Lesson Files (10 files)
+
+     Paths: 01-day1.txt through 10-day10.txt
+
+     Day 1: Introduction & Environment Setup
+     - Application overview and feature tour
+     - Docker Compose architecture (3 containers: web, db, nginx)
+     - Running the app locally
+     - Creating admin account with Flask CLI
+     - Basic Flask concepts: routes, templates, blueprints
+
+     Day 2: Flask Application Factory Pattern
+     - The create_app() factory pattern
+     - Extension initialization (SQLAlchemy, Flask-Login, Flask-Migrate, CSRF)
+     - Configuration management with environment variables
+     - Blueprint registration
+     - Application context and lifecycle
+
+     Day 3: Database Models & SQLAlchemy ORM
+     - Object-Relational Mapping concepts
+     - User model (password hashing with bcrypt)
+     - Regatta model (events with dates/locations)
+     - Document model (file uploads + external URLs)
+     - RSVP model (many-to-many relationships)
+     - Database schema design and foreign keys
+
+     Day 4: Authentication & User Management
+     - Flask-Login integration and UserMixin
+     - Login/logout implementation
+     - Invite-based registration system with tokens
+     - User profile management
+     - Admin user administration
+     - Authorization patterns (@login_required, role checks)
+
+     Day 5: Regatta Management (CRUD Operations)
+     - RESTful route design in Flask
+     - Create, Read, Update, Delete operations
+     - Form processing with request.form
+     - Date handling in Python
+     - Permission checks (admin-only routes)
+     - Flash messages for user feedback
+
+     Day 6: RSVP System & Database Relationships
+     - Many-to-many relationship implementation
+     - Upsert pattern (update or insert logic)
+     - SQLAlchemy lazy vs eager loading
+     - Custom Jinja2 template filters
+     - Status display and crew initials
+
+     Day 7: Document Upload & File Handling
+     - File upload processing in Flask
+     - UUID-based secure filename generation
+     - Supporting both uploads and external URLs
+     - Docker volume management for storage
+     - Secure file downloads with send_from_directory
+     - File size limits and validation
+
+     Day 8: Calendar Integration (iCal Feeds)
+     - iCalendar format (RFC 5545)
+     - Using the icalendar Python library
+     - Token-based feed authentication
+     - Generating calendar events
+     - All-day event handling
+     - Calendar subscription URLs
+
+     Day 9: Docker & Containerization
+     - Dockerfile structure and best practices
+     - Multi-container orchestration with docker-compose
+     - Container networking and service discovery
+     - Volume persistence for data
+     - Health checks for database dependencies
+     - Gunicorn production configuration
+     - Nginx reverse proxy setup
+
+     Day 10: Database Migrations & Deployment
+     - Flask-Migrate and Alembic
+     - Creating and applying migrations
+     - Automatic migration on startup
+     - Production deployment considerations
+     - Environment variables management
+     - SSL/HTTPS setup guidance
+     - Backup strategies
+
+     Appendix File
+
+     Path: 99-appendix.txt
+     Contents:
+     - Flask routing quick reference
+     - SQLAlchemy query patterns
+     - Jinja2 template syntax guide
+     - Docker Compose command cheat sheet
+     - Flask CLI commands reference
+     - Common troubleshooting scenarios
+     - Security best practices checklist
+     - Further reading resources
+
+     Content Structure (Each Daily Lesson)
+
+     1. Learning Objectives (3-5 bullet points)
+     2. Concepts Covered (technical topics list)
+     3. File Focus (which files to examine)
+     4. Code Walkthrough (detailed explanations)
+       - Key snippets included inline
+       - Longer code sections referenced by file:line
+     5. Architecture Diagrams (ASCII art where helpful)
+     6. Key Takeaways (summary and connections)
+
+     Writing Guidelines
+
+     Tone & Approach
+
+     - Professional and technical
+     - Assume Python/Docker familiarity
+     - Focus on Flask-specific patterns
+     - Explain WHY decisions were made, not just WHAT the code does
+     - Connect concepts to broader web development patterns
+
+     Code Examples
+
+     - Include inline: Critical snippets (5-20 lines) that demonstrate key patterns
+     - Reference by path: Full functions, longer route handlers
+     - Always provide file paths and line numbers for reference
+     - Format: File: app/models.py:25-45
+
+     Architecture Diagrams
+
+     Use ASCII art for:
+     - Application initialization flow (Day 2)
+     - Database ER diagram (Day 3)
+     - Request/response cycle (Day 5)
+     - Container architecture (Day 9)
+     - Authentication flow (Day 4)
+
+     Security Notes
+
+     Highlight security patterns when encountered:
+     - Password hashing (Day 3)
+     - CSRF protection (Day 4)
+     - File upload security (Day 7)
+     - Token-based authentication (Day 8)
+
+     Critical Files to Reference
+
+     Core Application
+
+     - thistle-regatta-schedule/app/__init__.py - App factory
+     - thistle-regatta-schedule/app/config.py - Configuration
+     - thistle-regatta-schedule/app/models.py - All 4 models
+     - thistle-regatta-schedule/app/commands.py - CLI commands
+
+     Blueprints (Routes)
+
+     - thistle-regatta-schedule/app/auth/routes.py - Authentication
+     - thistle-regatta-schedule/app/regattas/routes.py - CRUD operations
+     - thistle-regatta-schedule/app/calendar/routes.py - iCal feeds
+
+     Templates
+
+     - thistle-regatta-schedule/app/templates/base.html - Base template
+     - thistle-regatta-schedule/app/templates/index.html - Main page
+     - thistle-regatta-schedule/app/templates/regatta_form.html - Form example
+
+     Deployment
+
+     - thistle-regatta-schedule/Dockerfile - Container build
+     - thistle-regatta-schedule/docker-compose.yml - Orchestration
+     - thistle-regatta-schedule/nginx.conf - Reverse proxy
+     - thistle-regatta-schedule/gunicorn.conf.py - WSGI config
+     - thistle-regatta-schedule/entrypoint.sh - Startup script
+     - thistle-regatta-schedule/requirements.txt - Dependencies
+
+     Database
+
+     - thistle-regatta-schedule/migrations/versions/*.py - Migration examples
+
+     Implementation Steps
+
+     1. Day 1-3: Foundation (App structure, models, database)
+     2. Day 4-6: Core features (Auth, CRUD, relationships)
+     3. Day 7-8: Advanced features (Files, calendar)
+     4. Day 9-10: Deployment (Docker, production)
+     5. Appendix: Quick reference materials
+
+     Verification After Creation
+
+     1. ✅ Index file exists and provides clear navigation
+     2. All 10 daily lesson files created (01-10)
+     3. Appendix file created (99)
+     4. Each lesson follows the structure template
+     5. File paths referenced are accurate
+     6. ASCII diagrams render correctly in plain text
+     7. Lesson progression is logical and builds on previous days
+     8. Total word count per lesson is ~1500-2500 words
+
+     Success Criteria
+
+     The training materials succeed if:
+     - Each lesson can be read in 30-60 minutes
+     - Code explanations reference actual application files
+     - Flask patterns are clearly explained (not just Python)
+     - A developer with Python/Docker knowledge can understand the full Flask application architecture after 10 days
+     - Materials are self-contained in text files (no external dependencies)
+     - Lessons build progressively from basics to advanced topics
+
+● Perfect! The plan is approved. Let me create the training materials. I'll set up a task list to track progress.
+


### PR DESCRIPTION
## Summary
- Add `python-class/` directory with 10-day Flask training curriculum (12 text files + plan)
- All lessons updated to reflect current codebase at v0.34.2: Race Crew Network branding, 5 models (including ImportCache), 4 blueprints (including admin), S3 storage abstraction, Lightsail Container Service deployment, GitHub Actions CI/CD
- Version bump to 0.35.0

## Test plan
- [ ] Verify all 13 text files are present in python-class/
- [ ] Spot-check code snippets against actual source files
- [ ] Confirm no stale references to "Thistle Regatta Schedule", python:3.11, nginx, or old database naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)