### PR TITLE
Add content-hash caching for file imports

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.41.0
+- Cache file import results by content hash (SHA-256) to skip AI re-extraction for identical files
+- Add "Force re-extract (bypass cache)" checkbox to file import page
+
 ## 0.40.0
 - Add file upload import: admins can upload PDF, DOCX, or TXT schedule files for AI extraction
 - New "Import from File" page with file picker and year input

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.40.0"
+__version__ = "0.41.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,3 +1,4 @@
+import hashlib
 import ipaddress
 import json
 import logging
@@ -607,6 +608,7 @@ def import_schedule_extract_file():
         return denied
 
     uploaded = request.files.get("schedule_file")
+    force_extract = request.form.get("force_extract") == "1"
     current_year = date.today().year
     year = int(request.form.get("year", current_year))
     task_id = str(uuid.uuid4())
@@ -623,6 +625,12 @@ def import_schedule_extract_file():
         filename = uploaded.filename
         yield _sse({"type": "progress", "message": f"Reading file: {filename}..."})
 
+        # Read raw bytes for hashing, then reset stream for text extraction
+        raw_bytes = uploaded.stream.read()
+        content_hash = hashlib.sha256(raw_bytes).hexdigest()
+        cache_key = f"file-sha256:{content_hash}"
+        uploaded.stream.seek(0)
+
         try:
             content = extract_text_from_file(uploaded, filename)
         except ValueError as e:
@@ -632,21 +640,67 @@ def import_schedule_extract_file():
 
         content = content[:MAX_CONTENT_LENGTH]
 
-        yield _sse({"type": "progress", "message": "Sending to AI for extraction..."})
+        from_cache = False
 
-        try:
-            regattas = extract_regattas(content, year)
-        except (ValueError, ConnectionError) as e:
-            yield _sse({"type": "error", "message": str(e)})
-            yield _sse({"type": "failed"})
-            return
+        # Check cache by content hash
+        if not force_extract:
+            cached = ImportCache.query.filter_by(url=cache_key).first()
+            if cached:
+                try:
+                    regattas = json.loads(cached.results_json)
+                except (json.JSONDecodeError, ValueError):
+                    regattas = None
 
-        yield _sse(
-            {
-                "type": "result",
-                "message": f"AI returned {len(regattas)} event(s)",
-            }
-        )
+                if regattas is not None:
+                    from_cache = True
+                    days = _cache_age_days(cached.extracted_at)
+                    if days == 0:
+                        age_str = "today"
+                    elif days == 1:
+                        age_str = "1 day ago"
+                    else:
+                        age_str = f"{days} days ago"
+
+                    yield _sse(
+                        {
+                            "type": "progress",
+                            "message": (
+                                f"Using cached results from {age_str}"
+                                f" ({cached.regatta_count} regattas)"
+                            ),
+                        }
+                    )
+
+        if not from_cache:
+            if force_extract:
+                yield _sse(
+                    {
+                        "type": "progress",
+                        "message": "Force re-extract requested...",
+                    }
+                )
+
+            yield _sse(
+                {"type": "progress", "message": "Sending to AI for extraction..."}
+            )
+
+            try:
+                regattas = extract_regattas(content, year)
+            except (ValueError, ConnectionError) as e:
+                yield _sse({"type": "error", "message": str(e)})
+                yield _sse({"type": "failed"})
+                return
+
+            yield _sse(
+                {
+                    "type": "result",
+                    "message": f"AI returned {len(regattas)} event(s)",
+                }
+            )
+
+            # Cache results by content hash
+            if regattas:
+                _upsert_import_cache(cache_key, year, regattas)
 
         # Mark past events
         today = date.today().isoformat()
@@ -696,7 +750,7 @@ def import_schedule_extract_file():
         _extraction_results[task_id] = {
             "regattas": regattas,
             "year": year,
-            "from_cache": False,
+            "from_cache": from_cache,
             "source_url": "",
         }
 

--- a/app/templates/admin/import_file.html
+++ b/app/templates/admin/import_file.html
@@ -18,6 +18,10 @@
                 <input type="number" class="form-control" id="year" name="year" value="{{ current_year }}" style="max-width: 120px;">
                 <div class="form-text">Used to infer dates when the schedule doesn't include the year.</div>
             </div>
+            <div class="mb-3 form-check">
+                <input type="checkbox" class="form-check-input" id="force_extract" name="force_extract" value="1">
+                <label class="form-check-label" for="force_extract">Force re-extract (bypass cache)</label>
+            </div>
             <button type="submit" id="btn-submit" class="btn btn-primary">Extract Schedule</button>
             <a href="{{ url_for('regattas.index') }}" class="btn btn-outline-secondary ms-2">Cancel</a>
         </form>


### PR DESCRIPTION
## Summary
- Cache file import AI extraction results using SHA-256 hash of file contents
- Re-uploading the same file returns cached results instantly instead of calling the AI again
- Add "Force re-extract (bypass cache)" checkbox to the file import page
- Reuses existing `ImportCache` model with `file-sha256:<hash>` as the cache key

## Test plan
- [x] All existing tests pass (119/119)
- [ ] Manual: Upload a PDF, verify extraction works
- [ ] Manual: Upload the same PDF again, verify cached results are used
- [ ] Manual: Check "Force re-extract", verify AI is called again

🤖 Generated with [Claude Code](https://claude.com/claude-code)