### PR TITLE
Add admin-managed Google Analytics settings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,4 +8,4 @@
 - [ ] Update lessons
 - [ ] The "Extraction results not found or expired" error pops up in production when the results are cached and when scanning for documents.  Thistle URL
 - [ ] Remove TBD and make it blank
-- [ ] Add google analytics code to the base.html with the ga code defined in .env and to not register when running locally
+

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,12 @@
 # Version History
 
+## 0.36.0
+- Add database-backed site settings table for runtime configuration values
+- Add admin analytics settings page to manage Google Analytics Measurement ID
+- Add Admin navbar dropdown with Analytics Settings menu item
+- Inject GA script in base template only when configured and not in development/testing
+- Add migration and test coverage for site settings model, admin route access, and GA render behavior
+
 ## 0.35.1
 - Convert training files from ASCII-formatted text to Markdown (.txt → .md)
 - Replace old project name references (thistle-regatta-schedule → race-crew-network)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,8 +3,9 @@ from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
+from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.35.1"
+__version__ = "0.36.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -42,6 +43,27 @@ def create_app(test_config=None):
     @app.context_processor
     def inject_version():
         return {"app_version": __version__}
+
+    @app.context_processor
+    def inject_site_settings():
+        from app.models import SiteSetting
+
+        ga_measurement_id = ""
+        try:
+            ga_setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
+            if ga_setting and ga_setting.value:
+                ga_measurement_id = ga_setting.value.strip()
+        except SQLAlchemyError:
+            ga_measurement_id = ""
+
+        is_dev_or_test = bool(app.config.get("TESTING")) or (
+            app.config.get("ENV") == "development"
+        )
+
+        return {
+            "ga_measurement_id": ga_measurement_id,
+            "is_dev_or_test": is_dev_or_test,
+        }
 
     @app.template_filter("sort_rsvps")
     def sort_rsvps(rsvps):

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -18,7 +18,7 @@ from app import db
 from app.admin import bp
 from app.admin.ai_service import (discover_documents, discover_documents_deep,
                                   extract_regattas)
-from app.models import Document, ImportCache, Regatta
+from app.models import Document, ImportCache, Regatta, SiteSetting
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,17 @@ def _upsert_import_cache(url: str, year: int, regattas: list[dict]) -> None:
             extracted_at=now,
         )
         db.session.add(cached)
+    db.session.commit()
+
+
+def _upsert_site_setting(key: str, value: str) -> None:
+    """Insert or update a site setting key-value pair."""
+    setting = SiteSetting.query.filter_by(key=key).first()
+    if setting:
+        setting.value = value
+    else:
+        setting = SiteSetting(key=key, value=value)
+        db.session.add(setting)
     db.session.commit()
 
 
@@ -345,6 +356,37 @@ def import_paste():
     if denied:
         return denied
     return render_template("admin/import_paste.html")
+
+
+@bp.route("/admin/settings/analytics", methods=["GET", "POST"])
+@login_required
+def analytics_settings():
+    denied = _require_admin()
+    if denied:
+        return denied
+
+    if request.method == "POST":
+        ga_measurement_id = request.form.get("ga_measurement_id", "").strip().upper()
+        _upsert_site_setting("ga_measurement_id", ga_measurement_id)
+
+        if ga_measurement_id and not re.match(r"^(G|GT)-[A-Z0-9]+$", ga_measurement_id):
+            flash(
+                "Measurement ID saved, but format looks unusual. Expected examples: G-XXXXXXX or GT-XXXXXXX.",
+                "warning",
+            )
+
+        flash("Google Analytics settings updated.", "success")
+        return redirect(url_for("admin.analytics_settings"))
+
+    ga_measurement_id = ""
+    setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
+    if setting and setting.value:
+        ga_measurement_id = setting.value
+
+    return render_template(
+        "admin/analytics_settings.html",
+        ga_measurement_id=ga_measurement_id,
+    )
 
 
 @bp.route("/admin/import-schedule/extract", methods=["POST"])

--- a/app/models.py
+++ b/app/models.py
@@ -125,3 +125,22 @@ class ImportCache(db.Model):
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
+
+
+class SiteSetting(db.Model):
+    __tablename__ = "site_settings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    key = db.Column(db.String(100), nullable=False, unique=True, index=True)
+    value = db.Column(db.Text, nullable=False, default="")
+    created_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )

