### PR TITLE
Personalize invite email and set From display name

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,15 @@
 # Version History
 
+## 0.44.1
+- Personalize invite email body with inviter's name ("{name}'s crew")
+- Set From display name to "Race Crew Network" on all outgoing emails
+
+## 0.44.0
+- Add email invite option for crew members on Manage Crew page
+- "Send invite via email" checkbox on invite form (when SES is configured)
+- Bulk "Resend Invites" for pending users with select-all support
+- Graceful fallback to invite link flash if email send fails
+
 ## 0.43.3
 - Remove TODO.md
 - Widen SES IAM policy to allow sending from all verified identities

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.43.3"
+__version__ = "0.44.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/email_service.py
+++ b/app/admin/email_service.py
@@ -112,7 +112,7 @@ def send_email(
     # Build MIME message for custom headers
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
-    msg["From"] = sender
+    msg["From"] = f"Race Crew Network <{sender}>"
     msg["To"] = to
 
     # Add unsubscribe headers (RFC 8058)
@@ -135,7 +135,7 @@ def send_email(
         msg.attach(MIMEText(body_html_with_footer, "html", "utf-8"))
 
     client.send_raw_email(
-        Source=sender,
+        Source=f"Race Crew Network <{sender}>",
         Destinations=[to],
         RawMessage={"Data": msg.as_string()},
     )

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,9 +1,32 @@
+import logging
+
 from flask import flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required, login_user, logout_user
 
 from app import db
+from app.admin.email_service import is_email_configured, send_email
 from app.auth import bp
 from app.models import User
+
+logger = logging.getLogger(__name__)
+
+
+def _send_invite_email(email: str, invite_url: str, inviter_name: str) -> None:
+    """Send a welcome email with the invite link."""
+    subject = "You're invited to Race Crew Network"
+    body_text = (
+        f"You've been invited to join {inviter_name}'s crew on Race Crew Network!\n\n"
+        f"Click the link below to set up your account:\n{invite_url}\n\n"
+        "See you on the water!"
+    )
+    body_html = (
+        "<h2>You're invited to Race Crew Network!</h2>"
+        f"<p>You've been invited to join {inviter_name}'s crew. "
+        "Click the link below to set up your account:</p>"
+        f'<p><a href="{invite_url}">Accept Invitation</a></p>'
+        "<p>See you on the water!</p>"
+    )
+    send_email(email, subject, body_text, body_html)
 
 
 @bp.route("/login", methods=["GET", "POST"])
@@ -117,7 +140,11 @@ def admin_users():
         return redirect(url_for("regattas.index"))
 
     users = User.query.order_by(User.display_name).all()
-    return render_template("admin_users.html", users=users)
+    return render_template(
+        "admin_users.html",
+        users=users,
+        email_configured=is_email_configured(),
+    )
 
 
 @bp.route("/admin/users/invite", methods=["POST"])
@@ -150,7 +177,59 @@ def invite_user():
     db.session.commit()
 
     invite_url = url_for("auth.register", token=token, _external=True)
-    flash(f"Invite link: {invite_url}", "success")
+
+    send_email_invite = request.form.get("send_email_invite") == "on"
+    if send_email_invite and is_email_configured():
+        try:
+            _send_invite_email(email, invite_url, current_user.display_name)
+            flash(f"Invite email sent to {email}.", "success")
+        except Exception:
+            logger.exception("Failed to send invite email to %s", email)
+            flash("Failed to send invite email. Copy the link below.", "error")
+            flash(f"Invite link: {invite_url}", "success")
+    else:
+        flash(f"Invite link: {invite_url}", "success")
+
+    return redirect(url_for("auth.admin_users"))
+
+
+@bp.route("/admin/users/resend-invites", methods=["POST"])
+@login_required
+def resend_invites():
+    if not current_user.is_admin:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if not is_email_configured():
+        flash("Email is not configured.", "error")
+        return redirect(url_for("auth.admin_users"))
+
+    user_ids = request.form.getlist("user_ids")
+    if not user_ids:
+        flash("No users selected.", "error")
+        return redirect(url_for("auth.admin_users"))
+
+    sent = 0
+    failed = 0
+    for uid in user_ids:
+        user = db.session.get(User, int(uid))
+        if not user or not user.invite_token:
+            continue
+        invite_url = url_for("auth.register", token=user.invite_token, _external=True)
+        try:
+            _send_invite_email(user.email, invite_url, current_user.display_name)
+            sent += 1
+        except Exception:
+            logger.exception("Failed to resend invite to %s", user.email)
+            failed += 1
+
+    if sent:
+        flash(f"Invite emails sent to {sent} user(s).", "success")
+    if failed:
+        flash(f"Failed to send {failed} invite(s).", "error")
+    if not sent and not failed:
+        flash("No pending users in selection.", "warning")
+
     return redirect(url_for("auth.admin_users"))
 
 

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -12,6 +12,14 @@
                 <label for="email" class="form-label">Email</label>
                 <input type="email" class="form-control" id="email" name="email" required placeholder="crew@example.com">
             </div>
+            {% if email_configured %}
+            <div class="col-12 col-sm-auto d-flex align-items-center">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="send_email_invite" name="send_email_invite" checked>
+                    <label class="form-check-label" for="send_email_invite">Send invite via email</label>
+                </div>
+            </div>
+            {% endif %}
             <div class="col-12 col-sm-auto">
                 <button type="submit" class="btn btn-primary">Send Invite</button>
             </div>
@@ -19,46 +27,76 @@
     </div>
 </div>
 
+{% set pending_users = users | selectattr('invite_token') | list %}
+
 <div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th class="d-none d-sm-table-cell">Initials</th>
-                <th class="d-none d-md-table-cell">Email</th>
-                <th>Role</th>
-                <th>Status</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for user in users %}
-            <tr>
-                <td>{{ user.display_name }}</td>
-                <td class="d-none d-sm-table-cell"><span class="badge bg-secondary">{{ user.initials }}</span></td>
-                <td class="d-none d-md-table-cell">{{ user.email }}</td>
-                <td>{{ "Admin" if user.is_admin else "Crew" }}</td>
-                <td>
-                    {% if user.invite_token %}
-                    <span class="badge bg-warning">Pending</span>
-                    {% else %}
-                    <span class="badge bg-success">Active</span>
+    <form id="resendForm" method="POST" action="{{ url_for('auth.resend_invites') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <table class="table">
+            <thead>
+                <tr>
+                    {% if email_configured and pending_users %}
+                    <th class="text-center" style="width: 40px;">
+                        <input type="checkbox" id="selectAllPending" class="form-check-input">
+                    </th>
                     {% endif %}
-                </td>
-                <td>
-                    <div class="d-flex flex-wrap gap-1">
-                        <a href="{{ url_for('auth.edit_user', user_id=user.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
-                        {% if user.id != current_user.id %}
-                        <form method="POST" action="{{ url_for('auth.delete_user', user_id=user.id) }}" class="d-inline" onsubmit="return confirm('Delete {{ user.display_name }}?')">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
-                        </form>
+                    <th>Name</th>
+                    <th class="d-none d-sm-table-cell">Initials</th>
+                    <th class="d-none d-md-table-cell">Email</th>
+                    <th>Role</th>
+                    <th>Status</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in users %}
+                <tr>
+                    {% if email_configured and pending_users %}
+                    <td class="text-center">
+                        {% if user.invite_token %}
+                        <input type="checkbox" name="user_ids" value="{{ user.id }}" class="form-check-input pending-checkbox">
                         {% endif %}
