### PR TITLE
Remove TBD placeholder for boat class

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,5 @@
 - [ ] Create a help section with instructions
 - [ ] Update lessons
 - [ ] The "Extraction results not found or expired" error pops up in production when the results are cached and when scanning for documents.  Thistle URL
-- [ ] Remove TBD and make it blank
+- [x] Remove TBD and make it blank
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 0.37.0
+- Remove "TBD" placeholder behavior for regatta boat class and leave class blank when unknown
+- Update regatta create/edit and admin import flows to preserve blank boat class values
+- Add migration to convert existing `TBD` boat class values to blank and set DB default to blank
+- Update calendar summary logic and tests for blank boat class behavior
+
 ## 0.36.0
 - Add database-backed site settings table for runtime configuration values
 - Add admin analytics settings page to manage Google Analytics Measurement ID

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -790,7 +790,7 @@ def import_schedule_confirm():
 
     for idx in selected:
         name = request.form.get(f"name_{idx}", "").strip()
-        boat_class = request.form.get(f"boat_class_{idx}", "").strip() or "TBD"
+        boat_class = request.form.get(f"boat_class_{idx}", "").strip()
         location = request.form.get(f"location_{idx}", "").strip()
         location_url = request.form.get(f"location_url_{idx}", "").strip()
         start_date_str = request.form.get(f"start_date_{idx}", "").strip()
@@ -893,8 +893,7 @@ def import_schedule_discover():
             {
                 "idx": idx,
                 "name": request.form.get(f"name_{idx}", "").strip(),
-                "boat_class": request.form.get(f"boat_class_{idx}", "").strip()
-                or "TBD",
+                "boat_class": request.form.get(f"boat_class_{idx}", "").strip(),
                 "location": request.form.get(f"location_{idx}", "").strip(),
                 "location_url": request.form.get(f"location_url_{idx}", "").strip(),
                 "start_date": request.form.get(f"start_date_{idx}", "").strip(),

--- a/app/calendar/routes.py
+++ b/app/calendar/routes.py
@@ -48,7 +48,7 @@ def ical_feed(token: str):
     for regatta in regattas:
         event = Event()
         event.add("uid", f"regatta-{regatta.id}@racecrew.net")
-        if regatta.boat_class and regatta.boat_class != "TBD":
+        if regatta.boat_class:
             event.add("summary", f"{regatta.boat_class} — {regatta.name}")
         else:
             event.add("summary", regatta.name)

--- a/app/models.py
+++ b/app/models.py
@@ -49,7 +49,7 @@ class Regatta(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(200), nullable=False)
-    boat_class = db.Column(db.String(100), nullable=False, default="TBD")
+    boat_class = db.Column(db.String(100), nullable=False, default="")
     location = db.Column(db.String(200), nullable=False)
     location_url = db.Column(db.String(500), nullable=True)
     start_date = db.Column(db.Date, nullable=False)

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -249,7 +249,7 @@ def delete_doc(doc_id: int):
 
 def _save_regatta(regatta: Regatta | None):
     name = request.form.get("name", "").strip()
-    boat_class = request.form.get("boat_class", "").strip() or "TBD"
+    boat_class = request.form.get("boat_class", "").strip()
     location = request.form.get("location", "").strip()
     location_url = request.form.get("location_url", "").strip()
     start_date_str = request.form.get("start_date", "")

--- a/migrations/versions/c3d4e5f6a7b8_blank_default_for_boat_class.py
+++ b/migrations/versions/c3d4e5f6a7b8_blank_default_for_boat_class.py
@@ -1,0 +1,41 @@
+"""Set blank default for regatta boat_class
+
+Revision ID: c3d4e5f6a7b8
+Revises: 9a8b7c6d5e4f
+Create Date: 2026-03-05
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3d4e5f6a7b8"
+down_revision = "9a8b7c6d5e4f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Normalize existing placeholder values to empty string.
+    op.execute("UPDATE regattas SET boat_class = '' WHERE boat_class = 'TBD'")
+
+    op.alter_column(
+        "regattas",
+        "boat_class",
+        existing_type=sa.String(length=100),
+        nullable=False,
+        server_default="",
+    )
+
+
+def downgrade():
+    # Restore placeholder for rows that were blanked by this migration.
+    op.execute("UPDATE regattas SET boat_class = 'TBD' WHERE boat_class = ''")
+
+    op.alter_column(
+        "regattas",
+        "boat_class",
+        existing_type=sa.String(length=100),
+        nullable=False,
+        server_default="TBD",
+    )

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -174,7 +174,7 @@ class TestImportScheduleConfirm:
         assert regatta.start_date == date(2026, 9, 1)
         assert regatta.boat_class == "Thistle"
 
-    def test_imports_regatta_boat_class_defaults_to_tbd(
+    def test_imports_regatta_boat_class_defaults_to_blank(
         self, app, logged_in_client, db
     ):
         resp = logged_in_client.post(
@@ -195,7 +195,7 @@ class TestImportScheduleConfirm:
 
         regatta = Regatta.query.filter_by(name="No Class Regatta").first()
         assert regatta is not None
-        assert regatta.boat_class == "TBD"
+        assert regatta.boat_class == ""
 
     def test_skips_duplicate(self, app, logged_in_client, db, admin_user):
         existing = Regatta(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -47,7 +47,7 @@ class TestRegattaModel:
         assert regatta.id is not None
         assert regatta.name == "Test Regatta"
 
-    def test_boat_class_defaults_to_tbd(self, app, db, admin_user):
+    def test_boat_class_defaults_to_blank(self, app, db, admin_user):
         regatta = Regatta(
             name="Default Class Test",
             location="Test YC",
@@ -57,7 +57,7 @@ class TestRegattaModel:
         db.session.add(regatta)
         db.session.commit()
 
-        assert regatta.boat_class == "TBD"
+        assert regatta.boat_class == ""
 
     def test_boat_class_explicit_value(self, app, db, admin_user):
         regatta = Regatta(


### PR DESCRIPTION
## Summary
- remove "TBD" placeholder behavior for regatta boat class
- keep boat class blank when unknown across create/edit and admin import flows
- migrate existing TBD values to blank and set DB default to blank
- update tests and version/changelog
