### PR TITLE
Fix GA production gating and add analytics status

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.38.0
+- Fix Google Analytics environment gating to disable only for local hosts and tests
+- Add warning log when analytics setting cannot be loaded from database
+- Add Analytics Settings status banner showing whether GA is enabled or why it is disabled
+
 ## 0.37.0
 - Remove "TBD" placeholder behavior for regatta boat class and leave class blank when unknown
 - Update regatta create/edit and admin import flows to preserve blank boat class values

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,11 @@
-from flask import Flask
+from flask import Flask, has_request_context, request
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -53,12 +53,17 @@ def create_app(test_config=None):
             ga_setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
             if ga_setting and ga_setting.value:
                 ga_measurement_id = ga_setting.value.strip()
-        except SQLAlchemyError:
+        except SQLAlchemyError as exc:
+            app.logger.warning("Unable to load GA setting from database: %s", exc)
             ga_measurement_id = ""
 
-        is_dev_or_test = bool(app.config.get("TESTING")) or (
-            app.config.get("ENV") == "development"
-        )
+        is_local_host = False
+        if has_request_context():
+            host = (request.host or "").split(":", 1)[0].lower()
+            is_local_host = host in {"localhost", "127.0.0.1"}
+
+        # Disable GA only for tests and local hosts.
+        is_dev_or_test = bool(app.config.get("TESTING")) or is_local_host
 
         return {
             "ga_measurement_id": ga_measurement_id,

--- a/app/templates/admin/analytics_settings.html
+++ b/app/templates/admin/analytics_settings.html
@@ -4,6 +4,19 @@
 <div class="row justify-content-center mt-3">
     <div class="col-md-6 col-lg-5">
         <h2 class="mb-3">Analytics Settings</h2>
+        {% if ga_measurement_id and not is_dev_or_test %}
+        <div class="alert alert-success" role="alert">
+            <strong>Status:</strong> Enabled on this environment.
+        </div>
+        {% elif not ga_measurement_id %}
+        <div class="alert alert-warning" role="alert">
+            <strong>Status:</strong> Disabled because no Measurement ID is configured.
+        </div>
+        {% else %}
+        <div class="alert alert-warning" role="alert">
+            <strong>Status:</strong> Disabled for local/testing environment.
+        </div>
+        {% endif %}
         <p class="text-muted">
             Configure the Google Analytics Measurement ID used for tracking in production.
             Tracking is automatically disabled in development and testing.


### PR DESCRIPTION
## Summary
- fix GA gating so tracking is disabled only for localhost/testing
- add warning log when GA setting lookup fails
- add analytics status banner on admin analytics settings page
- bump version to 0.38.0 and update VERSIONS.md
