### PR TITLE
Add email unsubscribe and bounce/complaint handling

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,19 @@
 # Version History
 
+## 0.43.0
+- Add one-click email unsubscribe (RFC 8058) with HMAC-signed links
+- Add SES bounce and complaint handling via SNS webhook
+- Add email_opt_in field to User model with profile page toggle
+- Switch email service to send_raw_email for custom List-Unsubscribe headers
+- Add Terraform resources for SNS topic and SES notification config
+- Skip sending email to users who have opted out
+
+## 0.42.0
+- Add admin email settings page for configuring AWS SES sender address and region
+- Add email service module with SES integration (send_email, load/save settings)
+- Add test email endpoint to verify SES configuration from admin UI
+- Add "Email Settings" link in Admin navigation dropdown
+
 ## 0.41.0
 - Cache file import results by content hash (SHA-256) to skip AI re-extraction for identical files
 - Add "Force re-extract (bypass cache)" checkbox to file import page

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.41.0"
+__version__ = "0.43.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -29,11 +29,13 @@ def create_app(test_config=None):
     from app.admin import bp as admin_bp
     from app.auth import bp as auth_bp
     from app.calendar import bp as calendar_bp
+    from app.email import bp as email_bp
     from app.regattas import bp as regattas_bp
 
     app.register_blueprint(admin_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(calendar_bp)
+    app.register_blueprint(email_bp)
     app.register_blueprint(regattas_bp)
 
     from app.commands import register_commands

--- a/app/admin/email_service.py
+++ b/app/admin/email_service.py
@@ -1,0 +1,127 @@
+import hashlib
+import hmac
+import logging
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import boto3
+from flask import current_app, url_for
+
+from app.models import SiteSetting, User
+
+logger = logging.getLogger(__name__)
+
+
+def _get_ses_client(region: str | None = None):
+    """Return a boto3 SES client for the given (or default) region."""
+    if not region:
+        region = current_app.config["AWS_REGION"]
+    return boto3.client("ses", region_name=region)
+
+
+def load_email_settings() -> dict:
+    """Load email settings from SiteSetting table."""
+    sender = ""
+    region = current_app.config["AWS_REGION"]
+
+    sender_to = ""
+
+    setting = SiteSetting.query.filter_by(key="ses_sender").first()
+    if setting and setting.value:
+        sender = setting.value
+
+    to_setting = SiteSetting.query.filter_by(key="ses_sender_to").first()
+    if to_setting and to_setting.value:
+        sender_to = to_setting.value
+
+    region_setting = SiteSetting.query.filter_by(key="ses_region").first()
+    if region_setting and region_setting.value:
+        region = region_setting.value
+
+    return {"ses_sender": sender, "ses_sender_to": sender_to, "ses_region": region}
+
+
+def is_email_configured() -> bool:
+    """Return True if a SES sender email is configured."""
+    setting = SiteSetting.query.filter_by(key="ses_sender").first()
+    return bool(setting and setting.value and setting.value.strip())
+
+
+def generate_unsubscribe_token(email: str) -> str:
+    """Generate an HMAC-SHA256 token for unsubscribe verification."""
+    secret = current_app.config["SECRET_KEY"]
+    return hmac.new(
+        secret.encode("utf-8"),
+        email.lower().encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_unsubscribe_token(email: str, token: str) -> bool:
+    """Verify an unsubscribe HMAC token."""
+    expected = generate_unsubscribe_token(email)
+    return hmac.compare_digest(expected, token)
+
+
+def generate_unsubscribe_url(email: str) -> str:
+    """Generate a full unsubscribe URL with HMAC token."""
+    token = generate_unsubscribe_token(email)
+    return url_for("email.unsubscribe", email=email, token=token, _external=True)
+
+
+def send_email(
+    to: str,
+    subject: str,
+    body_text: str,
+    body_html: str | None = None,
+) -> None:
+    """Send an email via AWS SES with unsubscribe headers.
+
+    Raises ValueError if email is not configured.
+    Raises botocore.exceptions.ClientError on SES failures.
+    Skips sending if the recipient has opted out.
+    """
+    # Check opt-in status
+    user = User.query.filter_by(email=to).first()
+    if user and not user.email_opt_in:
+        logger.info("Skipping email to %s: user has opted out", to)
+        return
+
+    settings = load_email_settings()
+    sender = settings["ses_sender"]
+    if not sender:
+        raise ValueError("Email not configured: no SES sender address set.")
+
+    region = settings["ses_region"]
+    client = _get_ses_client(region)
+
+    # Build MIME message for custom headers
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = to
+
+    # Add unsubscribe headers (RFC 8058)
+    unsubscribe_url = generate_unsubscribe_url(to)
+    msg["List-Unsubscribe"] = f"<{unsubscribe_url}>"
+    msg["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+
+    # Attach text part
+    msg.attach(MIMEText(body_text, "plain", "utf-8"))
+
+    # Attach HTML part with unsubscribe footer
+    if body_html:
+        footer = (
+            '<hr style="margin-top:20px;border:none;border-top:1px solid #ddd;">'
+            '<p style="font-size:12px;color:#888;">'
+            f'<a href="{unsubscribe_url}">Unsubscribe</a> from Race Crew Network emails.'
+            "</p>"
+        )
+        body_html_with_footer = body_html + footer
+        msg.attach(MIMEText(body_html_with_footer, "html", "utf-8"))
+
+    client.send_raw_email(
+        Source=sender,
+        Destinations=[to],
+        RawMessage={"Data": msg.as_string()},
+    )

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -9,15 +9,18 @@ from socket import getaddrinfo
 from urllib.parse import quote_plus, urljoin, urlparse
 
 import requests
+from botocore.exceptions import ClientError
 from bs4 import BeautifulSoup
-from flask import (Response, flash, redirect, render_template, request,
-                   stream_with_context, url_for)
+from flask import (Response, flash, jsonify, redirect, render_template,
+                   request, stream_with_context, url_for)
 from flask_login import current_user, login_required
 
 from app import db
 from app.admin import bp
 from app.admin.ai_service import (discover_documents, discover_documents_deep,
                                   extract_regattas)
+from app.admin.email_service import (is_email_configured, load_email_settings,
+                                     send_email)
 from app.admin.file_utils import extract_text_from_file
 from app.models import Document, ImportCache, Regatta, SiteSetting
 
@@ -419,6 +422,61 @@ def analytics_settings():
         "admin/analytics_settings.html",
         ga_measurement_id=ga_measurement_id,
     )
+
+
+@bp.route("/admin/settings/email", methods=["GET", "POST"])
+@login_required
+def email_settings():
+    denied = _require_admin()
+    if denied:
+        return denied
+
+    if request.method == "POST":
+        ses_sender = request.form.get("ses_sender", "").strip()
+        ses_sender_to = request.form.get("ses_sender_to", "").strip()
+        ses_region = request.form.get("ses_region", "").strip()
+
+        _upsert_site_setting("ses_sender", ses_sender)
+        _upsert_site_setting("ses_sender_to", ses_sender_to)
+        if ses_region:
+            _upsert_site_setting("ses_region", ses_region)
+
+        flash("Email settings updated.", "success")
+        return redirect(url_for("admin.email_settings"))
+
+    settings = load_email_settings()
+    return render_template(
+        "admin/email_settings.html",
+        ses_sender=settings["ses_sender"],
+        ses_sender_to=settings["ses_sender_to"],
+        ses_region=settings["ses_region"],
+        email_configured=is_email_configured(),
+    )
+
+
+@bp.route("/admin/settings/email/test", methods=["POST"])
+@login_required
+def email_test():
+    if not current_user.is_admin:
+        return jsonify({"success": False, "error": "Access denied."}), 403
+
+    try:
+        settings = load_email_settings()
+        recipient = settings["ses_sender_to"] or current_user.email
+        send_email(
+            to=recipient,
+            subject="Race Crew Network — Test Email",
+            body_text="This is a test email from Race Crew Network. "
+            "If you received this, your email settings are working correctly.",
+            body_html="<p>This is a test email from <strong>Race Crew Network</strong>.</p>"
+            "<p>If you received this, your email settings are working correctly.</p>",
+        )
+        return jsonify({"success": True, "message": f"Test email sent to {recipient}."})
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 400
+    except ClientError as exc:
+        error_msg = exc.response["Error"].get("Message", str(exc))
+        return jsonify({"success": False, "error": error_msg}), 500
 
 
 @bp.route("/admin/import-schedule/extract", methods=["POST"])

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -89,6 +89,7 @@ def profile():
             current_user.initials = initials
             current_user.email = email
             current_user.phone = request.form.get("phone", "").strip() or None
+            current_user.email_opt_in = request.form.get("email_opt_in") == "on"
             if password:
                 current_user.set_password(password)
             db.session.commit()

--- a/app/email/__init__.py
+++ b/app/email/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("email", __name__)
+
+from app.email import routes  # noqa: E402, F401

--- a/app/email/routes.py
+++ b/app/email/routes.py
@@ -1,0 +1,123 @@
+import json
+import logging
+
+import requests
+from flask import abort, render_template, request
+
+from app import csrf, db
+from app.admin.email_service import verify_unsubscribe_token
+from app.email import bp
+from app.models import User
+
+logger = logging.getLogger(__name__)
+
+
+@bp.route("/unsubscribe", methods=["GET", "POST"])
+def unsubscribe():
+    """Handle email unsubscribe requests.
+
+    GET:  Show confirmation page.
+    POST: Process one-click unsubscribe (RFC 8058) — returns 204.
+    """
+    email = request.args.get("email", "").strip().lower()
+    token = request.args.get("token", "")
+
+    if not email or not token or not verify_unsubscribe_token(email, token):
+        abort(400)
+
+    user = User.query.filter_by(email=email).first()
+    if not user:
+        abort(404)
+
+    if request.method == "POST":
+        user.email_opt_in = False
+        db.session.commit()
+        logger.info("One-click unsubscribe processed for %s", email)
+        return "", 204
+
+    # GET — show confirmation page (user already unsubscribed)
+    user.email_opt_in = False
+    db.session.commit()
+    logger.info("Unsubscribe via link for %s", email)
+    return render_template("unsubscribe.html")
+
+
+@bp.route("/webhooks/ses", methods=["POST"])
+@csrf.exempt
+def ses_webhook():
+    """Process AWS SNS notifications for SES bounces and complaints."""
+    try:
+        payload = json.loads(request.get_data(as_text=True))
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Invalid JSON in SNS webhook")
+        abort(400)
+
+    msg_type = payload.get("Type")
+
+    # Handle subscription confirmation
+    if msg_type == "SubscriptionConfirmation":
+        subscribe_url = payload.get("SubscribeURL")
+        if subscribe_url:
+            try:
+                requests.get(subscribe_url, timeout=10)
+                logger.info("SNS subscription confirmed")
+            except requests.RequestException:
+                logger.error("Failed to confirm SNS subscription")
+        return "", 200
+
+    # Handle notifications
+    if msg_type == "Notification":
+        try:
+            message = json.loads(payload.get("Message", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Invalid JSON in SNS notification message")
+            return "", 200
+
+        notification_type = message.get("notificationType")
+
+        if notification_type == "Bounce":
+            _handle_bounce(message)
+        elif notification_type == "Complaint":
+            _handle_complaint(message)
+
+        return "", 200
+
+    return "", 200
+
+
+def _handle_bounce(message: dict) -> None:
+    """Process SES bounce notification."""
+    bounce = message.get("bounce", {})
+    bounce_type = bounce.get("bounceType")
+    recipients = bounce.get("bouncedRecipients", [])
+
+    for recipient in recipients:
+        email = recipient.get("emailAddress", "").lower()
+        if not email:
+            continue
+
+        if bounce_type == "Permanent":
+            user = User.query.filter_by(email=email).first()
+            if user:
+                user.email_opt_in = False
+                db.session.commit()
+                logger.warning("Hard bounce for %s — opted out", email)
+        else:
+            logger.info("Soft bounce for %s (type: %s) — no action", email, bounce_type)
+
+
+def _handle_complaint(message: dict) -> None:
+    """Process SES complaint notification."""
+    complaint = message.get("complaint", {})
+    recipients = complaint.get("complainedRecipients", [])
+
+    for recipient in recipients:
+        email = recipient.get("emailAddress", "").lower()
+        if not email:
+            continue
+
+        user = User.query.filter_by(email=email).first()
+        if user:
+            user.email_opt_in = False
+            db.session.commit()
+            logger.error("Complaint received for %s — opted out", email)

--- a/app/models.py
+++ b/app/models.py
@@ -24,6 +24,7 @@ class User(UserMixin, db.Model):
     # Token for iCal subscription feed (generated on first request)
     calendar_token = db.Column(db.String(64), unique=True, nullable=True)
     phone = db.Column(db.String(20), nullable=True)
+    email_opt_in = db.Column(db.Boolean, default=True, nullable=False)
 
     rsvps = db.relationship("RSVP", backref="user", lazy="dynamic")
     documents = db.relationship("Document", backref="uploaded_by_user", lazy="dynamic")

--- a/app/templates/admin/email_settings.html
+++ b/app/templates/admin/email_settings.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+{% block title %}Email Settings — Race Crew Network{% endblock %}
+{% block content %}
+<div class="row justify-content-center mt-3">
+    <div class="col-md-6 col-lg-5">
+        <h2 class="mb-3">Email Settings</h2>
+        {% if email_configured %}
+        <div class="alert alert-success" role="alert">
+            <strong>Status:</strong> Email configured.
+        </div>
+        {% else %}
+        <div class="alert alert-warning" role="alert">
+            <strong>Status:</strong> Not configured. Set a verified SES sender address below.
+        </div>
+        {% endif %}
+        <p class="text-muted">
+            Configure AWS SES for sending emails. The sender address must be
+            <a href="https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html" target="_blank" rel="noopener">verified in AWS SES</a>
+            before emails can be sent.
+        </p>
+        <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="mb-3">
+                <label for="ses_sender" class="form-label">Send From</label>
+                <input
+                    type="email"
+                    class="form-control"
+                    id="ses_sender"
+                    name="ses_sender"
+                    value="{{ ses_sender }}"
+                    placeholder="noreply@racecrew.net"
+                >
+                <div class="form-text">Must be a verified email address or domain in AWS SES.</div>
+            </div>
+            <div class="mb-3">
+                <label for="ses_sender_to" class="form-label">Send Email To</label>
+                <input
+                    type="email"
+                    class="form-control"
+                    id="ses_sender_to"
+                    name="ses_sender_to"
+                    value="{{ ses_sender_to }}"
+                    placeholder="admin@racecrew.net"
+                >
+                <div class="form-text">Email address where test emails will be sent.</div>
+            </div>
+            <div class="mb-3">
+                <label for="ses_region" class="form-label">SES Region</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    id="ses_region"
+                    name="ses_region"
+                    value="{{ ses_region }}"
+                    placeholder="us-east-1"
+                >
+                <div class="form-text">AWS region for SES. Defaults to the app's AWS_REGION if left blank.</div>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                <button type="submit" class="btn btn-primary">Save Settings</button>
+                <button type="button" class="btn btn-outline-success" id="btn-test-email" {% if not email_configured %}disabled{% endif %}>Send Test Email</button>
+                <a href="{{ url_for('regattas.index') }}" class="btn btn-outline-secondary">Cancel</a>
+            </div>
+        </form>
+        <div id="test-email-result" class="mt-3" style="display:none;"></div>
+    </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+document.getElementById('btn-test-email').addEventListener('click', function() {
+    const btn = this;
+    const resultDiv = document.getElementById('test-email-result');
+    btn.disabled = true;
+    btn.textContent = 'Sending...';
+    resultDiv.style.display = 'none';
+
+    fetch('{{ url_for("admin.email_test") }}', {
+        method: 'POST',
+        headers: {
+            'X-CSRFToken': '{{ csrf_token() }}'
+        }
+    })
+    .then(resp => resp.json().then(data => ({status: resp.status, data})))
+    .then(({status, data}) => {
+        if (data.success) {
+            resultDiv.className = 'mt-3 alert alert-success';
+            resultDiv.textContent = data.message;
+        } else {
+            resultDiv.className = 'mt-3 alert alert-danger';
+            resultDiv.textContent = data.error || 'Failed to send test email.';
+        }
+        resultDiv.style.display = 'block';
+    })
+    .catch(() => {
+        resultDiv.className = 'mt-3 alert alert-danger';
+        resultDiv.textContent = 'Network error — could not reach server.';
+        resultDiv.style.display = 'block';
+    })
+    .finally(() => {
+        btn.disabled = false;
+        btn.textContent = 'Send Test Email';
+    });
+});
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -40,6 +40,7 @@
                         <a class="nav-link nav-pill-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Admin</a>
                         <ul class="dropdown-menu">
                             <li><a class="dropdown-item" href="{{ url_for('admin.analytics_settings') }}">Analytics Settings</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('admin.email_settings') }}">Email Settings</a></li>
                         </ul>
                     </li>
                     <li class="nav-item dropdown">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -23,6 +23,12 @@
                 <input type="tel" class="form-control" id="phone" name="phone" value="{{ current_user.phone or '' }}" placeholder="e.g. 555-123-4567">
             </div>
             <hr>
+            <div class="mb-3 form-check">
+                <input type="checkbox" class="form-check-input" id="email_opt_in" name="email_opt_in" {% if current_user.email_opt_in %}checked{% endif %}>
+                <label class="form-check-label" for="email_opt_in">Receive email communications</label>
+                <div class="form-text">Uncheck to stop receiving emails from Race Crew Network.</div>
+            </div>
+            <hr>
             <p class="text-muted">Leave password blank to keep your current password.</p>
             <div class="mb-3">
                 <label for="password" class="form-label">New Password</label>

--- a/app/templates/unsubscribe.html
+++ b/app/templates/unsubscribe.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Unsubscribed — Race Crew Network{% endblock %}
+{% block content %}
+<div class="row justify-content-center mt-5">
+    <div class="col-md-6 text-center">
+        <h2 class="mb-3">You've been unsubscribed</h2>
+        <p class="text-muted">You will no longer receive email communications from Race Crew Network.</p>
+        <p class="text-muted">If this was a mistake, you can re-subscribe from your profile settings after logging in.</p>
+    </div>
+</div>
+{% endblock %}

--- a/migrations/versions/1f34ac0f8204_add_email_opt_in_to_users.py
+++ b/migrations/versions/1f34ac0f8204_add_email_opt_in_to_users.py
@@ -1,0 +1,26 @@
+"""Add email_opt_in to users
+
+Revision ID: 1f34ac0f8204
+Revises: c3d4e5f6a7b8
+Create Date: 2026-03-08 13:05:00.237007
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1f34ac0f8204'
+down_revision = 'c3d4e5f6a7b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('email_opt_in', sa.Boolean(), nullable=False, server_default=sa.text('1')))
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('email_opt_in')

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -217,3 +217,98 @@ resource "aws_route53_record" "apex" {
     evaluate_target_health = false
   }
 }
+
+# --- SES Email ---
+
+resource "aws_ses_domain_identity" "app" {
+  domain = var.domain_name
+}
+
+resource "aws_ses_domain_dkim" "app" {
+  domain = aws_ses_domain_identity.app.domain
+}
+
+resource "aws_ses_domain_mail_from" "app" {
+  domain           = aws_ses_domain_identity.app.domain
+  mail_from_domain = "mail.${var.domain_name}"
+}
+
+# DKIM CNAME records (3 tokens)
+resource "aws_route53_record" "ses_dkim" {
+  count   = 3
+  zone_id = var.route53_zone_id
+  name    = "${aws_ses_domain_dkim.app.dkim_tokens[count.index]}._domainkey.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["${aws_ses_domain_dkim.app.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+# SPF TXT record on root domain (includes both Outlook and SES)
+resource "aws_route53_record" "spf" {
+  zone_id = var.route53_zone_id
+  name    = var.domain_name
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:spf.protection.outlook.com include:amazonses.com -all"]
+}
+
+# DMARC TXT record
+resource "aws_route53_record" "dmarc" {
+  zone_id = var.route53_zone_id
+  name    = "_dmarc.${var.domain_name}"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1; p=none;"]
+}
+
+# MAIL FROM MX record
+resource "aws_route53_record" "ses_mail_from_mx" {
+  zone_id = var.route53_zone_id
+  name    = "mail.${var.domain_name}"
+  type    = "MX"
+  ttl     = 300
+  records = ["10 feedback-smtp.${var.aws_region}.amazonses.com"]
+}
+
+# MAIL FROM SPF record
+resource "aws_route53_record" "ses_mail_from_spf" {
+  zone_id = var.route53_zone_id
+  name    = "mail.${var.domain_name}"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+# --- SES Bounce & Complaint Notifications ---
+
+# SNS topic for SES bounce/complaint notifications
+resource "aws_sns_topic" "ses_notifications" {
+  name = "ses-bounce-complaint"
+
+  tags = {
+    Project = "race-crew-network"
+  }
+}
+
+# Subscribe the app webhook to the SNS topic
+resource "aws_sns_topic_subscription" "ses_webhook" {
+  topic_arn = aws_sns_topic.ses_notifications.arn
+  protocol  = "https"
+  endpoint  = "https://www.${var.domain_name}/webhooks/ses"
+}
+
+# SES notification configuration — bounces
+resource "aws_ses_identity_notification_topic" "bounce" {
+  topic_arn                = aws_sns_topic.ses_notifications.arn
+  notification_type        = "Bounce"
+  identity                 = aws_ses_domain_identity.app.domain
+  include_original_headers = false
+}
+
+# SES notification configuration — complaints
+resource "aws_ses_identity_notification_topic" "complaint" {
+  topic_arn                = aws_sns_topic.ses_notifications.arn
+  notification_type        = "Complaint"
+  identity                 = aws_ses_domain_identity.app.domain
+  include_original_headers = false
+}

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -30,6 +30,16 @@ class TestAdminAccessUnauthenticated:
         assert resp.status_code == 302
         assert "/login" in resp.headers["Location"]
 
+    def test_email_settings_requires_login(self, client):
+        resp = client.get("/admin/settings/email")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_email_test_requires_login(self, client):
+        resp = client.post("/admin/settings/email/test")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
     def test_import_url_requires_admin(self, app, client, db):
         """Non-admin user should be denied."""
         user = User(
@@ -68,6 +78,46 @@ class TestAdminAccessUnauthenticated:
         )
         resp = client.get("/admin/settings/analytics", follow_redirects=True)
         assert b"Access denied" in resp.data
+
+    def test_email_settings_requires_admin(self, app, client, db):
+        user = User(
+            email="crew3@test.com",
+            display_name="Crew 3",
+            initials="C3",
+            is_admin=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew3@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/admin/settings/email", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_email_test_requires_admin_json(self, app, client, db):
+        user = User(
+            email="crew4@test.com",
+            display_name="Crew 4",
+            initials="C4",
+            is_admin=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew4@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.post("/admin/settings/email/test")
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data["success"] is False
 
 
 class TestAdminAccessAuthenticated:
@@ -119,6 +169,66 @@ class TestAdminAccessAuthenticated:
         setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
         assert setting is not None
         assert setting.value == "G-TESTABC123"
+
+    def test_email_settings_accessible_for_admin(self, logged_in_client):
+        resp = logged_in_client.get("/admin/settings/email")
+        assert resp.status_code == 200
+        assert b"Email Settings" in resp.data
+
+    def test_email_settings_persists_sender_and_region(self, logged_in_client):
+        resp = logged_in_client.post(
+            "/admin/settings/email",
+            data={"ses_sender": "noreply@example.com", "ses_region": "us-west-2"},
+            follow_redirects=True,
+        )
+        assert b"Email settings updated" in resp.data
+
+        sender = SiteSetting.query.filter_by(key="ses_sender").first()
+        assert sender is not None
+        assert sender.value == "noreply@example.com"
+
+        region = SiteSetting.query.filter_by(key="ses_region").first()
+        assert region is not None
+        assert region.value == "us-west-2"
+
+    @patch("app.admin.routes.send_email")
+    def test_email_test_success(self, mock_send, logged_in_client):
+        resp = logged_in_client.post("/admin/settings/email/test")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "Test email sent" in data["message"]
+        mock_send.assert_called_once()
+
+    @patch("app.admin.routes.send_email")
+    def test_email_test_not_configured(self, mock_send, logged_in_client):
+        mock_send.side_effect = ValueError(
+            "Email not configured: no SES sender address set."
+        )
+        resp = logged_in_client.post("/admin/settings/email/test")
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "not configured" in data["error"]
+
+    @patch("app.admin.routes.send_email")
+    def test_email_test_ses_error(self, mock_send, logged_in_client):
+        from botocore.exceptions import ClientError
+
+        mock_send.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "MessageRejected",
+                    "Message": "Email address not verified.",
+                }
+            },
+            "SendEmail",
+        )
+        resp = logged_in_client.post("/admin/settings/email/test")
+        assert resp.status_code == 500
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "not verified" in data["error"]
 
 
 class TestImportSchedulePreview:

--- a/tests/test_email_routes.py
+++ b/tests/test_email_routes.py
@@ -1,0 +1,204 @@
+"""Tests for email blueprint (unsubscribe and SES webhook)."""
+
+import json
+from unittest.mock import patch
+
+from app.admin.email_service import generate_unsubscribe_token
+from app.models import User
+
+
+class TestUnsubscribeGet:
+    def test_valid_token_unsubscribes(self, app, db, client):
+        user = User(
+            email="crew@example.com",
+            display_name="Crew",
+            initials="CR",
+            email_opt_in=True,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        token = generate_unsubscribe_token("crew@example.com")
+        resp = client.get(f"/unsubscribe?email=crew@example.com&token={token}")
+
+        assert resp.status_code == 200
+        assert b"unsubscribed" in resp.data.lower()
+
+        db.session.refresh(user)
+        assert user.email_opt_in is False
+
+    def test_missing_email_returns_400(self, app, client):
+        resp = client.get("/unsubscribe?token=abc")
+        assert resp.status_code == 400
+
+    def test_missing_token_returns_400(self, app, client):
+        resp = client.get("/unsubscribe?email=crew@example.com")
+        assert resp.status_code == 400
+
+    def test_invalid_token_returns_400(self, app, client):
+        resp = client.get("/unsubscribe?email=crew@example.com&token=invalid")
+        assert resp.status_code == 400
+
+    def test_unknown_user_returns_404(self, app, db, client):
+        token = generate_unsubscribe_token("unknown@example.com")
+        resp = client.get(f"/unsubscribe?email=unknown@example.com&token={token}")
+        assert resp.status_code == 404
+
+
+class TestUnsubscribePost:
+    def test_one_click_unsubscribe(self, app, db, client):
+        user = User(
+            email="crew@example.com",
+            display_name="Crew",
+            initials="CR",
+            email_opt_in=True,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        token = generate_unsubscribe_token("crew@example.com")
+        resp = client.post(f"/unsubscribe?email=crew@example.com&token={token}")
+
+        assert resp.status_code == 204
+
+        db.session.refresh(user)
+        assert user.email_opt_in is False
+
+    def test_invalid_token_post_returns_400(self, app, client):
+        resp = client.post("/unsubscribe?email=crew@example.com&token=badtoken")
+        assert resp.status_code == 400
+
+
+class TestSesWebhook:
+    def test_subscription_confirmation(self, app, db, client):
+        payload = {
+            "Type": "SubscriptionConfirmation",
+            "SubscribeURL": "https://sns.example.com/confirm?token=abc",
+        }
+        with patch("app.email.routes.requests.get") as mock_get:
+            resp = client.post(
+                "/webhooks/ses",
+                data=json.dumps(payload),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        mock_get.assert_called_once_with(payload["SubscribeURL"], timeout=10)
+
+    def test_hard_bounce_opts_out_user(self, app, db, client):
+        user = User(
+            email="bounce@example.com",
+            display_name="Bouncer",
+            initials="BO",
+            email_opt_in=True,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        payload = {
+            "Type": "Notification",
+            "Message": json.dumps(
+                {
+                    "notificationType": "Bounce",
+                    "bounce": {
+                        "bounceType": "Permanent",
+                        "bouncedRecipients": [{"emailAddress": "bounce@example.com"}],
+                    },
+                }
+            ),
+        }
+        resp = client.post(
+            "/webhooks/ses",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+
+        db.session.refresh(user)
+        assert user.email_opt_in is False
+
+    def test_soft_bounce_does_not_opt_out(self, app, db, client):
+        user = User(
+            email="soft@example.com",
+            display_name="Soft",
+            initials="SF",
+            email_opt_in=True,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        payload = {
+            "Type": "Notification",
+            "Message": json.dumps(
+                {
+                    "notificationType": "Bounce",
+                    "bounce": {
+                        "bounceType": "Transient",
+                        "bouncedRecipients": [{"emailAddress": "soft@example.com"}],
+                    },
+                }
+            ),
+        }
+        resp = client.post(
+            "/webhooks/ses",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+
+        db.session.refresh(user)
+        assert user.email_opt_in is True
+
+    def test_complaint_opts_out_user(self, app, db, client):
+        user = User(
+            email="complain@example.com",
+            display_name="Complainer",
+            initials="CO",
+            email_opt_in=True,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        payload = {
+            "Type": "Notification",
+            "Message": json.dumps(
+                {
+                    "notificationType": "Complaint",
+                    "complaint": {
+                        "complainedRecipients": [
+                            {"emailAddress": "complain@example.com"}
+                        ],
+                    },
+                }
+            ),
+        }
+        resp = client.post(
+            "/webhooks/ses",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+
+        db.session.refresh(user)
+        assert user.email_opt_in is False
+
+    def test_invalid_json_returns_400(self, app, client):
+        resp = client.post(
+            "/webhooks/ses",
+            data="not json",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_unknown_type_returns_200(self, app, client):
+        payload = {"Type": "UnknownType"}
+        resp = client.post(
+            "/webhooks/ses",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,0 +1,197 @@
+"""Tests for email service (SES integration)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from app.admin.email_service import (generate_unsubscribe_token,
+                                     generate_unsubscribe_url,
+                                     is_email_configured, load_email_settings,
+                                     send_email, verify_unsubscribe_token)
+from app.models import SiteSetting, User
+
+
+class TestLoadEmailSettings:
+    def test_returns_defaults_when_empty(self, app, db):
+        settings = load_email_settings()
+        assert settings["ses_sender"] == ""
+        assert settings["ses_sender_to"] == ""
+        assert settings["ses_region"] == "us-east-1"
+
+    def test_loads_stored_settings(self, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="test@example.com"))
+        db.session.add(SiteSetting(key="ses_sender_to", value="admin@example.com"))
+        db.session.add(SiteSetting(key="ses_region", value="us-west-2"))
+        db.session.commit()
+
+        settings = load_email_settings()
+        assert settings["ses_sender"] == "test@example.com"
+        assert settings["ses_sender_to"] == "admin@example.com"
+        assert settings["ses_region"] == "us-west-2"
+
+
+class TestIsEmailConfigured:
+    def test_false_when_no_sender(self, app, db):
+        assert is_email_configured() is False
+
+    def test_false_when_sender_empty(self, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value=""))
+        db.session.commit()
+        assert is_email_configured() is False
+
+    def test_false_when_sender_whitespace(self, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="   "))
+        db.session.commit()
+        assert is_email_configured() is False
+
+    def test_true_when_sender_set(self, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="noreply@example.com"))
+        db.session.commit()
+        assert is_email_configured() is True
+
+
+class TestUnsubscribeToken:
+    def test_generate_and_verify(self, app):
+        token = generate_unsubscribe_token("user@example.com")
+        assert isinstance(token, str)
+        assert len(token) == 64  # SHA-256 hex digest
+
+    def test_verify_valid_token(self, app):
+        token = generate_unsubscribe_token("user@example.com")
+        assert verify_unsubscribe_token("user@example.com", token) is True
+
+    def test_verify_invalid_token(self, app):
+        assert verify_unsubscribe_token("user@example.com", "badtoken") is False
+
+    def test_case_insensitive_email(self, app):
+        token = generate_unsubscribe_token("User@Example.COM")
+        assert verify_unsubscribe_token("user@example.com", token) is True
+
+    def test_different_emails_different_tokens(self, app):
+        token1 = generate_unsubscribe_token("user1@example.com")
+        token2 = generate_unsubscribe_token("user2@example.com")
+        assert token1 != token2
+
+    def test_generate_unsubscribe_url(self, app):
+        url = generate_unsubscribe_url("user@example.com")
+        assert "/unsubscribe" in url
+        assert "email=user%40example.com" in url or "email=user@example.com" in url
+        assert "token=" in url
+
+
+class TestSendEmail:
+    def test_raises_when_not_configured(self, app, db):
+        with pytest.raises(ValueError, match="not configured"):
+            send_email("to@example.com", "Subject", "Body")
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_sends_raw_email(self, mock_get_client, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("to@example.com", "Test Subject", "Text body")
+
+        mock_client.send_raw_email.assert_called_once()
+        call_kwargs = mock_client.send_raw_email.call_args[1]
+        assert call_kwargs["Source"] == "from@example.com"
+        assert call_kwargs["Destinations"] == ["to@example.com"]
+        raw_data = call_kwargs["RawMessage"]["Data"]
+        assert "List-Unsubscribe:" in raw_data
+        assert "List-Unsubscribe-Post:" in raw_data
+        assert "Test Subject" in raw_data
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_sends_html_with_footer(self, mock_get_client, app, db):
+        import base64
+
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("to@example.com", "Subject", "Text body", body_html="<p>HTML</p>")
+
+        raw_data = mock_client.send_raw_email.call_args[1]["RawMessage"]["Data"]
+        # HTML body is base64-encoded in the MIME message; decode to verify
+        assert "text/html" in raw_data
+        # Extract and decode the base64 HTML part
+        parts = raw_data.split("text/html")
+        b64_content = parts[1].split("\n\n", 1)[1].split("\n--")[0].strip()
+        decoded_html = base64.b64decode(b64_content).decode("utf-8")
+        assert "<p>HTML</p>" in decoded_html
+        assert "Unsubscribe" in decoded_html
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_uses_configured_region(self, mock_get_client, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.add(SiteSetting(key="ses_region", value="eu-west-1"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("to@example.com", "Subject", "Body")
+
+        mock_get_client.assert_called_once_with("eu-west-1")
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_propagates_client_error(self, mock_get_client, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_client.send_raw_email.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "MessageRejected",
+                    "Message": "Email address not verified.",
+                }
+            },
+            "SendRawEmail",
+        )
+        mock_get_client.return_value = mock_client
+
+        with pytest.raises(ClientError):
+            send_email("to@example.com", "Subject", "Body")
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_skips_opted_out_user(self, mock_get_client, app, db):
+        user = User(
+            email="optout@example.com",
+            display_name="Opted Out",
+            initials="OO",
+            email_opt_in=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        send_email("optout@example.com", "Subject", "Body")
+
+        mock_get_client.return_value.send_raw_email.assert_not_called()
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_sends_to_opted_in_user(self, mock_get_client, app, db):
+        user = User(
+            email="optin@example.com",
+            display_name="Opted In",
+            initials="OI",
+            email_opt_in=True,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("optin@example.com", "Subject", "Body")
+
+        mock_client.send_raw_email.assert_called_once()


### PR DESCRIPTION
## Summary
- Add one-click email unsubscribe (RFC 8058) with HMAC-signed links and confirmation page
- Add SES bounce/complaint processing via SNS webhook (hard bounce and complaint auto-opt-out)
- Add `email_opt_in` field to User model with profile page toggle
- Add admin email settings page for SES sender config and test email
- Switch email service to `send_raw_email` for custom `List-Unsubscribe` headers
- Add Terraform resources for SNS topic and SES notification config
- Skip sending to opted-out users

Closes #51

## Test plan
- [x] 160 tests pass (32 new), only pre-existing GA test failure
- [x] black, isort, flake8 clean
- [x] `terraform validate` passes
- [ ] Manual: send test email, verify `List-Unsubscribe` header present
- [ ] Manual: click unsubscribe link, verify user is opted out
- [ ] Manual: verify profile checkbox toggles email preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)