--- a/app/templates/admin/analytics_settings.html
+++ b/app/templates/admin/analytics_settings.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Analytics Settings — Race Crew Network{% endblock %}
+{% block content %}
+<div class="row justify-content-center mt-3">
+    <div class="col-md-6 col-lg-5">
+        <h2 class="mb-3">Analytics Settings</h2>
+        <p class="text-muted">
+            Configure the Google Analytics Measurement ID used for tracking in production.
+            Tracking is automatically disabled in development and testing.
+        </p>
+        <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="mb-3">
+                <label for="ga_measurement_id" class="form-label">Measurement ID</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    id="ga_measurement_id"
+                    name="ga_measurement_id"
+                    value="{{ ga_measurement_id }}"
+                    placeholder="G-XXXXXXXXXX"
+                >
+                <div class="form-text">Example values: G-XXXXXXXXXX or GT-XXXXXXXXXX</div>
+            </div>
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Save Settings</button>
+                <a href="{{ url_for('regattas.index') }}" class="btn btn-outline-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -28,6 +28,12 @@
                     {% if current_user.is_admin %}
                     <a class="nav-link nav-pill-link" href="{{ url_for('auth.admin_users') }}">Crew</a>
                     <li class="nav-item dropdown">
+                        <a class="nav-link nav-pill-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Admin</a>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="{{ url_for('admin.analytics_settings') }}">Analytics Settings</a></li>
+                        </ul>
+                    </li>
+                    <li class="nav-item dropdown">
                         <a class="nav-link nav-pill-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Import</a>
                         <ul class="dropdown-menu">
                             <li><a class="dropdown-item" href="{{ url_for('admin.import_single') }}">Single Regatta</a></li>
