### PR TITLE
Add dedicated IAM user for SES sending

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.43.1
+- Add dedicated IAM user for SES with Terraform-managed credentials
+- Support separate SES_ACCESS_KEY_ID / SES_SECRET_ACCESS_KEY env vars
+
 ## 0.43.0
 - Add one-click email unsubscribe (RFC 8058) with HMAC-signed links
 - Add SES bounce and complaint handling via SNS webhook

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.43.0"
+__version__ = "0.43.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/email_service.py
+++ b/app/admin/email_service.py
@@ -13,9 +13,23 @@ logger = logging.getLogger(__name__)
 
 
 def _get_ses_client(region: str | None = None):
-    """Return a boto3 SES client for the given (or default) region."""
+    """Return a boto3 SES client for the given (or default) region.
+
+    Uses SES_ACCESS_KEY_ID / SES_SECRET_ACCESS_KEY if set, otherwise
+    falls back to the default boto3 credential chain (env vars, instance
+    profile, etc.).
+    """
     if not region:
         region = current_app.config["AWS_REGION"]
+    ses_key = current_app.config.get("SES_ACCESS_KEY_ID")
+    ses_secret = current_app.config.get("SES_SECRET_ACCESS_KEY")
+    if ses_key and ses_secret:
+        return boto3.client(
+            "ses",
+            region_name=region,
+            aws_access_key_id=ses_key,
+            aws_secret_access_key=ses_secret,
+        )
     return boto3.client("ses", region_name=region)
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -12,4 +12,6 @@ class Config:
     UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "uploads")
     BUCKET_NAME = os.environ.get("BUCKET_NAME", "")
     AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+    SES_ACCESS_KEY_ID = os.environ.get("SES_ACCESS_KEY_ID", "")
+    SES_SECRET_ACCESS_KEY = os.environ.get("SES_SECRET_ACCESS_KEY", "")
     ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -279,6 +279,39 @@ resource "aws_route53_record" "ses_mail_from_spf" {
   records = ["v=spf1 include:amazonses.com -all"]
 }
 
+# --- SES IAM User ---
+# Dedicated IAM user for SES sending (Lightsail bucket keys lack SES permissions).
+
+resource "aws_iam_user" "ses_sender" {
+  name = "${var.instance_name}-ses-sender"
+
+  tags = {
+    Project = "race-crew-network"
+  }
+}
+
+resource "aws_iam_user_policy" "ses_send" {
+  name = "ses-send-raw-email"
+  user = aws_iam_user.ses_sender.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ses:SendRawEmail", "ses:SendEmail"]
+        Resource = "arn:aws:ses:${var.aws_region}:${data.aws_caller_identity.current.account_id}:identity/${var.domain_name}"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_access_key" "ses_sender" {
+  user = aws_iam_user.ses_sender.name
+}
+
+data "aws_caller_identity" "current" {}
+
 # --- SES Bounce & Complaint Notifications ---
 
 # SNS topic for SES bounce/complaint notifications

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -33,3 +33,14 @@ output "cloudfront_distribution_domain" {
   description = "CloudFront domain name for apex redirect"
   value       = aws_cloudfront_distribution.apex_redirect.domain_name
 }
+
+output "ses_access_key_id" {
+  description = "Access key ID for the SES sender IAM user"
+  value       = aws_iam_access_key.ses_sender.id
+}
+
+output "ses_secret_access_key" {
+  description = "Secret access key for the SES sender IAM user"
+  value       = aws_iam_access_key.ses_sender.secret
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- Add Terraform-managed IAM user (`race-crew-network-ses-sender`) with `ses:SendRawEmail` and `ses:SendEmail` permissions scoped to the domain identity
- Add `SES_ACCESS_KEY_ID` / `SES_SECRET_ACCESS_KEY` config vars so the email service uses separate credentials from the Lightsail bucket keys
- Terraform outputs expose the new credentials (sensitive)

## After merge
1. `terraform apply` to create the IAM user and access key
2. Retrieve credentials: `terraform output ses_secret_access_key`
3. Add `SES_ACCESS_KEY_ID` and `SES_SECRET_ACCESS_KEY` to GitHub secrets
4. Add both to the container environment in `deploy.yml`
5. Redeploy

## Test plan
- [x] All 32 email tests pass
- [x] `terraform validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)