### PR TITLE
Add multi-user skipper/crew model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ A simple web app for organizing sailboat regattas. Track dates, locations, NOR/S
 
 ## Features
 
-- Single-page regatta table sorted by date
+- **Multi-user roles**: Admin (site-wide), Skipper (owns schedule + crew), Crew (views + RSVPs)
+- Single-page regatta table sorted by date, scoped to user's visible regattas
+- Skippers manage their own crew and import their own regatta schedule
+- Crew members see their skippers' regattas with skipper filter dropdown
 - Location links to Google Maps
 - Upload/download NOR and SI PDFs (stored in S3)
 - Crew RSVP (Yes / No / Maybe) with color-coded initials
 - AI-powered schedule import: paste text or URL, Claude extracts regattas for review and bulk import, with auto-discovery of NOR/SI/WWW documents from regatta detail pages and regatta websites (including clubspot Parse API integration)
-- Admin: add/edit/delete regattas, upload documents, invite crew, import schedules
-- Crew: view schedule, download docs, set RSVP
+- Admin: manage all users, site settings, invite skippers
+- Skipper: add/edit/delete own regattas, upload documents, invite crew, import schedules
+- Crew: view skipper's schedule, download docs, set RSVP
 - Invite-based registration (no public sign-up)
 
 ## Tech Stack

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,19 @@
 # Version History
 
+## 0.45.0
+- Multi-user skipper/crew model with three roles: Admin, Skipper, Crew
+- Skippers own their regatta schedule and can import regattas
+- Skippers invite and manage their own crew via "My Crew" page
+- Crew members see only their skippers' regattas and can RSVP
+- Admins see all regattas across all skippers
+- Role-aware navbar: Skippers see "My Crew" + "Import"; Admins see "Users" + "Admin"
+- Skipper filter dropdown on home page for users with multiple skippers
+- Scoped regatta visibility in iCal feeds and PDF export
+- Permission-based access control for regatta CRUD, imports, and RSVP
+- New `skipper_crew` association table and `is_skipper`/`invited_by` fields on User
+- Registration auto-links new users to their inviting skipper's crew
+- Admin can mark invitees as Skippers and toggle `is_skipper` on user edit
+
 ## 0.44.1
 - Personalize invite email body with inviter's name ("{name}'s crew")
 - Set From display name to "Race Crew Network" on all outgoing emails

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.44.1"
+__version__ = "0.45.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -62,6 +62,14 @@ def _require_admin():
     return None
 
 
+def _require_skipper_or_admin():
+    """Return a redirect response if the user is not a skipper or admin."""
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+    return None
+
+
 def _normalize_regatta_name(name: str) -> str:
     """Strip 4-digit year prefixes from each segment of a regatta name.
 
@@ -73,14 +81,20 @@ def _normalize_regatta_name(name: str) -> str:
     return "/".join(cleaned)
 
 
-def _find_duplicate(name: str, start_date) -> Regatta | None:
+def _find_duplicate(
+    name: str, start_date, owner_id: int | None = None
+) -> Regatta | None:
     """Find an existing regatta with the same name and start date.
 
     Compares with leading year prefixes stripped so that
     "2026 Orange Peel Regatta" matches "Orange Peel Regatta".
+    When *owner_id* is given, only check that owner's regattas.
     """
     normalized = _normalize_regatta_name(name).lower()
-    candidates = Regatta.query.filter(Regatta.start_date == start_date).all()
+    query = Regatta.query.filter(Regatta.start_date == start_date)
+    if owner_id is not None:
+        query = query.filter(Regatta.created_by == owner_id)
+    candidates = query.all()
     for r in candidates:
         if _normalize_regatta_name(r.name).lower() == normalized:
             return r
@@ -363,7 +377,7 @@ def _extract_jsonld_events(html: str) -> str:
 @bp.route("/admin/import-url")
 @login_required
 def import_url():
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
     prefill_url = request.args.get("url", "")
@@ -378,7 +392,7 @@ def import_url():
 @bp.route("/admin/import-file")
 @login_required
 def import_file():
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
     return render_template("admin/import_file.html", current_year=date.today().year)
@@ -408,7 +422,7 @@ def import_multiple():
 @bp.route("/admin/import-paste")
 @login_required
 def import_paste():
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
     return render_template("admin/import_paste.html")
@@ -504,7 +518,7 @@ def email_test():
 @login_required
 def import_schedule_extract():
     """SSE endpoint that streams extraction progress."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -514,6 +528,7 @@ def import_schedule_extract():
     current_year = date.today().year
     year = int(request.form.get("year", current_year))
     task_id = str(uuid.uuid4())
+    user_id = current_user.id
 
     def _sse(event: dict) -> str:
         return f"data: {json.dumps(event)}\n\n"
@@ -636,7 +651,9 @@ def import_schedule_extract():
             start = r.get("start_date")
             name = r.get("name")
             if name and start:
-                existing = _find_duplicate(name, date.fromisoformat(start))
+                existing = _find_duplicate(
+                    name, date.fromisoformat(start), owner_id=user_id
+                )
                 if existing:
                     dup_count += 1
                     r["duplicate_of"] = {
@@ -687,7 +704,7 @@ def import_schedule_extract():
 @login_required
 def import_schedule_extract_file():
     """SSE endpoint that streams extraction progress for an uploaded file."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -696,6 +713,7 @@ def import_schedule_extract_file():
     current_year = date.today().year
     year = int(request.form.get("year", current_year))
     task_id = str(uuid.uuid4())
+    user_id = current_user.id
 
     def _sse(event: dict) -> str:
         return f"data: {json.dumps(event)}\n\n"
@@ -814,7 +832,9 @@ def import_schedule_extract_file():
             start = r.get("start_date")
             name = r.get("name")
             if name and start:
-                existing = _find_duplicate(name, date.fromisoformat(start))
+                existing = _find_duplicate(
+                    name, date.fromisoformat(start), owner_id=user_id
+                )
                 if existing:
                     dup_count += 1
                     r["duplicate_of"] = {
@@ -863,7 +883,7 @@ def import_schedule_extract_file():
 @login_required
 def import_schedule_extract_single():
     """SSE endpoint: extract a single regatta (no document discovery)."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -872,6 +892,7 @@ def import_schedule_extract_single():
     current_year = date.today().year
     year = int(request.form.get("year", current_year))
     task_id = str(uuid.uuid4())
+    user_id = current_user.id
 
     def _sse(event: dict) -> str:
         return f"data: {json.dumps(event)}\n\n"
@@ -966,7 +987,9 @@ def import_schedule_extract_single():
         start = r.get("start_date")
         name = r.get("name")
         if name and start:
-            existing = _find_duplicate(name, date.fromisoformat(start))
+            existing = _find_duplicate(
+                name, date.fromisoformat(start), owner_id=user_id
+            )
             if existing:
                 r["duplicate_of"] = {
                     "id": existing.id,
@@ -1011,7 +1034,7 @@ def import_schedule_extract_single():
 @login_required
 def import_single_preview():
     """Render single regatta editable preview from extraction results."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -1031,7 +1054,7 @@ def import_single_preview():
 @login_required
 def import_schedule_preview():
     """Render extraction results from SSE extraction."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -1070,7 +1093,7 @@ def import_schedule_preview():
 @bp.route("/admin/import-schedule/confirm", methods=["POST"])
 @login_required
 def import_schedule_confirm():
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -1107,8 +1130,8 @@ def import_schedule_confirm():
             skipped += 1
             continue
 
-        # Duplicate check: case-insensitive name + start_date
-        existing = _find_duplicate(name, start_date)
+        # Duplicate check: case-insensitive name + start_date (scoped to user)
+        existing = _find_duplicate(name, start_date, owner_id=current_user.id)
         if existing:
             skipped += 1
             continue
@@ -1174,7 +1197,7 @@ def import_schedule_confirm():
 @bp.route("/admin/import-schedule/discover", methods=["POST"])
 @login_required
 def import_schedule_discover():
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -1379,7 +1402,7 @@ def import_schedule_discover():
 @bp.route("/admin/import-schedule/documents")
 @login_required
 def import_schedule_documents():
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -1402,7 +1425,7 @@ def import_schedule_documents():
 @login_required
 def discover_documents_for_regatta(regatta_id: int):
     """SSE endpoint: discover NOR/SI/WWW documents for an existing regatta."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -1547,7 +1570,7 @@ def discover_documents_for_regatta(regatta_id: int):
 @login_required
 def review_documents_for_regatta(regatta_id: int):
     """Show discovered documents with checkboxes for an existing regatta."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 
@@ -1577,7 +1600,7 @@ def review_documents_for_regatta(regatta_id: int):
 @login_required
 def attach_documents_for_regatta(regatta_id: int):
     """Create Document records for selected discovered documents."""
-    denied = _require_admin()
+    denied = _require_skipper_or_admin()
     if denied:
         return denied
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,4 +1,5 @@
 import logging
+import secrets
 
 from flask import flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required, login_user, logout_user
@@ -6,7 +7,7 @@ from flask_login import current_user, login_required, login_user, logout_user
 from app import db
 from app.admin.email_service import is_email_configured, send_email
 from app.auth import bp
-from app.models import User
+from app.models import Document, Regatta, RSVP, User, skipper_crew
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +69,8 @@ def register(token: str):
 
         if not display_name or not initials:
             flash("Name and initials are required.", "error")
-        elif len(initials) < 2 or len(initials) > 3:
-            flash("Initials must be 2-3 characters.", "error")
+        elif len(initials) < 2 or len(initials) > 3 or not initials.isalnum():
+            flash("Initials must be 2-3 letters or numbers.", "error")
         elif len(password) < 6:
             flash("Password must be at least 6 characters.", "error")
         elif password != password2:
@@ -79,6 +80,14 @@ def register(token: str):
             user.initials = initials
             user.set_password(password)
             user.invite_token = None  # Mark registration complete
+
+            # Auto-link to inviting skipper's crew
+            if user.invited_by:
+                inviter = db.session.get(User, user.invited_by)
+                if inviter and inviter.is_skipper:
+                    if user not in inviter.crew_members.all():
+                        inviter.crew_members.append(user)
+
             db.session.commit()
             login_user(user)
             flash("Welcome aboard!", "success")
@@ -99,8 +108,8 @@ def profile():
 
         if not display_name or not initials or not email:
             flash("Name, initials, and email are required.", "error")
-        elif len(initials) < 2 or len(initials) > 3:
-            flash("Initials must be 2-3 characters.", "error")
+        elif len(initials) < 2 or len(initials) > 3 or not initials.isalnum():
+            flash("Initials must be 2-3 letters or numbers.", "error")
         elif email != current_user.email and User.query.filter_by(email=email).first():
             flash("That email is already in use.", "error")
         elif password and len(password) < 6:
@@ -132,6 +141,11 @@ def view_profile(user_id: int):
     return render_template("view_profile.html", user=user)
 
 
+# ---------------------------------------------------------------------------
+# Admin: user management
+# ---------------------------------------------------------------------------
+
+
 @bp.route("/admin/users")
 @login_required
 def admin_users():
@@ -154,8 +168,6 @@ def invite_user():
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
-    import secrets
-
     email = request.form.get("email", "").strip().lower()
     if not email:
         flash("Email is required.", "error")
@@ -165,6 +177,7 @@ def invite_user():
         flash("A user with that email already exists.", "error")
         return redirect(url_for("auth.admin_users"))
 
+    is_skipper = request.form.get("is_skipper") == "on"
     token = secrets.token_urlsafe(32)
     user = User(
         email=email,
@@ -172,6 +185,8 @@ def invite_user():
         display_name=email,
         initials="??",
         invite_token=token,
+        is_skipper=is_skipper,
+        invited_by=current_user.id,
     )
     db.session.add(user)
     db.session.commit()
@@ -250,24 +265,34 @@ def edit_user(user_id: int):
         initials = request.form.get("initials", "").strip().upper()
         email = request.form.get("email", "").strip().lower()
         is_admin = request.form.get("is_admin") == "on"
+        is_skipper = request.form.get("is_skipper") == "on"
         password = request.form.get("password", "")
+        registration_complete = request.form.get("registration_complete") == "on"
 
         if not display_name or not initials or not email:
             flash("Name, initials, and email are required.", "error")
-        elif len(initials) < 2 or len(initials) > 3:
-            flash("Initials must be 2-3 characters.", "error")
+        elif len(initials) < 2 or len(initials) > 3 or not initials.isalnum():
+            flash("Initials must be 2-3 letters or numbers.", "error")
         elif email != user.email and User.query.filter_by(email=email).first():
             flash("That email is already in use.", "error")
         elif password and len(password) < 6:
             flash("Password must be at least 6 characters.", "error")
+        elif registration_complete and not password:
+            flash(
+                "A password is required when marking registration complete.",
+                "error",
+            )
         else:
             user.display_name = display_name
             user.initials = initials
             user.email = email
             user.is_admin = is_admin
+            user.is_skipper = is_skipper
             user.phone = request.form.get("phone", "").strip() or None
             if password:
                 user.set_password(password)
+            if registration_complete and user.invite_token:
+                user.invite_token = None
             db.session.commit()
             flash(f"User '{display_name}' updated.", "success")
             return redirect(url_for("auth.admin_users"))
@@ -288,8 +313,156 @@ def delete_user(user_id: int):
     elif user.id == current_user.id:
         flash("You cannot delete yourself.", "error")
     else:
+        # Delete regattas created by this user (cascades their docs & RSVPs)
+        for regatta in Regatta.query.filter_by(created_by=user.id).all():
+            db.session.delete(regatta)
+        # Delete user's own RSVPs and uploaded documents
+        RSVP.query.filter_by(user_id=user.id).delete()
+        Document.query.filter_by(uploaded_by=user.id).delete()
+        # Clean up skipper_crew associations
+        db.session.execute(
+            skipper_crew.delete().where(
+                (skipper_crew.c.skipper_id == user.id)
+                | (skipper_crew.c.crew_id == user.id)
+            )
+        )
         db.session.delete(user)
         db.session.commit()
         flash(f"User {user.display_name} deleted.", "success")
 
     return redirect(url_for("auth.admin_users"))
+
+
+# ---------------------------------------------------------------------------
+# Skipper: crew management
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/create-schedule", methods=["POST"])
+@login_required
+def create_schedule():
+    if not current_user.is_skipper:
+        current_user.is_skipper = True
+        db.session.commit()
+        flash("Your schedule has been created!", "success")
+    return redirect(url_for("regattas.index"))
+
+
+@bp.route("/delete-schedule", methods=["POST"])
+@login_required
+def delete_schedule():
+    if current_user.is_admin:
+        flash("Admins cannot delete their schedule.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if not current_user.is_skipper:
+        flash("You don't have a schedule to delete.", "error")
+        return redirect(url_for("regattas.index"))
+
+    # Delete all regattas created by this user (cascades their docs & RSVPs)
+    for regatta in Regatta.query.filter_by(created_by=current_user.id).all():
+        db.session.delete(regatta)
+
+    # Delete any remaining RSVPs/documents owned by this user on other regattas
+    RSVP.query.filter_by(user_id=current_user.id).delete()
+    Document.query.filter_by(uploaded_by=current_user.id).delete()
+
+    # Unlink crew members
+    db.session.execute(
+        skipper_crew.delete().where(skipper_crew.c.skipper_id == current_user.id)
+    )
+
+    current_user.is_skipper = False
+    db.session.commit()
+    flash("Your schedule has been deleted.", "success")
+    return redirect(url_for("regattas.index"))
+
+
+@bp.route("/my-crew")
+@login_required
+def my_crew():
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    crew = current_user.crew_members.order_by(User.display_name).all()
+    return render_template(
+        "my_crew.html",
+        crew=crew,
+        email_configured=is_email_configured(),
+    )
+
+
+@bp.route("/my-crew/invite", methods=["POST"])
+@login_required
+def invite_crew():
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    email = request.form.get("email", "").strip().lower()
+    if not email:
+        flash("Email is required.", "error")
+        return redirect(url_for("auth.my_crew"))
+
+    existing_user = User.query.filter_by(email=email).first()
+    if existing_user:
+        # User already exists — just add to crew if not already
+        if existing_user in current_user.crew_members.all():
+            flash(f"{existing_user.display_name} is already on your crew.", "warning")
+        else:
+            current_user.crew_members.append(existing_user)
+            db.session.commit()
+            flash(f"{existing_user.display_name} added to your crew.", "success")
+        return redirect(url_for("auth.my_crew"))
+
+    # Create new invited user
+    token = secrets.token_urlsafe(32)
+    user = User(
+        email=email,
+        password_hash="pending",
+        display_name=email,
+        initials="??",
+        invite_token=token,
+        invited_by=current_user.id,
+    )
+    db.session.add(user)
+    db.session.flush()
+    current_user.crew_members.append(user)
+    db.session.commit()
+
+    invite_url = url_for("auth.register", token=token, _external=True)
+
+    send_email_invite = request.form.get("send_email_invite") == "on"
+    if send_email_invite and is_email_configured():
+        try:
+            _send_invite_email(email, invite_url, current_user.display_name)
+            flash(f"Invite email sent to {email}.", "success")
+        except Exception:
+            logger.exception("Failed to send invite email to %s", email)
+            flash("Failed to send invite email. Copy the link below.", "error")
+            flash(f"Invite link: {invite_url}", "success")
+    else:
+        flash(f"Invite link: {invite_url}", "success")
+
+    return redirect(url_for("auth.my_crew"))
+
+
+@bp.route("/my-crew/<int:user_id>/remove", methods=["POST"])
+@login_required
+def remove_crew(user_id: int):
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    user = db.session.get(User, user_id)
+    if not user:
+        flash("User not found.", "error")
+    elif user not in current_user.crew_members.all():
+        flash("That user is not on your crew.", "warning")
+    else:
+        current_user.crew_members.remove(user)
+        db.session.commit()
+        flash(f"{user.display_name} removed from your crew.", "success")
+
+    return redirect(url_for("auth.my_crew"))

--- a/app/calendar/routes.py
+++ b/app/calendar/routes.py
@@ -43,7 +43,7 @@ def ical_feed(token: str):
     cal.add("x-wr-calname", "Race Crew Network")
     cal.add("method", "PUBLISH")
 
-    regattas = Regatta.query.order_by(Regatta.start_date).all()
+    regattas = user.visible_regattas().order_by(Regatta.start_date).all()
 
     for regatta in regattas:
         event = Event()

--- a/app/commands.py
+++ b/app/commands.py
@@ -29,6 +29,7 @@ def register_commands(app: Flask) -> None:
             display_name="Administrator",
             initials="AD",
             is_admin=True,
+            is_skipper=True,
         )
         user.set_password(password)
         db.session.add(user)
@@ -51,6 +52,7 @@ def register_commands(app: Flask) -> None:
             display_name=name,
             initials=initials.upper(),
             is_admin=True,
+            is_skipper=True,
         )
         user.set_password(password)
         db.session.add(user)

--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,22 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import bcrypt
 from flask_login import UserMixin
 
 from app import db, login_manager
+
+# Self-referential many-to-many: skipper <-> crew
+skipper_crew = db.Table(
+    "skipper_crew",
+    db.Column("skipper_id", db.Integer, db.ForeignKey("users.id"), primary_key=True),
+    db.Column("crew_id", db.Integer, db.ForeignKey("users.id"), primary_key=True),
+    db.Column(
+        "created_at",
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    ),
+)
 
 
 class User(UserMixin, db.Model):
@@ -15,6 +28,8 @@ class User(UserMixin, db.Model):
     display_name = db.Column(db.String(100), nullable=False)
     initials = db.Column(db.String(5), nullable=False)
     is_admin = db.Column(db.Boolean, default=False, nullable=False)
+    is_skipper = db.Column(db.Boolean, default=False, nullable=False)
+    invited_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     created_at = db.Column(
         db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
     )
@@ -29,6 +44,19 @@ class User(UserMixin, db.Model):
     rsvps = db.relationship("RSVP", backref="user", lazy="dynamic")
     documents = db.relationship("Document", backref="uploaded_by_user", lazy="dynamic")
 
+    # Skipper -> their crew members
+    crew_members = db.relationship(
+        "User",
+        secondary=skipper_crew,
+        primaryjoin=id == skipper_crew.c.skipper_id,
+        secondaryjoin=id == skipper_crew.c.crew_id,
+        backref="skippers",
+        lazy="dynamic",
+    )
+
+    # Who invited this user
+    inviter = db.relationship("User", remote_side=[id], foreign_keys=[invited_by])
+
     def set_password(self, password: str) -> None:
         self.password_hash = bcrypt.hashpw(
             password.encode("utf-8"), bcrypt.gensalt()
@@ -38,6 +66,48 @@ class User(UserMixin, db.Model):
         return bcrypt.checkpw(
             password.encode("utf-8"), self.password_hash.encode("utf-8")
         )
+
+    @property
+    def is_crew(self) -> bool:
+        """True if this user is crew for at least one skipper."""
+        return len(self.skippers) > 0
+
+    def visible_regattas(self):
+        """Return a query of regattas this user can see.
+
+        - Admin: all regattas
+        - Skipper: their own regattas
+        - Crew: regattas from their skippers
+        - Skipper+Crew: union of own + skippers' regattas
+        """
+        if self.is_admin:
+            return Regatta.query
+
+        owner_ids = set()
+        if self.is_skipper:
+            owner_ids.add(self.id)
+        for skipper in self.skippers:
+            owner_ids.add(skipper.id)
+
+        if not owner_ids:
+            # User has no role — return empty query
+            return Regatta.query.filter(Regatta.id < 0)
+
+        return Regatta.query.filter(Regatta.created_by.in_(owner_ids))
+
+    def visible_regattas_split(self):
+        """Return (upcoming, past) tuples of visible regattas."""
+        today = date.today()
+        base = self.visible_regattas()
+        upcoming = (
+            base.filter(Regatta.start_date >= today).order_by(Regatta.start_date).all()
+        )
+        past = (
+            base.filter(Regatta.start_date < today)
+            .order_by(Regatta.start_date.desc())
+            .all()
+        )
+        return upcoming, past
 
 
 @login_manager.user_loader

--- a/app/permissions.py
+++ b/app/permissions.py
@@ -1,0 +1,55 @@
+"""Role-based permission decorators and helpers."""
+
+from functools import wraps
+
+from flask import flash, redirect, url_for
+from flask_login import current_user
+
+
+def require_admin(f):
+    """Decorator: deny access unless current_user is admin."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not current_user.is_admin:
+            flash("Access denied.", "error")
+            return redirect(url_for("regattas.index"))
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def require_skipper(f):
+    """Decorator: deny access unless current_user is skipper or admin."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not (current_user.is_admin or current_user.is_skipper):
+            flash("Access denied.", "error")
+            return redirect(url_for("regattas.index"))
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def can_manage_regatta(user, regatta) -> bool:
+    """True if user can edit/delete this regatta (owner or admin)."""
+    if user.is_admin:
+        return True
+    return user.is_skipper and regatta.created_by == user.id
+
+
+def can_rsvp_to_regatta(user, regatta) -> bool:
+    """True if user can RSVP to this regatta.
+
+    Allowed for: admin, regatta owner, crew of the regatta owner.
+    """
+    if user.is_admin:
+        return True
+    if regatta.created_by == user.id:
+        return True
+    # Check if user is crew of the regatta creator
+    creator = regatta.creator
+    if creator and user in creator.crew_members.all():
+        return True
+    return False

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -10,6 +10,7 @@ from weasyprint import HTML
 
 from app import db, storage
 from app.models import RSVP, Document, Regatta, User
+from app.permissions import can_manage_regatta, can_rsvp_to_regatta
 from app.regattas import bp
 
 
@@ -18,42 +19,48 @@ def index():
     if not current_user.is_authenticated:
         return render_template("login.html")
 
-    today = date.today()
-    upcoming = (
-        Regatta.query.filter(Regatta.start_date >= today)
-        .order_by(Regatta.start_date)
-        .all()
-    )
-    past = (
-        Regatta.query.filter(Regatta.start_date < today)
-        .order_by(Regatta.start_date.desc())
-        .all()
-    )
+    upcoming, past = current_user.visible_regattas_split()
+
+    # Optional skipper filter
+    skipper_id = request.args.get("skipper", type=int)
+    if skipper_id:
+        upcoming = [r for r in upcoming if r.created_by == skipper_id]
+        past = [r for r in past if r.created_by == skipper_id]
+
     users = (
         User.query.filter(User.invite_token.is_(None)).order_by(User.display_name).all()
     )
-    return render_template("index.html", upcoming=upcoming, past=past, users=users)
+
+    # Build skipper list for filter dropdown (skippers whose regattas are visible)
+    skippers = []
+    if current_user.is_admin:
+        skippers = (
+            User.query.filter(User.is_skipper.is_(True))
+            .order_by(User.display_name)
+            .all()
+        )
+    elif current_user.is_crew:
+        skippers = list(current_user.skippers)
+
+    return render_template(
+        "index.html",
+        upcoming=upcoming,
+        past=past,
+        users=users,
+        skippers=skippers,
+        selected_skipper=skipper_id,
+    )
 
 
 @bp.route("/schedule.pdf")
 @login_required
 def pdf():
-    today = date.today()
-    upcoming = (
-        Regatta.query.filter(Regatta.start_date >= today)
-        .order_by(Regatta.start_date)
-        .all()
-    )
-    past = (
-        Regatta.query.filter(Regatta.start_date < today)
-        .order_by(Regatta.start_date.desc())
-        .all()
-    )
+    upcoming, past = current_user.visible_regattas_split()
     html_str = render_template(
         "pdf_schedule.html",
         upcoming=upcoming,
         past=past,
-        generated_date=today.strftime("%B %d, %Y"),
+        generated_date=date.today().strftime("%B %d, %Y"),
     )
     pdf_bytes = HTML(string=html_str).write_pdf()
     response = make_response(pdf_bytes)
@@ -65,7 +72,7 @@ def pdf():
 @bp.route("/regattas/new", methods=["GET", "POST"])
 @login_required
 def create():
-    if not current_user.is_admin:
+    if not (current_user.is_admin or current_user.is_skipper):
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
@@ -78,13 +85,13 @@ def create():
 @bp.route("/regattas/<int:regatta_id>/edit", methods=["GET", "POST"])
 @login_required
 def edit(regatta_id: int):
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
-
     regatta = db.session.get(Regatta, regatta_id)
     if not regatta:
         flash("Regatta not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if not can_manage_regatta(current_user, regatta):
+        flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
     if request.method == "POST":
@@ -96,11 +103,14 @@ def edit(regatta_id: int):
 @bp.route("/regattas/<int:regatta_id>/delete", methods=["POST"])
 @login_required
 def delete(regatta_id: int):
-    if not current_user.is_admin:
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta:
+        return redirect(url_for("regattas.index"))
+
+    if not can_manage_regatta(current_user, regatta):
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
-    regatta = db.session.get(Regatta, regatta_id)
     if regatta:
         db.session.delete(regatta)
         db.session.commit()
@@ -111,7 +121,7 @@ def delete(regatta_id: int):
 @bp.route("/regattas/bulk-delete", methods=["POST"])
 @login_required
 def bulk_delete():
-    if not current_user.is_admin:
+    if not (current_user.is_admin or current_user.is_skipper):
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
@@ -127,7 +137,7 @@ def bulk_delete():
         except (ValueError, TypeError):
             continue
         regatta = db.session.get(Regatta, rid)
-        if regatta:
+        if regatta and can_manage_regatta(current_user, regatta):
             db.session.delete(regatta)
             count += 1
 
@@ -142,6 +152,11 @@ def rsvp(regatta_id: int):
     status = request.form.get("status", "").lower()
     if status not in ("yes", "no", "maybe"):
         flash("Invalid RSVP status.", "error")
+        return redirect(url_for("regattas.index"))
+
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta or not can_rsvp_to_regatta(current_user, regatta):
+        flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
     existing = RSVP.query.filter_by(
@@ -176,12 +191,12 @@ def download_doc(doc_id: int):
 @bp.route("/regattas/<int:regatta_id>/upload", methods=["POST"])
 @login_required
 def upload_doc(regatta_id: int):
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
-
     regatta = db.session.get(Regatta, regatta_id)
     if not regatta:
+        flash("Regatta not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if not can_manage_regatta(current_user, regatta):
         flash("Regatta not found.", "error")
         return redirect(url_for("regattas.index"))
 
@@ -226,13 +241,14 @@ def upload_doc(regatta_id: int):
 @bp.route("/docs/<int:doc_id>/delete", methods=["POST"])
 @login_required
 def delete_doc(doc_id: int):
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
-
     doc = db.session.get(Document, doc_id)
     if not doc:
         flash("Document not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    regatta = db.session.get(Regatta, doc.regatta_id)
+    if regatta and not can_manage_regatta(current_user, regatta):
+        flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
     regatta_id = doc.regatta_id

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -1,16 +1,22 @@
 {% extends "base.html" %}
-{% block title %}Manage Crew — Race Crew Network{% endblock %}
+{% block title %}Manage Users — Race Crew Network{% endblock %}
 {% block content %}
-<h2 class="mb-4">Manage Crew</h2>
+<h2 class="mb-4">Manage Users</h2>
 
 <div class="card mb-4">
     <div class="card-body">
-        <h5 class="card-title">Invite New Crew Member</h5>
+        <h5 class="card-title">Invite New User</h5>
         <form method="POST" action="{{ url_for('auth.invite_user') }}" class="row g-2 align-items-end">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="col-12 col-sm">
                 <label for="email" class="form-label">Email</label>
                 <input type="email" class="form-control" id="email" name="email" required placeholder="crew@example.com">
+            </div>
+            <div class="col-12 col-sm-auto d-flex align-items-center">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="is_skipper" name="is_skipper">
+                    <label class="form-check-label" for="is_skipper">Skipper</label>
+                </div>
             </div>
             {% if email_configured %}
             <div class="col-12 col-sm-auto d-flex align-items-center">
@@ -61,7 +67,11 @@
                     <td>{{ user.display_name }}</td>
                     <td class="d-none d-sm-table-cell"><span class="badge bg-secondary">{{ user.initials }}</span></td>
                     <td class="d-none d-md-table-cell">{{ user.email }}</td>
-                    <td>{{ "Admin" if user.is_admin else "Crew" }}</td>
+                    <td>
+                        {% if user.is_admin %}Admin{% endif %}
+                        {% if user.is_skipper and not user.is_admin %}Skipper{% endif %}
+                        {% if not user.is_admin and not user.is_skipper %}Crew{% endif %}
+                    </td>
                     <td>
                         {% if user.invite_token %}
                         <span class="badge bg-warning">Pending</span>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -34,15 +34,8 @@
                 <div class="navbar-nav ms-auto align-items-center gap-2">
                     <a class="nav-link nav-pill-link" href="{{ url_for('regattas.index') }}">Home</a>
                     <a class="nav-link nav-pill-link" href="{{ url_for('calendar.subscribe') }}">iCal</a>
-                    {% if current_user.is_admin %}
-                    <a class="nav-link nav-pill-link" href="{{ url_for('auth.admin_users') }}">Crew</a>
-                    <li class="nav-item dropdown">
-                        <a class="nav-link nav-pill-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Admin</a>
-                        <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="{{ url_for('admin.analytics_settings') }}">Analytics Settings</a></li>
-                            <li><a class="dropdown-item" href="{{ url_for('admin.email_settings') }}">Email Settings</a></li>
-                        </ul>
-                    </li>
+                    {% if current_user.is_admin or current_user.is_skipper %}
+                    <a class="nav-link nav-pill-link" href="{{ url_for('auth.my_crew') }}">My Crew</a>
                     <li class="nav-item dropdown">
                         <a class="nav-link nav-pill-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Import</a>
                         <ul class="dropdown-menu">
@@ -52,10 +45,28 @@
                         </ul>
                     </li>
                     {% endif %}
+                    {% if current_user.is_admin %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link nav-pill-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Admin</a>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="{{ url_for('auth.admin_users') }}">Users</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('admin.analytics_settings') }}">Analytics Settings</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('admin.email_settings') }}">Email Settings</a></li>
+                        </ul>
+                    </li>
+                    {% endif %}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle nav-avatar" href="#" role="button" data-bs-toggle="dropdown">{{ current_user.initials }}</a>
                         <ul class="dropdown-menu dropdown-menu-end">
                             <li><a class="dropdown-item" href="{{ url_for('auth.profile') }}">Profile Settings</a></li>
+                            {% if not current_user.is_skipper and not current_user.is_admin %}
+                            <li>
+                                <form method="POST" action="{{ url_for('auth.create_schedule') }}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="dropdown-item">Create My Schedule</button>
+                                </form>
+                            </li>
+                            {% endif %}
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="{{ url_for('auth.logout') }}">Logout</a></li>
                         </ul>

--- a/app/templates/edit_user.html
+++ b/app/templates/edit_user.html
@@ -12,7 +12,7 @@
             </div>
             <div class="mb-3">
                 <label for="initials" class="form-label">Initials (2-3 characters)</label>
-                <input type="text" class="form-control" id="initials" name="initials" required maxlength="3" value="{{ user.initials }}" style="text-transform: uppercase;">
+                <input type="text" class="form-control" id="initials" name="initials" required maxlength="3" pattern="[A-Za-z0-9]{2,3}" title="2-3 letters or numbers" value="{{ user.initials }}" style="text-transform: uppercase;">
             </div>
             <div class="mb-3">
                 <label for="email" class="form-label">Email</label>
@@ -26,6 +26,17 @@
                 <input type="checkbox" class="form-check-input" id="is_admin" name="is_admin" {% if user.is_admin %}checked{% endif %}>
                 <label class="form-check-label" for="is_admin">Admin</label>
             </div>
+            <div class="mb-3 form-check">
+                <input type="checkbox" class="form-check-input" id="is_skipper" name="is_skipper" {% if user.is_skipper %}checked{% endif %}>
+                <label class="form-check-label" for="is_skipper">Skipper</label>
+            </div>
+            {% if user.invite_token %}
+            <div class="mb-3 form-check">
+                <input type="checkbox" class="form-check-input" id="registration_complete" name="registration_complete">
+                <label class="form-check-label" for="registration_complete">Registration complete</label>
+                <div class="form-text">Check this to activate the user without them completing the invite link. You must also set a password below.</div>
+            </div>
+            {% endif %}
             <hr>
             <p class="text-muted">Leave blank to keep current password.</p>
             <div class="mb-3">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,15 +1,45 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="mb-3 d-flex gap-2 btn-bar">
-    {% if current_user.is_admin %}
+<div class="mb-3 d-flex flex-wrap align-items-center">
+    <a href="{{ url_for('regattas.pdf') }}" class="btn btn-outline-secondary btn-sm no-print" target="_blank">Print PDF</a>
+    <div class="flex-grow-1 text-center">
+        {% if skippers|length == 1 %}
+        <h2 class="mb-0">{{ skippers[0].display_name }}'s Race Schedule</h2>
+        {% elif current_user.is_skipper %}
+        <h2 class="mb-0">{{ current_user.display_name }}'s Race Schedule</h2>
+        {% else %}
+        <h2 class="mb-0">Race Schedule</h2>
+        {% endif %}
+    </div>
+</div>
+
+<div class="mb-3 d-flex flex-wrap gap-2 btn-bar align-items-center">
+    {% if current_user.is_admin or current_user.is_skipper %}
     <a href="{{ url_for('regattas.create') }}" class="btn btn-primary btn-sm">+ Add Regatta</a>
     {% endif %}
-    <a href="{{ url_for('regattas.pdf') }}" class="btn btn-outline-secondary btn-sm no-print" target="_blank">Print PDF</a>
+    {% if current_user.is_skipper and not current_user.is_admin %}
+    <form method="POST" action="{{ url_for('auth.delete_schedule') }}" class="d-inline"
+          onsubmit="return confirm('This will delete all your regattas and remove your crew. Are you sure?')">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="btn btn-outline-danger btn-sm">Delete Schedule</button>
+    </form>
+    {% endif %}
+    {% if skippers|length > 1 %}
+    <form method="GET" class="d-inline-flex align-items-center ms-auto">
+        <select name="skipper" class="form-select form-select-sm" style="width:auto" onchange="this.form.submit()">
+            <option value="">All Skippers</option>
+            {% for s in skippers %}
+            <option value="{{ s.id }}" {% if selected_skipper == s.id %}selected{% endif %}>{{ s.display_name }}</option>
+            {% endfor %}
+        </select>
+    </form>
+    {% endif %}
 </div>
 
 {% macro regatta_table(regattas, is_past, table_id) %}
-{% if current_user.is_admin %}
+{% set can_manage = current_user.is_admin or current_user.is_skipper %}
+{% if can_manage %}
 <form method="POST" action="{{ url_for('regattas.bulk_delete') }}" id="{{ table_id }}-form" onsubmit="return confirmBulkDelete(this)">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 </form>
@@ -27,7 +57,7 @@
                 {% if not is_past %}
                 <th>Your RSVP</th>
                 {% endif %}
-                {% if current_user.is_admin %}
+                {% if can_manage %}
                 <th>Edit</th>
                 <th><input type="checkbox" class="select-all" data-table="{{ table_id }}"></th>
                 {% endif %}
@@ -78,7 +108,7 @@
                     </form>
                 </td>
                 {% endif %}
-                {% if current_user.is_admin %}
+                {% if can_manage %}
                 <td>
                     <a href="{{ url_for('regattas.edit', regatta_id=regatta.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
                 </td>
@@ -91,7 +121,7 @@
         </tbody>
     </table>
 </div>
-{% if current_user.is_admin %}
+{% if can_manage %}
 <div class="text-end regatta-table-desktop">
     <button type="submit" form="{{ table_id }}-form" class="btn btn-sm btn-outline-danger">Delete Selected</button>
 </div>
@@ -108,7 +138,7 @@
                     <span class="badge bg-secondary ms-1">{{ regatta.boat_class }}</span>
                     {% endif %}
                 </div>
-                {% if current_user.is_admin %}
+                {% if can_manage %}
                 <a href="{{ url_for('regattas.edit', regatta_id=regatta.id) }}" class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
                 {% endif %}
             </div>
@@ -159,7 +189,7 @@
 <h5>Upcoming</h5>
 {{ regatta_table(upcoming, false, "upcoming") }}
 {% else %}
-<p class="text-muted">No upcoming regattas. {% if current_user.is_admin %}Add one!{% endif %}</p>
+<p class="text-muted">No upcoming regattas. {% if current_user.is_admin or current_user.is_skipper %}Add one!{% endif %}</p>
 {% endif %}
 
 {% if past %}
@@ -167,7 +197,7 @@
 {{ regatta_table(past, true, "past") }}
 {% endif %}
 
-{% if current_user.is_admin %}
+{% if current_user.is_admin or current_user.is_skipper %}
 <script>
 document.querySelectorAll('.select-all').forEach(function(cb) {
     cb.addEventListener('change', function() {

--- a/app/templates/my_crew.html
+++ b/app/templates/my_crew.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+{% block title %}My Crew — Race Crew Network{% endblock %}
+{% block content %}
+<h2 class="mb-4">My Crew</h2>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <h5 class="card-title">Invite Crew Member</h5>
+        <form method="POST" action="{{ url_for('auth.invite_crew') }}" class="row g-2 align-items-end">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="col-12 col-sm">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" class="form-control" id="email" name="email" required placeholder="crew@example.com">
+            </div>
+            {% if email_configured %}
+            <div class="col-12 col-sm-auto d-flex align-items-center">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="send_email_invite" name="send_email_invite" checked>
+                    <label class="form-check-label" for="send_email_invite">Send invite via email</label>
+                </div>
+            </div>
+            {% endif %}
+            <div class="col-12 col-sm-auto">
+                <button type="submit" class="btn btn-primary">Invite</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+{% if crew %}
+<div class="table-responsive">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th class="d-none d-sm-table-cell">Initials</th>
+                <th class="d-none d-md-table-cell">Email</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for member in crew %}
+            <tr>
+                <td>{{ member.display_name }}</td>
+                <td class="d-none d-sm-table-cell"><span class="badge bg-secondary">{{ member.initials }}</span></td>
+                <td class="d-none d-md-table-cell">{{ member.email }}</td>
+                <td>
+                    {% if member.invite_token %}
+                    <span class="badge bg-warning">Pending</span>
+                    {% else %}
+                    <span class="badge bg-success">Active</span>
+                    {% endif %}
+                </td>
+                <td>
+                    <form method="POST" action="{{ url_for('auth.remove_crew', user_id=member.id) }}" class="d-inline" onsubmit="return confirm('Remove {{ member.display_name }} from your crew?')">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="text-muted">No crew members yet. Invite someone above!</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -12,7 +12,7 @@
             </div>
             <div class="mb-3">
                 <label for="initials" class="form-label">Initials (2-3 characters)</label>
-                <input type="text" class="form-control" id="initials" name="initials" required maxlength="3" value="{{ current_user.initials }}" style="text-transform: uppercase;">
+                <input type="text" class="form-control" id="initials" name="initials" required maxlength="3" pattern="[A-Za-z0-9]{2,3}" title="2-3 letters or numbers" value="{{ current_user.initials }}" style="text-transform: uppercase;">
             </div>
             <div class="mb-3">
                 <label for="email" class="form-label">Email</label>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -17,7 +17,7 @@
             </div>
             <div class="mb-3">
                 <label for="initials" class="form-label">Initials (2-3 characters)</label>
-                <input type="text" class="form-control" id="initials" name="initials" required maxlength="3" placeholder="e.g. CE" style="text-transform: uppercase;">
+                <input type="text" class="form-control" id="initials" name="initials" required maxlength="3" pattern="[A-Za-z0-9]{2,3}" title="2-3 letters or numbers" placeholder="e.g. CE" style="text-transform: uppercase;">
             </div>
             <div class="mb-3">
                 <label for="password" class="form-label">Password</label>

--- a/migrations/versions/a5b6c7d8e9f0_add_skipper_crew_model.py
+++ b/migrations/versions/a5b6c7d8e9f0_add_skipper_crew_model.py
@@ -1,0 +1,59 @@
+"""Add skipper/crew multi-user model
+
+Revision ID: a5b6c7d8e9f0
+Revises: 1f34ac0f8204
+Create Date: 2026-03-09
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a5b6c7d8e9f0"
+down_revision = "d4b5e6f7a8c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add is_skipper and invited_by columns to users
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_skipper",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            )
+        )
+        batch_op.add_column(sa.Column("invited_by", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_users_invited_by", "users", ["invited_by"], ["id"]
+        )
+
+    # Create skipper_crew association table
+    op.create_table(
+        "skipper_crew",
+        sa.Column(
+            "skipper_id", sa.Integer(), sa.ForeignKey("users.id"), primary_key=True
+        ),
+        sa.Column("crew_id", sa.Integer(), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # Data migration: set existing admins as skippers
+    op.execute("UPDATE users SET is_skipper = 1 WHERE is_admin = 1")
+
+
+def downgrade():
+    op.drop_table("skipper_crew")
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_users_invited_by", type_="foreignkey")
+        batch_op.drop_column("invited_by")
+        batch_op.drop_column("is_skipper")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,15 +66,51 @@ def client(app):
 
 @pytest.fixture()
 def admin_user(db):
-    """Create and return an admin user."""
+    """Create and return an admin user (also a skipper)."""
     user = User(
         email="admin@test.com",
         display_name="Admin",
         initials="AD",
         is_admin=True,
+        is_skipper=True,
     )
     user.set_password("password")
     db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def skipper_user(db):
+    """Create and return a skipper (non-admin) user."""
+    user = User(
+        email="skipper@test.com",
+        display_name="Skipper",
+        initials="SK",
+        is_admin=False,
+        is_skipper=True,
+    )
+    user.set_password("password")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def crew_user(db, skipper_user):
+    """Create a crew member linked to skipper_user."""
+    user = User(
+        email="crew@test.com",
+        display_name="Crew",
+        initials="CR",
+        is_admin=False,
+        is_skipper=False,
+        invited_by=skipper_user.id,
+    )
+    user.set_password("password")
+    db.session.add(user)
+    db.session.flush()
+    skipper_user.crew_members.append(user)
     db.session.commit()
     return user
 
@@ -85,6 +121,28 @@ def logged_in_client(client, admin_user):
     client.post(
         "/login",
         data={"email": "admin@test.com", "password": "password"},
+        follow_redirects=True,
+    )
+    return client
+
+
+@pytest.fixture()
+def logged_in_skipper(client, skipper_user):
+    """A test client logged in as skipper."""
+    client.post(
+        "/login",
+        data={"email": "skipper@test.com", "password": "password"},
+        follow_redirects=True,
+    )
+    return client
+
+
+@pytest.fixture()
+def logged_in_crew(client, crew_user):
+    """A test client logged in as crew."""
+    client.post(
+        "/login",
+        data={"email": "crew@test.com", "password": "password"},
         follow_redirects=True,
     )
     return client

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -72,6 +72,7 @@ class TestAppFactory:
             display_name="Admin Two",
             initials="A2",
             is_admin=True,
+            is_skipper=True,
         )
         user.set_password("password")
         db.session.add(user)
@@ -85,8 +86,9 @@ class TestAppFactory:
 
         resp = client.get("/")
         assert resp.status_code == 200
-        assert b">Crew<" in resp.data
+        assert b">My Crew<" in resp.data
         assert b">Import<" in resp.data
+        assert b"/admin/users" in resp.data
         assert b"/admin/settings/analytics" in resp.data
 
     def test_regatta_days_filter_single_day(self, app):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,100 @@ class TestUserModel:
         assert len(user.password_hash) > 20
 
 
+class TestSkipperCrewRelationship:
+    def test_skipper_crew_link(self, app, db, skipper_user, crew_user):
+        assert crew_user in skipper_user.crew_members.all()
+        assert skipper_user in crew_user.skippers
+
+    def test_is_crew_property(self, app, db, crew_user):
+        assert crew_user.is_crew is True
+
+    def test_is_crew_false_for_skipper(self, app, db, skipper_user):
+        assert skipper_user.is_crew is False
+
+    def test_visible_regattas_admin_sees_all(self, app, db, admin_user, skipper_user):
+        r1 = Regatta(
+            name="Admin Regatta",
+            location="YC",
+            start_date=date(2026, 7, 1),
+            created_by=admin_user.id,
+        )
+        r2 = Regatta(
+            name="Skipper Regatta",
+            location="YC",
+            start_date=date(2026, 7, 2),
+            created_by=skipper_user.id,
+        )
+        db.session.add_all([r1, r2])
+        db.session.commit()
+
+        visible = admin_user.visible_regattas().all()
+        assert len(visible) == 2
+
+    def test_visible_regattas_skipper_sees_own(self, app, db, admin_user, skipper_user):
+        r1 = Regatta(
+            name="Admin Regatta",
+            location="YC",
+            start_date=date(2026, 7, 1),
+            created_by=admin_user.id,
+        )
+        r2 = Regatta(
+            name="Skipper Regatta",
+            location="YC",
+            start_date=date(2026, 7, 2),
+            created_by=skipper_user.id,
+        )
+        db.session.add_all([r1, r2])
+        db.session.commit()
+
+        visible = skipper_user.visible_regattas().all()
+        assert len(visible) == 1
+        assert visible[0].name == "Skipper Regatta"
+
+    def test_visible_regattas_crew_sees_skippers(
+        self, app, db, admin_user, skipper_user, crew_user
+    ):
+        r1 = Regatta(
+            name="Admin Regatta",
+            location="YC",
+            start_date=date(2026, 7, 1),
+            created_by=admin_user.id,
+        )
+        r2 = Regatta(
+            name="Skipper Regatta",
+            location="YC",
+            start_date=date(2026, 7, 2),
+            created_by=skipper_user.id,
+        )
+        db.session.add_all([r1, r2])
+        db.session.commit()
+
+        visible = crew_user.visible_regattas().all()
+        assert len(visible) == 1
+        assert visible[0].name == "Skipper Regatta"
+
+    def test_visible_regattas_no_role_empty(self, app, db, admin_user):
+        norole = User(
+            email="norole@test.com",
+            display_name="No Role",
+            initials="NR",
+        )
+        norole.set_password("password")
+        db.session.add(norole)
+        db.session.flush()
+
+        r = Regatta(
+            name="Test",
+            location="YC",
+            start_date=date(2026, 7, 1),
+            created_by=admin_user.id,
+        )
+        db.session.add(r)
+        db.session.commit()
+
+        assert norole.visible_regattas().all() == []
+
+
 class TestRegattaModel:
     def test_create_regatta(self, app, db, admin_user):
         regatta = Regatta(

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,100 @@
+"""Tests for app.permissions."""
+
+from datetime import date
+
+from app.models import Regatta
+from app.permissions import can_manage_regatta, can_rsvp_to_regatta
+
+
+class TestCanManageRegatta:
+    def test_admin_can_manage_any(self, app, db, admin_user, skipper_user):
+        regatta = Regatta(
+            name="Skipper Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_manage_regatta(admin_user, regatta) is True
+
+    def test_skipper_can_manage_own(self, app, db, skipper_user):
+        regatta = Regatta(
+            name="My Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_manage_regatta(skipper_user, regatta) is True
+
+    def test_skipper_cannot_manage_others(self, app, db, admin_user, skipper_user):
+        regatta = Regatta(
+            name="Admin Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_manage_regatta(skipper_user, regatta) is False
+
+    def test_crew_cannot_manage(self, app, db, skipper_user, crew_user):
+        regatta = Regatta(
+            name="Skipper Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_manage_regatta(crew_user, regatta) is False
+
+
+class TestCanRsvpToRegatta:
+    def test_admin_can_rsvp_any(self, app, db, admin_user, skipper_user):
+        regatta = Regatta(
+            name="Skipper Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_rsvp_to_regatta(admin_user, regatta) is True
+
+    def test_owner_can_rsvp(self, app, db, skipper_user):
+        regatta = Regatta(
+            name="My Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_rsvp_to_regatta(skipper_user, regatta) is True
+
+    def test_crew_can_rsvp_to_skippers_regatta(self, app, db, skipper_user, crew_user):
+        regatta = Regatta(
+            name="Skipper Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_rsvp_to_regatta(crew_user, regatta) is True
+
+    def test_crew_cannot_rsvp_to_unrelated_regatta(
+        self, app, db, admin_user, crew_user
+    ):
+        regatta = Regatta(
+            name="Admin Regatta",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        assert can_rsvp_to_regatta(crew_user, regatta) is False

--- a/tests/test_skipper_crew.py
+++ b/tests/test_skipper_crew.py
@@ -1,0 +1,511 @@
+"""Tests for skipper-crew management routes and multi-user access control."""
+
+from datetime import date
+
+from app.models import Document, Regatta, RSVP, User, skipper_crew
+
+
+class TestCrewManagementPage:
+    def test_my_crew_requires_login(self, client):
+        resp = client.get("/my-crew")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_my_crew_denied_for_crew(self, logged_in_crew):
+        resp = logged_in_crew.get("/my-crew", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_my_crew_accessible_for_skipper(self, logged_in_skipper, crew_user):
+        resp = logged_in_skipper.get("/my-crew")
+        assert resp.status_code == 200
+        assert b"My Crew" in resp.data
+        assert crew_user.display_name.encode() in resp.data
+
+    def test_my_crew_accessible_for_admin(self, logged_in_client):
+        resp = logged_in_client.get("/my-crew")
+        assert resp.status_code == 200
+        assert b"My Crew" in resp.data
+
+
+class TestInviteCrew:
+    def test_invite_crew_creates_user(self, app, logged_in_skipper, db, skipper_user):
+        resp = logged_in_skipper.post(
+            "/my-crew/invite",
+            data={"email": "newcrew@test.com"},
+            follow_redirects=True,
+        )
+        assert b"Invite link:" in resp.data
+
+        new_user = User.query.filter_by(email="newcrew@test.com").first()
+        assert new_user is not None
+        assert new_user.invite_token is not None
+        assert new_user.invited_by == skipper_user.id
+        assert new_user in skipper_user.crew_members.all()
+
+    def test_invite_existing_user_adds_to_crew(
+        self, app, logged_in_skipper, db, skipper_user
+    ):
+        # Create a standalone user
+        other = User(
+            email="other@test.com",
+            display_name="Other",
+            initials="OT",
+            is_admin=False,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        resp = logged_in_skipper.post(
+            "/my-crew/invite",
+            data={"email": "other@test.com"},
+            follow_redirects=True,
+        )
+        assert b"added to your crew" in resp.data
+        assert other in skipper_user.crew_members.all()
+
+    def test_invite_duplicate_warns(self, logged_in_skipper, crew_user):
+        resp = logged_in_skipper.post(
+            "/my-crew/invite",
+            data={"email": crew_user.email},
+            follow_redirects=True,
+        )
+        assert b"already on your crew" in resp.data
+
+    def test_invite_crew_denied_for_crew_role(self, logged_in_crew):
+        resp = logged_in_crew.post(
+            "/my-crew/invite",
+            data={"email": "nope@test.com"},
+            follow_redirects=True,
+        )
+        assert b"Access denied" in resp.data
+
+
+class TestRemoveCrew:
+    def test_remove_crew_member(
+        self, app, logged_in_skipper, db, skipper_user, crew_user
+    ):
+        resp = logged_in_skipper.post(
+            f"/my-crew/{crew_user.id}/remove",
+            follow_redirects=True,
+        )
+        assert b"removed from your crew" in resp.data
+        assert crew_user not in skipper_user.crew_members.all()
+
+    def test_remove_nonmember_warns(self, app, logged_in_skipper, db):
+        other = User(
+            email="stranger@test.com",
+            display_name="Stranger",
+            initials="ST",
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        resp = logged_in_skipper.post(
+            f"/my-crew/{other.id}/remove",
+            follow_redirects=True,
+        )
+        assert b"not on your crew" in resp.data
+
+
+class TestSkipperRegattaAccess:
+    def test_skipper_can_create_regatta(self, app, logged_in_skipper, db):
+        resp = logged_in_skipper.post(
+            "/regattas/new",
+            data={
+                "name": "Skipper Regatta",
+                "boat_class": "Thistle",
+                "location": "Test YC",
+                "start_date": "2026-07-01",
+            },
+            follow_redirects=True,
+        )
+        assert b"Skipper Regatta" in resp.data
+        assert Regatta.query.filter_by(name="Skipper Regatta").first() is not None
+
+    def test_skipper_can_edit_own_regatta(
+        self, app, logged_in_skipper, db, skipper_user
+    ):
+        regatta = Regatta(
+            name="Edit Me",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_skipper.get(f"/regattas/{regatta.id}/edit")
+        assert resp.status_code == 200
+
+    def test_skipper_cannot_edit_others_regatta(
+        self, app, logged_in_skipper, db, admin_user
+    ):
+        regatta = Regatta(
+            name="Not Mine",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_skipper.get(
+            f"/regattas/{regatta.id}/edit", follow_redirects=True
+        )
+        assert b"Access denied" in resp.data
+
+    def test_skipper_can_delete_own_regatta(
+        self, app, logged_in_skipper, db, skipper_user
+    ):
+        regatta = Regatta(
+            name="Delete Me",
+            location="Test YC",
+            start_date=date(2026, 7, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        rid = regatta.id
+
+        resp = logged_in_skipper.post(f"/regattas/{rid}/delete", follow_redirects=True)
+        assert b"deleted" in resp.data
+        assert db.session.get(Regatta, rid) is None
+
+
+class TestCrewRegattaAccess:
+    def test_crew_cannot_create_regatta(self, logged_in_crew):
+        resp = logged_in_crew.get("/regattas/new", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_crew_sees_skippers_regattas(self, app, logged_in_crew, db, skipper_user):
+        regatta = Regatta(
+            name="Visible Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_crew.get("/")
+        assert b"Visible Regatta" in resp.data
+
+    def test_crew_cannot_see_unrelated_regattas(
+        self, app, logged_in_crew, db, admin_user
+    ):
+        regatta = Regatta(
+            name="Hidden Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_crew.get("/")
+        assert b"Hidden Regatta" not in resp.data
+
+    def test_crew_can_rsvp_to_skippers_regatta(
+        self, app, logged_in_crew, db, skipper_user
+    ):
+        regatta = Regatta(
+            name="RSVP Test",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_crew.post(
+            f"/regattas/{regatta.id}/rsvp",
+            data={"status": "yes"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    def test_crew_cannot_rsvp_to_unrelated_regatta(
+        self, app, logged_in_crew, db, admin_user
+    ):
+        regatta = Regatta(
+            name="Blocked RSVP",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_crew.post(
+            f"/regattas/{regatta.id}/rsvp",
+            data={"status": "yes"},
+            follow_redirects=True,
+        )
+        assert b"Access denied" in resp.data
+
+
+class TestAdminInviteWithSkipperFlag:
+    def test_admin_invite_as_skipper(self, app, logged_in_client, db):
+        logged_in_client.post(
+            "/admin/users/invite",
+            data={"email": "newskip@test.com", "is_skipper": "on"},
+            follow_redirects=True,
+        )
+        user = User.query.filter_by(email="newskip@test.com").first()
+        assert user is not None
+        assert user.is_skipper is True
+
+    def test_admin_invite_without_skipper(self, app, logged_in_client, db):
+        logged_in_client.post(
+            "/admin/users/invite",
+            data={"email": "newcrew@test.com"},
+            follow_redirects=True,
+        )
+        user = User.query.filter_by(email="newcrew@test.com").first()
+        assert user is not None
+        assert user.is_skipper is False
+
+
+class TestEditUserSkipperFlag:
+    def test_admin_can_set_skipper(self, app, logged_in_client, db):
+        user = User(
+            email="toedit@test.com",
+            display_name="Edit Me",
+            initials="EM",
+            is_admin=False,
+            is_skipper=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        resp = logged_in_client.post(
+            f"/admin/users/{user.id}/edit",
+            data={
+                "display_name": "Edit Me",
+                "initials": "EM",
+                "email": "toedit@test.com",
+                "is_skipper": "on",
+            },
+            follow_redirects=True,
+        )
+        assert b"updated" in resp.data
+        db.session.refresh(user)
+        assert user.is_skipper is True
+
+
+class TestRegistrationComplete:
+    def test_admin_can_activate_pending_user(self, app, logged_in_client, db):
+        user = User(
+            email="pending@test.com",
+            password_hash="pending",
+            display_name="Pending",
+            initials="PE",
+            invite_token="some-token",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        resp = logged_in_client.post(
+            f"/admin/users/{user.id}/edit",
+            data={
+                "display_name": "Now Active",
+                "initials": "NA",
+                "email": "pending@test.com",
+                "password": "newpass123",
+                "registration_complete": "on",
+            },
+            follow_redirects=True,
+        )
+        assert b"updated" in resp.data
+        db.session.refresh(user)
+        assert user.invite_token is None
+        assert user.check_password("newpass123")
+
+    def test_activation_requires_password(self, app, logged_in_client, db):
+        user = User(
+            email="pending2@test.com",
+            password_hash="pending",
+            display_name="Pending2",
+            initials="P2",
+            invite_token="another-token",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        resp = logged_in_client.post(
+            f"/admin/users/{user.id}/edit",
+            data={
+                "display_name": "Pending2",
+                "initials": "P2",
+                "email": "pending2@test.com",
+                "registration_complete": "on",
+            },
+            follow_redirects=True,
+        )
+        assert b"password is required" in resp.data
+        db.session.refresh(user)
+        assert user.invite_token is not None
+
+
+class TestRegistrationAutoLink:
+    def test_register_links_to_inviting_skipper(self, app, db, skipper_user):
+        """When a user registers via invite from a skipper, they join the crew."""
+        import secrets
+
+        token = secrets.token_urlsafe(32)
+        invited = User(
+            email="invited@test.com",
+            password_hash="pending",
+            display_name="invited@test.com",
+            initials="??",
+            invite_token=token,
+            invited_by=skipper_user.id,
+        )
+        db.session.add(invited)
+        db.session.flush()
+        skipper_user.crew_members.append(invited)
+        db.session.commit()
+
+        client = app.test_client()
+        resp = client.post(
+            f"/register/{token}",
+            data={
+                "display_name": "New Crew",
+                "initials": "NC",
+                "password": "password123",
+                "password2": "password123",
+            },
+            follow_redirects=True,
+        )
+        assert b"Welcome aboard" in resp.data
+
+        db.session.refresh(invited)
+        assert invited.invite_token is None
+        assert invited in skipper_user.crew_members.all()
+
+
+class TestSkipperImportAccess:
+    def test_skipper_can_access_import_url(self, logged_in_skipper):
+        resp = logged_in_skipper.get("/admin/import-url")
+        assert resp.status_code == 200
+        assert b"Import from URL" in resp.data
+
+    def test_skipper_can_access_import_file(self, logged_in_skipper):
+        resp = logged_in_skipper.get("/admin/import-file")
+        assert resp.status_code == 200
+
+    def test_skipper_can_access_import_paste(self, logged_in_skipper):
+        resp = logged_in_skipper.get("/admin/import-paste")
+        assert resp.status_code == 200
+
+    def test_crew_denied_import_url(self, logged_in_crew):
+        resp = logged_in_crew.get("/admin/import-url", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_crew_denied_import_file(self, logged_in_crew):
+        resp = logged_in_crew.get("/admin/import-file", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_skipper_denied_admin_settings(self, logged_in_skipper):
+        resp = logged_in_skipper.get("/admin/settings/analytics", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_skipper_denied_email_settings(self, logged_in_skipper):
+        resp = logged_in_skipper.get("/admin/settings/email", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+
+class TestCreateSchedule:
+    def test_crew_can_create_schedule(self, app, logged_in_crew, db, crew_user):
+        resp = logged_in_crew.post("/create-schedule", follow_redirects=True)
+        assert b"Your schedule has been created!" in resp.data
+        db.session.refresh(crew_user)
+        assert crew_user.is_skipper is True
+
+    def test_existing_crew_relationships_preserved(
+        self, app, logged_in_crew, db, crew_user, skipper_user
+    ):
+        """After promoting to skipper, user is still crew for their existing skipper."""
+        logged_in_crew.post("/create-schedule", follow_redirects=True)
+        db.session.refresh(crew_user)
+        assert crew_user.is_skipper is True
+        assert crew_user in skipper_user.crew_members.all()
+
+    def test_already_skipper_is_noop(self, logged_in_skipper, db, skipper_user):
+        resp = logged_in_skipper.post("/create-schedule", follow_redirects=True)
+        assert b"Your schedule has been created!" not in resp.data
+        db.session.refresh(skipper_user)
+        assert skipper_user.is_skipper is True
+
+    def test_unauthenticated_redirects_to_login(self, client):
+        resp = client.post("/create-schedule")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+
+class TestDeleteSchedule:
+    def test_skipper_can_delete_schedule(self, app, logged_in_skipper, db, skipper_user):
+        resp = logged_in_skipper.post("/delete-schedule", follow_redirects=True)
+        assert b"Your schedule has been deleted." in resp.data
+        db.session.refresh(skipper_user)
+        assert skipper_user.is_skipper is False
+
+    def test_delete_removes_regattas(
+        self, app, logged_in_skipper, db, skipper_user
+    ):
+        regatta = Regatta(
+            name="Gone Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+        rid = regatta.id
+
+        logged_in_skipper.post("/delete-schedule", follow_redirects=True)
+        assert db.session.get(Regatta, rid) is None
+
+    def test_delete_unlinks_crew(
+        self, app, logged_in_skipper, db, skipper_user, crew_user
+    ):
+        logged_in_skipper.post("/delete-schedule", follow_redirects=True)
+        rows = db.session.execute(
+            skipper_crew.select().where(
+                skipper_crew.c.skipper_id == skipper_user.id
+            )
+        ).fetchall()
+        assert len(rows) == 0
+
+    def test_former_crew_can_create_own_schedule(
+        self, app, logged_in_skipper, db, skipper_user, crew_user
+    ):
+        """After skipper deletes schedule, orphaned crew can still self-promote."""
+        # Skipper deletes their schedule, orphaning crew
+        logged_in_skipper.post("/delete-schedule", follow_redirects=True)
+        db.session.refresh(crew_user)
+        assert crew_user not in skipper_user.crew_members.all()
+
+        # Switch to crew user on the same client
+        logged_in_skipper.get("/logout", follow_redirects=True)
+        logged_in_skipper.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = logged_in_skipper.post("/create-schedule", follow_redirects=True)
+        assert b"Your schedule has been created!" in resp.data
+        db.session.expire_all()
+        updated = db.session.get(User, crew_user.id)
+        assert updated.is_skipper is True
+
+    def test_admin_cannot_delete_schedule(self, logged_in_client):
+        resp = logged_in_client.post("/delete-schedule", follow_redirects=True)
+        assert b"Admins cannot delete their schedule" in resp.data
+
+    def test_non_skipper_gets_error(self, logged_in_crew):
+        resp = logged_in_crew.post("/delete-schedule", follow_redirects=True)
+        assert b"don&#39;t have a schedule" in resp.data


### PR DESCRIPTION
## Summary
- Introduce three roles (Admin, Skipper, Crew) with scoped regatta access and role-aware UI
- Skippers own their schedule, manage crew via "My Crew" page, and import regattas independently
- Self-serve schedule management: crew can promote to skipper ("Create My Schedule" in profile dropdown), skippers can delete their schedule to revert
- Skipper filter dropdown on home page for users with multiple skippers

## Test plan
- [x] `pytest` — 229/230 pass (1 pre-existing GA test failure)
- [ ] Log in as crew → profile dropdown shows "Create My Schedule" → click → now see skipper UI
- [ ] As new skipper, add a regatta, invite crew → verify it works
- [ ] Click "Delete Schedule" → confirm → regattas gone, back to crew-only view
- [ ] Orphaned crew member can still log in and create their own schedule
- [ ] Admin cannot delete their schedule (blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)