@@ -70,6 +76,15 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    {% if ga_measurement_id and not is_dev_or_test %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_measurement_id }}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', '{{ ga_measurement_id }}');
+    </script>
+    {% endif %}
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/migrations/versions/9a8b7c6d5e4f_add_site_settings_table.py
+++ b/migrations/versions/9a8b7c6d5e4f_add_site_settings_table.py
@@ -1,0 +1,34 @@
+"""Add site_settings table
+
+Revision ID: 9a8b7c6d5e4f
+Revises: b2c3d4e5f678
+Create Date: 2026-03-05
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9a8b7c6d5e4f"
+down_revision = "b2c3d4e5f678"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "site_settings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("key", sa.String(length=100), nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key"),
+    )
+    op.create_index(op.f("ix_site_settings_key"), "site_settings", ["key"], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_site_settings_key"), table_name="site_settings")
+    op.drop_table("site_settings")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ beautifulsoup4>=4.12.0
 black>=24.0.0
 isort>=5.13.0
 flake8>=7.0.0
+pytest>=8.0.0

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -4,7 +4,7 @@ import json
 from datetime import date, datetime, timezone
 from unittest.mock import patch
 
-from app.models import Document, ImportCache, Regatta, User
+from app.models import Document, ImportCache, Regatta, SiteSetting, User
 
 
 class TestAdminAccessUnauthenticated:
@@ -22,6 +22,11 @@ class TestAdminAccessUnauthenticated:
 
     def test_import_paste_requires_login(self, client):
         resp = client.get("/admin/import-paste")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_analytics_settings_requires_login(self, client):
+        resp = client.get("/admin/settings/analytics")
         assert resp.status_code == 302
         assert "/login" in resp.headers["Location"]
 
@@ -43,6 +48,25 @@ class TestAdminAccessUnauthenticated:
             follow_redirects=True,
         )
         resp = client.get("/admin/import-multiple", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_analytics_settings_requires_admin(self, app, client, db):
+        user = User(
+            email="crew2@test.com",
+            display_name="Crew 2",
+            initials="C2",
+            is_admin=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew2@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/admin/settings/analytics", follow_redirects=True)
         assert b"Access denied" in resp.data
 
 
@@ -69,6 +93,23 @@ class TestAdminAccessAuthenticated:
         resp = logged_in_client.get("/admin/import-paste")
         assert resp.status_code == 200
         assert b"Paste Schedule Text" in resp.data
+
+    def test_analytics_settings_accessible_for_admin(self, logged_in_client):
+        resp = logged_in_client.get("/admin/settings/analytics")
+        assert resp.status_code == 200
+        assert b"Analytics Settings" in resp.data
+
+    def test_analytics_settings_persists_measurement_id(self, logged_in_client):
+        resp = logged_in_client.post(
+            "/admin/settings/analytics",
+            data={"ga_measurement_id": "G-TESTABC123"},
+            follow_redirects=True,
+        )
+        assert b"Google Analytics settings updated" in resp.data
+
+        setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
+        assert setting is not None
+        assert setting.value == "G-TESTABC123"
 
 
 class TestImportSchedulePreview:

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,6 +1,8 @@
 """Tests for the Flask app factory and core setup."""
 
 from app import __version__, create_app
+from app import db as _db
+from app.models import SiteSetting, User
 
 
 class TestAppFactory:
@@ -27,3 +29,60 @@ class TestAppFactory:
         resp = client.get("/login", follow_redirects=True)
         assert resp.status_code == 200
         assert b"Race Crew Network" in resp.data
+
+    def test_ga_script_not_rendered_in_testing(self, app, client, db):
+        setting = SiteSetting(key="ga_measurement_id", value="G-TESTHIDDEN")
+        db.session.add(setting)
+        db.session.commit()
+
+        resp = client.get("/", follow_redirects=True)
+        assert resp.status_code == 200
+        assert b"googletagmanager.com/gtag/js" not in resp.data
+
+    def test_ga_script_rendered_in_production_mode(self):
+        app = create_app(
+            test_config={
+                "TESTING": False,
+                "ENV": "production",
+                "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+                "WTF_CSRF_ENABLED": False,
+                "SERVER_NAME": "localhost",
+                "ANTHROPIC_API_KEY": "test-key",
+            }
+        )
+
+        with app.app_context():
+            _db.create_all()
+            setting = SiteSetting(key="ga_measurement_id", value="G-SHOWME123")
+            _db.session.add(setting)
+            _db.session.commit()
+
+            client = app.test_client()
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert b"googletagmanager.com/gtag/js?id=G-SHOWME123" in resp.data
+
+            _db.drop_all()
+
+    def test_admin_nav_contains_analytics_link(self, app, client, db):
+        user = User(
+            email="admin2@test.com",
+            display_name="Admin Two",
+            initials="A2",
+            is_admin=True,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "admin2@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert b">Crew<" in resp.data
+        assert b">Import<" in resp.data
+        assert b"/admin/settings/analytics" in resp.data

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ from datetime import date
 
 import pytest
 
-from app.models import RSVP, Document, ImportCache, Regatta, User
+from app.models import RSVP, Document, ImportCache, Regatta, SiteSetting, User
 
 
 class TestUserModel:
@@ -205,6 +205,29 @@ class TestImportCacheModel:
             regatta_count=0,
         )
         db.session.add(cache2)
+        with pytest.raises(Exception):
+            db.session.commit()
+        db.session.rollback()
+
+
+class TestSiteSettingModel:
+    def test_create_setting(self, app, db):
+        setting = SiteSetting(key="ga_measurement_id", value="G-TEST123")
+        db.session.add(setting)
+        db.session.commit()
+
+        assert setting.id is not None
+        assert setting.key == "ga_measurement_id"
+        assert setting.value == "G-TEST123"
+        assert setting.updated_at is not None
+
+    def test_key_unique_constraint(self, app, db):
+        first = SiteSetting(key="ga_measurement_id", value="G-ONE")
+        db.session.add(first)
+        db.session.commit()
+
+        duplicate = SiteSetting(key="ga_measurement_id", value="G-TWO")
+        db.session.add(duplicate)
         with pytest.raises(Exception):
             db.session.commit()
         db.session.rollback()


### PR DESCRIPTION
## Summary\n- add DB-backed site settings model and migration for analytics configuration\n- add admin analytics settings page and route\n- add Admin dropdown menu with Analytics Settings\n- conditionally inject GA script only outside development/testing\n- add/adjust tests and update version/changelog\n\n## Notes\n- migration updated for MySQL TEXT compatibility (no default on TEXT)\n- requirements include pytest for local test runs