### PR TITLE
Add regatta day labels and bump version to 0.39.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,5 @@
 - [ ] Create a help section with instructions
 - [ ] Update lessons
 - [ ] The "Extraction results not found or expired" error pops up in production when the results are cached and when scanning for documents.  Thistle URL
-- [x] Remove TBD and make it blank
-
+- [x] Put Day(s) of the week below the regatta dates.
+- [ ] Calendar View and List View (default)

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.39.0
+- Show day(s) of week below regatta dates in schedule views
+- Format day ranges as: single day `Sat`, two-day `Sat & Sun`, multi-day `Sat thru Mon`
+- Apply day-of-week display in both the main schedule and printable PDF schedule
+
 ## 0.38.1
 - Moved the Google Analyics tag from the footer below the head
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.38.1"
+__version__ = "0.39.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -76,5 +76,19 @@ def create_app(test_config=None):
         return sorted(
             rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name)
         )
+
+    @app.template_filter("regatta_days")
+    def regatta_days(start_date, end_date=None):
+        if not start_date:
+            return ""
+
+        if not end_date or end_date <= start_date:
+            return start_date.strftime("%a")
+
+        day_span = (end_date - start_date).days
+        if day_span == 1:
+            return f"{start_date.strftime('%a')} & {end_date.strftime('%a')}"
+
+        return f"{start_date.strftime('%a')} thru {end_date.strftime('%a')}"
 
     return app

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -38,6 +38,7 @@
             <tr>
                 <td class="text-nowrap">
                     {{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}
+                    <br><small class="text-muted">{{ regatta.start_date|regatta_days(regatta.end_date) }}</small>
                 </td>
                 <td>{{ regatta.boat_class }}</td>
                 <td>
@@ -113,6 +114,7 @@
             </div>
             <small class="text-muted">
                 {{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}
+                <br>{{ regatta.start_date|regatta_days(regatta.end_date) }}
                 {% if regatta.location %}
                 &middot;
                 {% if regatta.location_url %}

--- a/app/templates/pdf_schedule.html
+++ b/app/templates/pdf_schedule.html
@@ -66,6 +66,7 @@
     <tr>
         <td style="white-space: nowrap;">
             {{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}
+            <br><span class="notes">{{ regatta.start_date|regatta_days(regatta.end_date) }}</span>
         </td>
         <td>{{ regatta.boat_class }}</td>
         <td>

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,5 +1,7 @@
 """Tests for the Flask app factory and core setup."""
 
+from datetime import date
+
 from app import __version__, create_app
 from app import db as _db
 from app.models import SiteSetting, User
@@ -86,3 +88,18 @@ class TestAppFactory:
         assert b">Crew<" in resp.data
         assert b">Import<" in resp.data
         assert b"/admin/settings/analytics" in resp.data
+
+    def test_regatta_days_filter_single_day(self, app):
+        with app.app_context():
+            fn = app.jinja_env.filters["regatta_days"]
+            assert fn(date(2026, 7, 11), None) == "Sat"
+
+    def test_regatta_days_filter_two_day_range(self, app):
+        with app.app_context():
+            fn = app.jinja_env.filters["regatta_days"]
+            assert fn(date(2026, 7, 11), date(2026, 7, 12)) == "Sat & Sun"
+
+    def test_regatta_days_filter_multi_day_range(self, app):
+        with app.app_context():
+            fn = app.jinja_env.filters["regatta_days"]
+            assert fn(date(2026, 7, 11), date(2026, 7, 13)) == "Sat thru Mon"


### PR DESCRIPTION
## Summary\n- add day-of-week labels under regatta dates in schedule and PDF\n- add/adjust tests for regatta day formatting\n- bump app version and update changelog\n\n## Validation\n- code changes committed on this branch