-                    </div>
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+                    </td>
+                    {% endif %}
+                    <td>{{ user.display_name }}</td>
+                    <td class="d-none d-sm-table-cell"><span class="badge bg-secondary">{{ user.initials }}</span></td>
+                    <td class="d-none d-md-table-cell">{{ user.email }}</td>
+                    <td>{{ "Admin" if user.is_admin else "Crew" }}</td>
+                    <td>
+                        {% if user.invite_token %}
+                        <span class="badge bg-warning">Pending</span>
+                        {% else %}
+                        <span class="badge bg-success">Active</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        <div class="d-flex flex-wrap gap-1">
+                            <a href="{{ url_for('auth.edit_user', user_id=user.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                            {% if user.id != current_user.id %}
+                            <form method="POST" action="{{ url_for('auth.delete_user', user_id=user.id) }}" class="d-inline" onsubmit="return confirm('Delete {{ user.display_name }}?')">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                            </form>
+                            {% endif %}
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% if email_configured and pending_users %}
+        <button type="submit" class="btn btn-outline-primary" id="resendBtn">Resend Invites</button>
+        {% endif %}
+    </form>
 </div>
+
+{% if email_configured and pending_users %}
+<script>
+document.getElementById('selectAllPending').addEventListener('change', function() {
+    document.querySelectorAll('.pending-checkbox').forEach(function(cb) {
+        cb.checked = this.checked;
+    }.bind(this));
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/migrations/versions/1f34ac0f8204_add_email_opt_in_to_users.py
+++ b/migrations/versions/1f34ac0f8204_add_email_opt_in_to_users.py
@@ -5,22 +5,29 @@ Revises: c3d4e5f6a7b8
 Create Date: 2026-03-08 13:05:00.237007
 
 """
-from alembic import op
-import sqlalchemy as sa
 
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '1f34ac0f8204'
-down_revision = 'c3d4e5f6a7b8'
+revision = "1f34ac0f8204"
+down_revision = "c3d4e5f6a7b8"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    with op.batch_alter_table('users', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('email_opt_in', sa.Boolean(), nullable=False, server_default=sa.text('1')))
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "email_opt_in",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("1"),
+            )
+        )
 
 
 def downgrade():
-    with op.batch_alter_table('users', schema=None) as batch_op:
-        batch_op.drop_column('email_opt_in')
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.drop_column("email_opt_in")

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -1,0 +1,203 @@
+"""Tests for auth routes — invite email and resend invites."""
+
+from unittest.mock import patch
+
+from app.models import SiteSetting, User
+
+
+def _configure_email(db):
+    """Insert a SiteSetting so is_email_configured() returns True."""
+    db.session.add(SiteSetting(key="ses_sender", value="noreply@racecrew.net"))
+    db.session.commit()
+
+
+class TestInviteUser:
+    def test_invite_creates_user(self, logged_in_client, db):
+        resp = logged_in_client.post(
+            "/admin/users/invite",
+            data={"email": "new@example.com"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        user = User.query.filter_by(email="new@example.com").first()
+        assert user is not None
+        assert user.invite_token is not None
+        assert b"Invite link:" in resp.data
+
+    @patch("app.auth.routes.send_email")
+    def test_invite_with_email_sends_email(self, mock_send, logged_in_client, db):
+        _configure_email(db)
+        resp = logged_in_client.post(
+            "/admin/users/invite",
+            data={"email": "new@example.com", "send_email_invite": "on"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        mock_send.assert_called_once()
+        assert b"Invite email sent to new@example.com" in resp.data
+
+    @patch("app.auth.routes.send_email")
+    def test_invite_without_email_checkbox(self, mock_send, logged_in_client, db):
+        _configure_email(db)
+        resp = logged_in_client.post(
+            "/admin/users/invite",
+            data={"email": "new@example.com"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        mock_send.assert_not_called()
+        assert b"Invite link:" in resp.data
+
+    @patch(
+        "app.auth.routes.send_email",
+        side_effect=Exception("SES error"),
+    )
+    def test_invite_email_failure_still_creates_user(
+        self, mock_send, logged_in_client, db
+    ):
+        _configure_email(db)
+        resp = logged_in_client.post(
+            "/admin/users/invite",
+            data={"email": "new@example.com", "send_email_invite": "on"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        user = User.query.filter_by(email="new@example.com").first()
+        assert user is not None
+        assert b"Failed to send invite email" in resp.data
+        assert b"Invite link:" in resp.data
+
+
+class TestResendInvites:
+    @patch("app.auth.routes.send_email")
+    def test_resend_sends_emails(self, mock_send, logged_in_client, db):
+        _configure_email(db)
+        u1 = User(
+            email="p1@test.com",
+            password_hash="pending",
+            display_name="P1",
+            initials="P1",
+            invite_token="tok1",
+        )
+        u2 = User(
+            email="p2@test.com",
+            password_hash="pending",
+            display_name="P2",
+            initials="P2",
+            invite_token="tok2",
+        )
+        db.session.add_all([u1, u2])
+        db.session.commit()
+
+        resp = logged_in_client.post(
+            "/admin/users/resend-invites",
+            data={"user_ids": [str(u1.id), str(u2.id)]},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert mock_send.call_count == 2
+        assert b"Invite emails sent to 2 user(s)" in resp.data
+
+    @patch("app.auth.routes.send_email")
+    def test_resend_skips_active_users(self, mock_send, logged_in_client, db):
+        _configure_email(db)
+        active = User(
+            email="active@test.com",
+            password_hash="hashed",
+            display_name="Active",
+            initials="AC",
+            invite_token=None,
+        )
+        db.session.add(active)
+        db.session.commit()
+
+        resp = logged_in_client.post(
+            "/admin/users/resend-invites",
+            data={"user_ids": [str(active.id)]},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        mock_send.assert_not_called()
+        assert b"No pending users in selection" in resp.data
+
+    def test_resend_no_selection(self, logged_in_client, db):
+        _configure_email(db)
+        resp = logged_in_client.post(
+            "/admin/users/resend-invites",
+            data={},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert b"No users selected" in resp.data
+
+    def test_resend_email_not_configured(self, logged_in_client, db):
+        resp = logged_in_client.post(
+            "/admin/users/resend-invites",
+            data={"user_ids": ["1"]},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert b"Email is not configured" in resp.data
+
+    def test_resend_requires_admin(self, app, client, db):
+        crew = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+            is_admin=False,
+        )
+        crew.set_password("password")
+        db.session.add(crew)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.post(
+            "/admin/users/resend-invites",
+            data={"user_ids": ["1"]},
+            follow_redirects=True,
+        )
+        assert b"Access denied" in resp.data
+
+    def test_resend_requires_login(self, client):
+        resp = client.post("/admin/users/resend-invites")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+
+class TestAdminUsersPage:
+    def test_shows_email_ui_when_configured(self, logged_in_client, db):
+        _configure_email(db)
+        pending = User(
+            email="pending@test.com",
+            password_hash="pending",
+            display_name="Pending",
+            initials="PE",
+            invite_token="tok123",
+        )
+        db.session.add(pending)
+        db.session.commit()
+
+        resp = logged_in_client.get("/admin/users")
+        assert resp.status_code == 200
+        assert b"send_email_invite" in resp.data
+        assert b"Resend Invites" in resp.data
+
+    def test_hides_email_ui_when_not_configured(self, logged_in_client, db):
+        pending = User(
+            email="pending@test.com",
+            password_hash="pending",
+            display_name="Pending",
+            initials="PE",
+            invite_token="tok123",
+        )
+        db.session.add(pending)
+        db.session.commit()
+
+        resp = logged_in_client.get("/admin/users")
+        assert resp.status_code == 200
+        assert b"send_email_invite" not in resp.data
+        assert b"Resend Invites" not in resp.data

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -97,7 +97,7 @@ class TestSendEmail:
 
         mock_client.send_raw_email.assert_called_once()
         call_kwargs = mock_client.send_raw_email.call_args[1]
-        assert call_kwargs["Source"] == "from@example.com"
+        assert call_kwargs["Source"] == "Race Crew Network <from@example.com>"
         assert call_kwargs["Destinations"] == ["to@example.com"]
         raw_data = call_kwargs["RawMessage"]["Data"]
         assert "List-Unsubscribe:" in raw_data
@@ -116,7 +116,9 @@ class TestSendEmail:
 
         send_email("to@example.com", "Subject", "Text body", body_html="<p>HTML</p>")
 
-        raw_data = mock_client.send_raw_email.call_args[1]["RawMessage"]["Data"]
+        call_kwargs = mock_client.send_raw_email.call_args[1]
+        assert call_kwargs["Source"] == "Race Crew Network <from@example.com>"
+        raw_data = call_kwargs["RawMessage"]["Data"]
         # HTML body is base64-encoded in the MIME message; decode to verify
         assert "text/html" in raw_data
         # Extract and decode the base64 HTML part


### PR DESCRIPTION
## Summary
- Personalize invite email body with inviter's name ("{name}'s crew on Race Crew Network")
- Set From display name to "Race Crew Network" on all outgoing SES emails
- Add email invite option with checkbox, bulk resend, and admin_users template updates
- Bump version to 0.44.1

## Test plan
- [x] `pytest` — 172 tests pass (1 pre-existing GA test failure unrelated)
- [x] `black . && isort . && flake8` — clean
- [ ] Manual: invite a user with email enabled, verify From shows "Race Crew Network" and body includes inviter name

🤖 Generated with [Claude Code](https://claude.com/claude-code)