### PR TITLE
Add profile pictures, schedule switcher, and RSVP filters

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,22 @@
 # Version History
 
+## 0.48.0
+- Add profile picture support in Profile Settings with image upload and preview
+- Add optional remove-profile-picture action from Profile Settings
+- Validate profile image types (JPG, JPEG, PNG, GIF, WEBP)
+- Persist uploaded profile image key on users via new database migration
+- Delete user profile image object from storage when an admin deletes that user
+- Unified schedule switcher dropdown for skipper+crew users with multiple contexts
+- Dropdown shows "All Schedules", "My Schedule", and each skipper's name
+- Per-row Edit/checkbox scoped to own regattas (not all skipper regattas)
+- Add Regatta and Delete Schedule buttons hidden when viewing another skipper's schedule
+- Page title reflects selected schedule context
+- Append "'s Schedule" to other skipper names in schedule switcher dropdown
+- Add Skipper column to desktop table and mobile cards in "All Schedules" view
+- Add RSVP attendance filter with Yes/Maybe/No toggle buttons
+- RSVP filter supports multi-select; all checked or none means no filter
+- Preserve skipper and RSVP filter state across RSVP submissions
+
 ## 0.45.0
 - Multi-user skipper/crew model with three roles: Admin, Skipper, Crew
 - Skippers own their regatta schedule and can import regattas

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.45.0"
+__version__ = "0.48.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,15 +1,47 @@
 import logging
+import os
 import secrets
+import uuid
 
-from flask import flash, redirect, render_template, request, url_for
+from flask import current_app, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required, login_user, logout_user
+from werkzeug.utils import secure_filename
 
-from app import db
+from app import db, storage
 from app.admin.email_service import is_email_configured, send_email
 from app.auth import bp
 from app.models import Document, Regatta, RSVP, User, skipper_crew
 
 logger = logging.getLogger(__name__)
+
+ALLOWED_PROFILE_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+
+def _build_profile_image_url(image_key: str | None) -> str | None:
+    """Return a temporary URL for a stored profile image key."""
+    if not image_key or not current_app.config.get("BUCKET_NAME"):
+        return None
+
+    try:
+        return storage.get_file_url(image_key)
+    except Exception:
+        logger.exception("Failed to generate profile image URL for key: %s", image_key)
+        return None
+
+
+def _upload_profile_image(file_storage) -> str:
+    """Validate and upload a profile image, returning its storage key."""
+    if not current_app.config.get("BUCKET_NAME"):
+        raise ValueError("Profile image storage is not configured.")
+
+    safe_name = secure_filename(file_storage.filename or "")
+    ext = os.path.splitext(safe_name)[1].lower()
+    if ext not in ALLOWED_PROFILE_IMAGE_EXTENSIONS:
+        raise ValueError("Profile picture must be a JPG, JPEG, PNG, GIF, or WEBP file.")
+
+    stored_filename = f"profile-images/{uuid.uuid4().hex}{ext}"
+    storage.upload_file(file_storage, stored_filename)
+    return stored_filename
 
 
 def _send_invite_email(email: str, invite_url: str, inviter_name: str) -> None:
@@ -105,6 +137,8 @@ def profile():
         email = request.form.get("email", "").strip().lower()
         password = request.form.get("password", "")
         password2 = request.form.get("password2", "")
+        remove_profile_image = request.form.get("remove_profile_image") == "on"
+        profile_image = request.files.get("profile_image")
 
         if not display_name or not initials or not email:
             flash("Name, initials, and email are required.", "error")
@@ -117,18 +151,43 @@ def profile():
         elif password and password != password2:
             flash("Passwords do not match.", "error")
         else:
-            current_user.display_name = display_name
-            current_user.initials = initials
-            current_user.email = email
-            current_user.phone = request.form.get("phone", "").strip() or None
-            current_user.email_opt_in = request.form.get("email_opt_in") == "on"
-            if password:
-                current_user.set_password(password)
-            db.session.commit()
-            flash("Profile updated.", "success")
-            return redirect(url_for("auth.profile"))
+            old_image_key = current_user.profile_image_key
+            new_image_key = None
+            try:
+                if profile_image and profile_image.filename:
+                    new_image_key = _upload_profile_image(profile_image)
+                    current_user.profile_image_key = new_image_key
+                elif remove_profile_image:
+                    current_user.profile_image_key = None
 
-    return render_template("profile.html")
+                current_user.display_name = display_name
+                current_user.initials = initials
+                current_user.email = email
+                current_user.phone = request.form.get("phone", "").strip() or None
+                current_user.email_opt_in = request.form.get("email_opt_in") == "on"
+                if password:
+                    current_user.set_password(password)
+
+                db.session.commit()
+            except ValueError as exc:
+                db.session.rollback()
+                flash(str(exc), "error")
+            except Exception:
+                db.session.rollback()
+                if new_image_key:
+                    storage.delete_file(new_image_key)
+                logger.exception("Failed to update profile for user %s", current_user.id)
+                flash("Unable to update profile right now. Please try again.", "error")
+            else:
+                if old_image_key and old_image_key != current_user.profile_image_key:
+                    storage.delete_file(old_image_key)
+                flash("Profile updated.", "success")
+                return redirect(url_for("auth.profile"))
+
+    return render_template(
+        "profile.html",
+        profile_image_url=_build_profile_image_url(current_user.profile_image_key),
+    )
 
 
 @bp.route("/crew/<int:user_id>")
@@ -313,6 +372,10 @@ def delete_user(user_id: int):
     elif user.id == current_user.id:
         flash("You cannot delete yourself.", "error")
     else:
+        # Delete profile image from object storage if present.
+        if user.profile_image_key:
+            storage.delete_file(user.profile_image_key)
+
         # Delete regattas created by this user (cascades their docs & RSVPs)
         for regatta in Regatta.query.filter_by(created_by=user.id).all():
             db.session.delete(regatta)

--- a/app/models.py
+++ b/app/models.py
@@ -40,6 +40,7 @@ class User(UserMixin, db.Model):
     calendar_token = db.Column(db.String(64), unique=True, nullable=True)
     phone = db.Column(db.String(20), nullable=True)
     email_opt_in = db.Column(db.Boolean, default=True, nullable=False)
+    profile_image_key = db.Column(db.String(255), nullable=True)
 
     rsvps = db.relationship("RSVP", backref="user", lazy="dynamic")
     documents = db.relationship("Document", backref="uploaded_by_user", lazy="dynamic")

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -21,34 +21,68 @@ def index():
 
     upcoming, past = current_user.visible_regattas_split()
 
-    # Optional skipper filter
+    # Skipper filter: default non-admin skippers to their own schedule
     skipper_id = request.args.get("skipper", type=int)
+    if skipper_id is None and current_user.is_skipper and not current_user.is_admin:
+        skipper_id = current_user.id
+    # skipper_id == 0 means "All Schedules" (explicit selection, no filter)
     if skipper_id:
         upcoming = [r for r in upcoming if r.created_by == skipper_id]
         past = [r for r in past if r.created_by == skipper_id]
+
+    # RSVP attendance filter
+    rsvp_filters = [
+        v.lower()
+        for v in request.args.getlist("rsvp")
+        if v.lower() in ("yes", "no", "maybe")
+    ]
+    if rsvp_filters and set(rsvp_filters) != {"yes", "no", "maybe"}:
+        rsvp_regatta_ids = {
+            r.regatta_id
+            for r in RSVP.query.filter(
+                RSVP.user_id == current_user.id,
+                RSVP.status.in_(rsvp_filters),
+            ).all()
+        }
+        upcoming = [r for r in upcoming if r.id in rsvp_regatta_ids]
+        past = [r for r in past if r.id in rsvp_regatta_ids]
 
     users = (
         User.query.filter(User.invite_token.is_(None)).order_by(User.display_name).all()
     )
 
-    # Build skipper list for filter dropdown (skippers whose regattas are visible)
-    skippers = []
+    # Build schedule contexts for dropdown
+    schedules = []
     if current_user.is_admin:
-        skippers = (
+        schedules = (
             User.query.filter(User.is_skipper.is_(True))
             .order_by(User.display_name)
             .all()
         )
-    elif current_user.is_crew:
-        skippers = list(current_user.skippers)
+    else:
+        if current_user.is_skipper:
+            schedules.append(current_user)
+        for skipper in current_user.skippers:
+            if skipper.id != current_user.id:
+                schedules.append(skipper)
+
+    # Can user manage any regattas in current view?
+    if current_user.is_admin:
+        can_manage_any = True
+    elif current_user.is_skipper:
+        can_manage_any = skipper_id in (0, current_user.id) or not skipper_id
+    else:
+        can_manage_any = False
 
     return render_template(
         "index.html",
         upcoming=upcoming,
         past=past,
         users=users,
-        skippers=skippers,
+        schedules=schedules,
         selected_skipper=skipper_id,
+        can_manage_any=can_manage_any,
+        rsvp_filters=rsvp_filters,
     )
 
 
@@ -171,7 +205,16 @@ def rsvp(regatta_id: int):
         )
 
     db.session.commit()
-    return redirect(url_for("regattas.index"))
+
+    # Preserve filter state in redirect
+    redirect_args = {}
+    redirect_skipper = request.form.get("redirect_skipper")
+    if redirect_skipper is not None and redirect_skipper != "":
+        redirect_args["skipper"] = redirect_skipper
+    redirect_rsvp = request.form.getlist("redirect_rsvp")
+    if redirect_rsvp:
+        redirect_args["rsvp"] = redirect_rsvp
+    return redirect(url_for("regattas.index", **redirect_args))
 
 
 @bp.route("/docs/<int:doc_id>")

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,10 +4,15 @@
 <div class="mb-3 d-flex flex-wrap align-items-center">
     <a href="{{ url_for('regattas.pdf') }}" class="btn btn-outline-secondary btn-sm no-print" target="_blank">Print PDF</a>
     <div class="flex-grow-1 text-center">
-        {% if skippers|length == 1 %}
-        <h2 class="mb-0">{{ skippers[0].display_name }}'s Race Schedule</h2>
-        {% elif current_user.is_skipper %}
+        {% if selected_skipper == 0 %}
+        <h2 class="mb-0">Race Schedule</h2>
+        {% elif selected_skipper == current_user.id %}
         <h2 class="mb-0">{{ current_user.display_name }}'s Race Schedule</h2>
+        {% elif selected_skipper %}
+        {% set viewing_skipper = schedules|selectattr('id', 'equalto', selected_skipper)|first %}
+        <h2 class="mb-0">{{ viewing_skipper.display_name }}'s Race Schedule</h2>
+        {% elif schedules|length == 1 %}
+        <h2 class="mb-0">{{ schedules[0].display_name }}'s Race Schedule</h2>
         {% else %}
         <h2 class="mb-0">Race Schedule</h2>
         {% endif %}
@@ -15,31 +20,48 @@
 </div>
 
 <div class="mb-3 d-flex flex-wrap gap-2 btn-bar align-items-center">
-    {% if current_user.is_admin or current_user.is_skipper %}
+    {% if current_user.is_admin or (current_user.is_skipper and (selected_skipper == 0 or selected_skipper == current_user.id)) %}
     <a href="{{ url_for('regattas.create') }}" class="btn btn-primary btn-sm">+ Add Regatta</a>
     {% endif %}
-    {% if current_user.is_skipper and not current_user.is_admin %}
+    {% if current_user.is_skipper and not current_user.is_admin and (selected_skipper == 0 or selected_skipper == current_user.id) %}
     <form method="POST" action="{{ url_for('auth.delete_schedule') }}" class="d-inline"
           onsubmit="return confirm('This will delete all your regattas and remove your crew. Are you sure?')">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="btn btn-outline-danger btn-sm">Delete Schedule</button>
     </form>
     {% endif %}
-    {% if skippers|length > 1 %}
-    <form method="GET" class="d-inline-flex align-items-center ms-auto">
+    <form method="GET" id="filter-form" class="d-inline-flex flex-wrap align-items-center gap-2 ms-auto">
+        {% if schedules|length > 1 %}
         <select name="skipper" class="form-select form-select-sm" style="width:auto" onchange="this.form.submit()">
-            <option value="">All Skippers</option>
-            {% for s in skippers %}
-            <option value="{{ s.id }}" {% if selected_skipper == s.id %}selected{% endif %}>{{ s.display_name }}</option>
+            <option value="0" {% if selected_skipper == 0 %}selected{% endif %}>All Schedules</option>
+            {% if current_user.is_skipper %}
+            <option value="{{ current_user.id }}" {% if selected_skipper == current_user.id %}selected{% endif %}>My Schedule</option>
+            {% endif %}
+            {% for s in schedules if s.id != current_user.id %}
+            <option value="{{ s.id }}" {% if selected_skipper == s.id %}selected{% endif %}>{{ s.display_name }}'s Schedule</option>
             {% endfor %}
         </select>
+        {% endif %}
+        <div class="btn-group btn-group-sm" role="group" aria-label="RSVP filter">
+            <input type="checkbox" class="btn-check" name="rsvp" value="yes"
+                   id="rsvp-yes" {% if 'yes' in rsvp_filters or not rsvp_filters %}checked{% endif %}
+                   onchange="document.getElementById('filter-form').submit()">
+            <label class="btn btn-outline-success" for="rsvp-yes">Yes</label>
+            <input type="checkbox" class="btn-check" name="rsvp" value="maybe"
+                   id="rsvp-maybe" {% if 'maybe' in rsvp_filters or not rsvp_filters %}checked{% endif %}
+                   onchange="document.getElementById('filter-form').submit()">
+            <label class="btn btn-outline-warning" for="rsvp-maybe">Maybe</label>
+            <input type="checkbox" class="btn-check" name="rsvp" value="no"
+                   id="rsvp-no" {% if 'no' in rsvp_filters or not rsvp_filters %}checked{% endif %}
+                   onchange="document.getElementById('filter-form').submit()">
+            <label class="btn btn-outline-danger" for="rsvp-no">No</label>
+        </div>
     </form>
-    {% endif %}
 </div>
 
-{% macro regatta_table(regattas, is_past, table_id) %}
-{% set can_manage = current_user.is_admin or current_user.is_skipper %}
-{% if can_manage %}
+{% set show_skipper = (selected_skipper == 0) or (selected_skipper is none and schedules|length > 1) %}
+{% macro regatta_table(regattas, is_past, table_id, show_skipper) %}
+{% if can_manage_any %}
 <form method="POST" action="{{ url_for('regattas.bulk_delete') }}" id="{{ table_id }}-form" onsubmit="return confirmBulkDelete(this)">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 </form>
@@ -50,6 +72,7 @@
             <tr>
                 <th>Date(s)</th>
                 <th>Class</th>
+                {% if show_skipper %}<th>Skipper</th>{% endif %}
                 <th>Regatta</th>
                 <th>Location</th>
                 <th class="text-nowrap">Docs</th>
@@ -57,7 +80,7 @@
                 {% if not is_past %}
                 <th>Your RSVP</th>
                 {% endif %}
-                {% if can_manage %}
+                {% if can_manage_any %}
                 <th>Edit</th>
                 <th><input type="checkbox" class="select-all" data-table="{{ table_id }}"></th>
                 {% endif %}
@@ -71,6 +94,7 @@
                     <br><small class="text-muted">{{ regatta.start_date|regatta_days(regatta.end_date) }}</small>
                 </td>
                 <td>{{ regatta.boat_class }}</td>
+                {% if show_skipper %}<td>{{ regatta.creator.display_name }}</td>{% endif %}
                 <td>
                     <strong>{{ regatta.name }}</strong>
                     {% if regatta.notes %}
@@ -98,6 +122,8 @@
                 <td>
                     <form method="POST" action="{{ url_for('regattas.rsvp', regatta_id=regatta.id) }}" class="d-inline">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        {% if selected_skipper is not none %}<input type="hidden" name="redirect_skipper" value="{{ selected_skipper }}">{% endif %}
+                        {% for rf in rsvp_filters %}<input type="hidden" name="redirect_rsvp" value="{{ rf }}">{% endfor %}
                         {% set my_rsvp = regatta.rsvps.filter_by(user_id=current_user.id).first() %}
                         <select name="status" class="form-select form-select-sm d-inline-block w-auto" onchange="this.form.submit()">
                             <option value="" {% if not my_rsvp %}selected{% endif %}>—</option>
@@ -108,20 +134,25 @@
                     </form>
                 </td>
                 {% endif %}
-                {% if can_manage %}
+                {% if can_manage_any %}
+                {% if current_user.is_admin or regatta.created_by == current_user.id %}
                 <td>
                     <a href="{{ url_for('regattas.edit', regatta_id=regatta.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
                 </td>
                 <td>
                     <input type="checkbox" name="selected" value="{{ regatta.id }}" form="{{ table_id }}-form">
                 </td>
+                {% else %}
+                <td></td>
+                <td></td>
+                {% endif %}
                 {% endif %}
             </tr>
             {% endfor %}
         </tbody>
     </table>
 </div>
-{% if can_manage %}
+{% if can_manage_any %}
 <div class="text-end regatta-table-desktop">
     <button type="submit" form="{{ table_id }}-form" class="btn btn-sm btn-outline-danger">Delete Selected</button>
 </div>
@@ -138,13 +169,16 @@
                     <span class="badge bg-secondary ms-1">{{ regatta.boat_class }}</span>
                     {% endif %}
                 </div>
-                {% if can_manage %}
+                {% if current_user.is_admin or regatta.created_by == current_user.id %}
                 <a href="{{ url_for('regattas.edit', regatta_id=regatta.id) }}" class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
                 {% endif %}
             </div>
             <small class="text-muted">
                 {{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}
                 <br>{{ regatta.start_date|regatta_days(regatta.end_date) }}
+                {% if show_skipper %}
+                &middot; Skipper: {{ regatta.creator.display_name }}
+                {% endif %}
                 {% if regatta.location %}
                 &middot;
                 {% if regatta.location_url %}
@@ -169,6 +203,8 @@
             <div class="mt-1">
                 <form method="POST" action="{{ url_for('regattas.rsvp', regatta_id=regatta.id) }}" class="d-inline">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    {% if selected_skipper is not none %}<input type="hidden" name="redirect_skipper" value="{{ selected_skipper }}">{% endif %}
+                    {% for rf in rsvp_filters %}<input type="hidden" name="redirect_rsvp" value="{{ rf }}">{% endfor %}
                     {% set my_rsvp = regatta.rsvps.filter_by(user_id=current_user.id).first() %}
                     <select name="status" class="form-select form-select-sm d-inline-block w-auto" onchange="this.form.submit()">
                         <option value="" {% if not my_rsvp %}selected{% endif %}>—</option>
@@ -187,17 +223,17 @@
 
 {% if upcoming %}
 <h5>Upcoming</h5>
-{{ regatta_table(upcoming, false, "upcoming") }}
+{{ regatta_table(upcoming, false, "upcoming", show_skipper) }}
 {% else %}
 <p class="text-muted">No upcoming regattas. {% if current_user.is_admin or current_user.is_skipper %}Add one!{% endif %}</p>
 {% endif %}
 
 {% if past %}
 <h5 class="mt-4">Past</h5>
-{{ regatta_table(past, true, "past") }}
+{{ regatta_table(past, true, "past", show_skipper) }}
 {% endif %}
 
-{% if current_user.is_admin or current_user.is_skipper %}
+{% if can_manage_any %}
 <script>
 document.querySelectorAll('.select-all').forEach(function(cb) {
     cb.addEventListener('change', function() {

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -4,8 +4,27 @@
 <div class="row justify-content-center mt-3">
     <div class="col-md-5">
         <h2 class="mb-4">Profile Settings</h2>
-        <form method="POST">
+        <form method="POST" enctype="multipart/form-data">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="mb-3">
+                <label for="profile_image" class="form-label">Profile Picture</label>
+                {% if profile_image_url %}
+                <div class="mb-2">
+                    <img
+                        src="{{ profile_image_url }}"
+                        alt="Current profile picture"
+                        class="img-thumbnail"
+                        style="max-width: 160px; max-height: 160px;"
+                    >
+                </div>
+                <div class="form-check mb-2">
+                    <input type="checkbox" class="form-check-input" id="remove_profile_image" name="remove_profile_image">
+                    <label class="form-check-label" for="remove_profile_image">Remove current picture</label>
+                </div>
+                {% endif %}
+                <input type="file" class="form-control" id="profile_image" name="profile_image" accept=".jpg,.jpeg,.png,.gif,.webp,image/*">
+                <div class="form-text">Accepted formats: JPG, JPEG, PNG, GIF, WEBP.</div>
+            </div>
             <div class="mb-3">
                 <label for="display_name" class="form-label">Display Name</label>
                 <input type="text" class="form-control" id="display_name" name="display_name" required value="{{ current_user.display_name }}">

--- a/migrations/versions/f6b7c8d9e0f1_add_profile_image_key_to_users.py
+++ b/migrations/versions/f6b7c8d9e0f1_add_profile_image_key_to_users.py
@@ -1,0 +1,24 @@
+"""Add profile image key to users
+
+Revision ID: f6b7c8d9e0f1
+Revises: a5b6c7d8e9f0
+Create Date: 2026-03-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f6b7c8d9e0f1"
+down_revision = "a5b6c7d8e9f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users", sa.Column("profile_image_key", sa.String(length=255), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("users", "profile_image_key")

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -48,7 +48,7 @@ class TestAppFactory:
                 "ENV": "production",
                 "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
                 "WTF_CSRF_ENABLED": False,
-                "SERVER_NAME": "localhost",
+                "SERVER_NAME": "prod.example",
                 "ANTHROPIC_API_KEY": "test-key",
             }
         )
@@ -60,7 +60,7 @@ class TestAppFactory:
             _db.session.commit()
 
             client = app.test_client()
-            resp = client.get("/")
+            resp = client.get("/", base_url="http://prod.example")
             assert resp.status_code == 200
             assert b"googletagmanager.com/gtag/js?id=G-SHOWME123" in resp.data
 

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -201,3 +201,46 @@ class TestAdminUsersPage:
         assert resp.status_code == 200
         assert b"send_email_invite" not in resp.data
         assert b"Resend Invites" not in resp.data
+
+
+class TestDeleteUser:
+    @patch("app.auth.routes.storage.delete_file")
+    def test_delete_user_removes_profile_image(self, mock_delete_file, logged_in_client, db):
+        user = User(
+            email="delete-me@test.com",
+            password_hash="pending",
+            display_name="Delete Me",
+            initials="DM",
+            profile_image_key="profile-images/avatar.png",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        resp = logged_in_client.post(
+            f"/admin/users/{user.id}/delete",
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert db.session.get(User, user.id) is None
+        mock_delete_file.assert_called_once_with("profile-images/avatar.png")
+
+    @patch("app.auth.routes.storage.delete_file")
+    def test_delete_user_without_profile_image(self, mock_delete_file, logged_in_client, db):
+        user = User(
+            email="no-image@test.com",
+            password_hash="pending",
+            display_name="No Image",
+            initials="NI",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        resp = logged_in_client.post(
+            f"/admin/users/{user.id}/delete",
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert db.session.get(User, user.id) is None
+        mock_delete_file.assert_not_called()

--- a/tests/test_profile_picture.py
+++ b/tests/test_profile_picture.py
@@ -1,0 +1,126 @@
+from io import BytesIO
+from unittest.mock import patch
+
+from app.models import User
+
+
+class TestProfilePicture:
+    @patch("app.auth.routes.storage.upload_file")
+    def test_upload_profile_picture(self, mock_upload, app, client, db):
+        app.config["BUCKET_NAME"] = "test-bucket"
+
+        user = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+            is_admin=False,
+            is_skipper=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.post(
+            "/profile",
+            data={
+                "display_name": "Crew",
+                "initials": "CR",
+                "email": "crew@test.com",
+                "email_opt_in": "on",
+                "profile_image": (BytesIO(b"fake-image"), "avatar.png"),
+            },
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        db.session.refresh(user)
+        assert user.profile_image_key is not None
+        assert user.profile_image_key.startswith("profile-images/")
+        assert user.profile_image_key.endswith(".png")
+        mock_upload.assert_called_once()
+
+    @patch("app.auth.routes.storage.upload_file")
+    def test_rejects_invalid_profile_picture_extension(
+        self, mock_upload, app, client, db
+    ):
+        app.config["BUCKET_NAME"] = "test-bucket"
+
+        user = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+            is_admin=False,
+            is_skipper=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.post(
+            "/profile",
+            data={
+                "display_name": "Crew",
+                "initials": "CR",
+                "email": "crew@test.com",
+                "email_opt_in": "on",
+                "profile_image": (BytesIO(b"not-an-image"), "avatar.txt"),
+            },
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert b"Profile picture must be a JPG, JPEG, PNG, GIF, or WEBP file." in resp.data
+        db.session.refresh(user)
+        assert user.profile_image_key is None
+        mock_upload.assert_not_called()
+
+    @patch("app.auth.routes.storage.delete_file")
+    def test_remove_profile_picture(self, mock_delete, app, client, db):
+        user = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+            is_admin=False,
+            is_skipper=False,
+            profile_image_key="profile-images/old.png",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.post(
+            "/profile",
+            data={
+                "display_name": "Crew",
+                "initials": "CR",
+                "email": "crew@test.com",
+                "email_opt_in": "on",
+                "remove_profile_image": "on",
+            },
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        db.session.refresh(user)
+        assert user.profile_image_key is None
+        mock_delete.assert_called_once_with("profile-images/old.png")

--- a/tests/test_schedule_filters.py
+++ b/tests/test_schedule_filters.py
@@ -1,0 +1,294 @@
+"""Tests for schedule page filter enhancements: dropdown labels, skipper column, RSVP filter."""
+
+from datetime import date, timedelta
+
+from app.models import RSVP, Regatta, User
+
+
+def _create_regatta(db, name, created_by, days_offset=7):
+    """Helper to create a regatta with a future start date."""
+    r = Regatta(
+        name=name,
+        location="Test Location",
+        start_date=date.today() + timedelta(days=days_offset),
+        created_by=created_by,
+    )
+    db.session.add(r)
+    db.session.commit()
+    return r
+
+
+class TestDropdownLabels:
+    """Dropdown shows "'s Schedule" suffix for other skippers."""
+
+    def test_other_skipper_shows_schedule_suffix(
+        self, app, db, logged_in_client, admin_user
+    ):
+        # Create another skipper so dropdown appears (admin + other = 2 schedules)
+        other = User(
+            email="skipper2@test.com",
+            display_name="John Smith",
+            initials="JS",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        resp = logged_in_client.get("/")
+        assert (
+            b"John Smith&#39;s Schedule" in resp.data
+            or b"John Smith's Schedule" in resp.data
+        )
+
+    def test_my_schedule_label_unchanged(self, app, db, logged_in_client, admin_user):
+        other = User(
+            email="skipper2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        resp = logged_in_client.get("/")
+        assert b"My Schedule" in resp.data
+
+    def test_all_schedules_label_unchanged(self, app, db, logged_in_client, admin_user):
+        other = User(
+            email="skipper2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        resp = logged_in_client.get("/?skipper=0")
+        assert b"All Schedules" in resp.data
+
+
+class TestSkipperColumn:
+    """All Schedules view includes Skipper column; single skipper hides it."""
+
+    def test_all_schedules_shows_skipper_column(
+        self, app, db, logged_in_client, admin_user
+    ):
+        other = User(
+            email="skipper2@test.com",
+            display_name="Jane Doe",
+            initials="JD",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        _create_regatta(db, "Regatta A", admin_user.id)
+        _create_regatta(db, "Regatta B", other.id)
+
+        resp = logged_in_client.get("/?skipper=0")
+        assert b"<th>Skipper</th>" in resp.data
+        assert b"Jane Doe" in resp.data
+        assert b"Admin" in resp.data
+
+    def test_single_skipper_hides_skipper_column(
+        self, app, db, logged_in_client, admin_user
+    ):
+        _create_regatta(db, "Regatta A", admin_user.id)
+
+        resp = logged_in_client.get(f"/?skipper={admin_user.id}")
+        assert b"<th>Skipper</th>" not in resp.data
+
+    def test_mobile_shows_skipper_in_all_schedules(
+        self, app, db, logged_in_client, admin_user
+    ):
+        other = User(
+            email="skipper2@test.com",
+            display_name="Jane Doe",
+            initials="JD",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        _create_regatta(db, "Regatta A", other.id)
+
+        resp = logged_in_client.get("/?skipper=0")
+        assert b"Skipper: Jane Doe" in resp.data
+
+
+class TestRSVPFilter:
+    """RSVP toggle buttons filter regattas by attendance status."""
+
+    def test_filter_yes_shows_only_yes_regattas(
+        self, app, db, logged_in_client, admin_user
+    ):
+        r1 = _create_regatta(db, "Yes Regatta", admin_user.id, days_offset=10)
+        r2 = _create_regatta(db, "No Regatta", admin_user.id, days_offset=11)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r2.id, user_id=admin_user.id, status="no"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/?rsvp=yes")
+        assert b"Yes Regatta" in resp.data
+        assert b"No Regatta" not in resp.data
+
+    def test_filter_no_shows_only_no_regattas(
+        self, app, db, logged_in_client, admin_user
+    ):
+        r1 = _create_regatta(db, "Yes Regatta", admin_user.id, days_offset=10)
+        r2 = _create_regatta(db, "No Regatta", admin_user.id, days_offset=11)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r2.id, user_id=admin_user.id, status="no"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/?rsvp=no")
+        assert b"No Regatta" in resp.data
+        assert b"Yes Regatta" not in resp.data
+
+    def test_combined_yes_maybe_shows_both(self, app, db, logged_in_client, admin_user):
+        r1 = _create_regatta(db, "Yes Regatta", admin_user.id, days_offset=10)
+        r2 = _create_regatta(db, "Maybe Regatta", admin_user.id, days_offset=11)
+        r3 = _create_regatta(db, "No Regatta", admin_user.id, days_offset=12)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r2.id, user_id=admin_user.id, status="maybe"))
+        db.session.add(RSVP(regatta_id=r3.id, user_id=admin_user.id, status="no"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/?rsvp=yes&rsvp=maybe")
+        assert b"Yes Regatta" in resp.data
+        assert b"Maybe Regatta" in resp.data
+        assert b"No Regatta" not in resp.data
+
+    def test_all_three_checked_shows_everything(
+        self, app, db, logged_in_client, admin_user
+    ):
+        r1 = _create_regatta(db, "Yes Regatta", admin_user.id, days_offset=10)
+        _create_regatta(db, "Unrsvpd Regatta", admin_user.id, days_offset=11)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/?rsvp=yes&rsvp=no&rsvp=maybe")
+        assert b"Yes Regatta" in resp.data
+        assert b"Unrsvpd Regatta" in resp.data
+
+    def test_no_filter_shows_everything(self, app, db, logged_in_client, admin_user):
+        r1 = _create_regatta(db, "Yes Regatta", admin_user.id, days_offset=10)
+        _create_regatta(db, "Unrsvpd Regatta", admin_user.id, days_offset=11)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/")
+        assert b"Yes Regatta" in resp.data
+        assert b"Unrsvpd Regatta" in resp.data
+
+    def test_combined_skipper_and_rsvp_filter(
+        self, app, db, logged_in_client, admin_user
+    ):
+        other = User(
+            email="skipper2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        r1 = _create_regatta(db, "Admin Yes", admin_user.id, days_offset=10)
+        r2 = _create_regatta(db, "Other Yes", other.id, days_offset=11)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r2.id, user_id=admin_user.id, status="yes"))
+        db.session.commit()
+
+        # Filter by admin's schedule + RSVP yes
+        resp = logged_in_client.get(f"/?skipper={admin_user.id}&rsvp=yes")
+        assert b"Admin Yes" in resp.data
+        assert b"Other Yes" not in resp.data
+
+
+class TestRSVPToggleButtons:
+    """Toggle buttons are present with correct checked state."""
+
+    def test_toggle_buttons_present(self, app, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/")
+        assert b'id="rsvp-yes"' in resp.data
+        assert b'id="rsvp-maybe"' in resp.data
+        assert b'id="rsvp-no"' in resp.data
+
+    def test_default_all_checked(self, app, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/")
+        html = resp.data.decode()
+        # All three should be checked by default (no rsvp_filters)
+        assert 'id="rsvp-yes" checked' in html
+        assert 'id="rsvp-maybe" checked' in html
+        assert 'id="rsvp-no" checked' in html
+
+    def test_filtered_state_reflected(self, app, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/?rsvp=yes")
+        html = resp.data.decode()
+        assert 'id="rsvp-yes" checked' in html
+        # Maybe and No should NOT be checked
+        assert 'id="rsvp-maybe" checked' not in html
+        assert 'id="rsvp-no" checked' not in html
+
+
+class TestRSVPFilterStatePreservation:
+    """RSVP submission preserves filter state in redirect."""
+
+    def test_rsvp_preserves_skipper_filter(self, app, db, logged_in_client, admin_user):
+        r = _create_regatta(db, "Test Regatta", admin_user.id)
+
+        resp = logged_in_client.post(
+            f"/regattas/{r.id}/rsvp",
+            data={
+                "status": "yes",
+                "redirect_skipper": str(admin_user.id),
+            },
+        )
+        assert resp.status_code == 302
+        location = resp.headers["Location"]
+        assert f"skipper={admin_user.id}" in location
+
+    def test_rsvp_preserves_rsvp_filter(self, app, db, logged_in_client, admin_user):
+        r = _create_regatta(db, "Test Regatta", admin_user.id)
+
+        resp = logged_in_client.post(
+            f"/regattas/{r.id}/rsvp",
+            data={
+                "status": "yes",
+                "redirect_rsvp": ["yes", "maybe"],
+            },
+        )
+        assert resp.status_code == 302
+        location = resp.headers["Location"]
+        assert "rsvp=yes" in location
+        assert "rsvp=maybe" in location
+
+    def test_rsvp_preserves_combined_filters(
+        self, app, db, logged_in_client, admin_user
+    ):
+        r = _create_regatta(db, "Test Regatta", admin_user.id)
+
+        resp = logged_in_client.post(
+            f"/regattas/{r.id}/rsvp",
+            data={
+                "status": "yes",
+                "redirect_skipper": "0",
+                "redirect_rsvp": ["yes"],
+            },
+        )
+        assert resp.status_code == 302
+        location = resp.headers["Location"]
+        assert "skipper=0" in location
+        assert "rsvp=yes" in location

--- a/tests/test_skipper_crew.py
+++ b/tests/test_skipper_crew.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 
-from app.models import Document, Regatta, RSVP, User, skipper_crew
+from app.models import RSVP, Document, Regatta, User, skipper_crew
 
 
 class TestCrewManagementPage:
@@ -447,15 +447,15 @@ class TestCreateSchedule:
 
 
 class TestDeleteSchedule:
-    def test_skipper_can_delete_schedule(self, app, logged_in_skipper, db, skipper_user):
+    def test_skipper_can_delete_schedule(
+        self, app, logged_in_skipper, db, skipper_user
+    ):
         resp = logged_in_skipper.post("/delete-schedule", follow_redirects=True)
         assert b"Your schedule has been deleted." in resp.data
         db.session.refresh(skipper_user)
         assert skipper_user.is_skipper is False
 
-    def test_delete_removes_regattas(
-        self, app, logged_in_skipper, db, skipper_user
-    ):
+    def test_delete_removes_regattas(self, app, logged_in_skipper, db, skipper_user):
         regatta = Regatta(
             name="Gone Regatta",
             location="Test YC",
@@ -474,9 +474,7 @@ class TestDeleteSchedule:
     ):
         logged_in_skipper.post("/delete-schedule", follow_redirects=True)
         rows = db.session.execute(
-            skipper_crew.select().where(
-                skipper_crew.c.skipper_id == skipper_user.id
-            )
+            skipper_crew.select().where(skipper_crew.c.skipper_id == skipper_user.id)
         ).fetchall()
         assert len(rows) == 0
 
@@ -509,3 +507,281 @@ class TestDeleteSchedule:
     def test_non_skipper_gets_error(self, logged_in_crew):
         resp = logged_in_crew.post("/delete-schedule", follow_redirects=True)
         assert b"don&#39;t have a schedule" in resp.data
+
+
+class TestScheduleSwitcher:
+    """Tests for the unified schedule switcher dropdown and action scoping."""
+
+    def test_skipper_crew_sees_dropdown(self, app, db, skipper_user):
+        """Skipper+crew user with 2 contexts sees the schedule dropdown."""
+        # Create a second skipper and make skipper_user crew for them
+        other_skipper = User(
+            email="skip2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.flush()
+        other_skipper.crew_members.append(skipper_user)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "skipper@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/")
+        assert b"My Schedule" in resp.data
+        assert b"Other Skipper" in resp.data
+        assert b"All Schedules" in resp.data
+
+    def test_skipper_crew_own_schedule_shows_management(self, app, db, skipper_user):
+        """Filtering to own schedule shows Add Regatta and Edit buttons."""
+        other_skipper = User(
+            email="skip2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.flush()
+        other_skipper.crew_members.append(skipper_user)
+
+        regatta = Regatta(
+            name="My Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "skipper@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get(f"/?skipper={skipper_user.id}")
+        assert b"+ Add Regatta" in resp.data
+        assert b"Edit" in resp.data
+        assert b"Delete Schedule" in resp.data
+
+    def test_skipper_crew_other_schedule_hides_management(self, app, db, skipper_user):
+        """Filtering to another skipper hides Add Regatta and Edit."""
+        other_skipper = User(
+            email="skip2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.flush()
+        other_skipper.crew_members.append(skipper_user)
+
+        regatta = Regatta(
+            name="Their Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=other_skipper.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "skipper@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get(f"/?skipper={other_skipper.id}")
+        assert b"+ Add Regatta" not in resp.data
+        assert b"Delete Schedule" not in resp.data
+        # The Edit column headers should not appear
+        assert b"Delete Selected" not in resp.data
+
+    def test_pure_crew_one_skipper_no_dropdown(
+        self, app, logged_in_crew, db, skipper_user
+    ):
+        """Crew with only 1 skipper sees no dropdown."""
+        regatta = Regatta(
+            name="Crew View",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_crew.get("/")
+        assert b"All Schedules" not in resp.data
+        # No skipper dropdown should render
+        assert b'name="skipper"' not in resp.data
+
+    def test_pure_crew_two_skippers_shows_dropdown(self, app, db, skipper_user):
+        """Crew with 2 skippers sees the dropdown."""
+        crew = User(
+            email="multicrew@test.com",
+            display_name="Multi Crew",
+            initials="MC",
+            is_skipper=False,
+        )
+        crew.set_password("password")
+        db.session.add(crew)
+        db.session.flush()
+
+        skipper_user.crew_members.append(crew)
+
+        other_skipper = User(
+            email="skip2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.flush()
+        other_skipper.crew_members.append(crew)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "multicrew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/")
+        assert b"All Schedules" in resp.data
+        assert b"Skipper" in resp.data
+        assert b"Other Skipper" in resp.data
+        # Pure crew: dropdown should not include "My Schedule" option
+        html = resp.data.decode()
+        assert ">My Schedule</option>" not in html
+
+    def test_edit_only_on_own_regattas_in_all_view(self, app, db, skipper_user):
+        """In All Schedules view, Edit button only appears on own regattas."""
+        other_skipper = User(
+            email="skip2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.flush()
+        other_skipper.crew_members.append(skipper_user)
+
+        own_regatta = Regatta(
+            name="Own Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=skipper_user.id,
+        )
+        other_regatta = Regatta(
+            name="Other Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 2),
+            created_by=other_skipper.id,
+        )
+        db.session.add_all([own_regatta, other_regatta])
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "skipper@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/")
+        html = resp.data.decode()
+
+        # Own regatta row should have an edit link
+        assert f"/regattas/{own_regatta.id}/edit" in html
+        # Other regatta row should NOT have an edit link
+        assert f"/regattas/{other_regatta.id}/edit" not in html
+
+    def test_skipper_only_no_dropdown(self, app, logged_in_skipper, db, skipper_user):
+        """A skipper with no crew relationships sees no dropdown."""
+        resp = logged_in_skipper.get("/")
+        assert b"All Schedules" not in resp.data
+
+    def test_page_title_filtered_to_self(self, app, db, skipper_user):
+        """Filtering to own schedule shows own name in title."""
+        other_skipper = User(
+            email="skip2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.flush()
+        other_skipper.crew_members.append(skipper_user)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "skipper@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get(f"/?skipper={skipper_user.id}")
+        assert (
+            b"Skipper&#39;s Race Schedule" in resp.data
+            or b"Skipper's Race Schedule" in resp.data
+        )
+
+    def test_page_title_filtered_to_other(self, app, db, skipper_user):
+        """Filtering to another skipper shows their name in title."""
+        other_skipper = User(
+            email="skip2@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.flush()
+        other_skipper.crew_members.append(skipper_user)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "skipper@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get(f"/?skipper={other_skipper.id}")
+        html = resp.data.decode()
+        assert (
+            "Other Skipper&#39;s Race Schedule" in html
+            or "Other Skipper's Race Schedule" in html
+        )
+
+    def test_page_title_single_context(self, app, logged_in_crew, db, skipper_user):
+        """Single-context crew user sees skipper name in title."""
+        resp = logged_in_crew.get("/")
+        html = resp.data.decode()
+        assert (
+            "Skipper&#39;s Race Schedule" in html or "Skipper's Race Schedule" in html
+        )
+
+    def test_crew_no_edit_buttons(self, app, logged_in_crew, db, skipper_user):
+        """Pure crew user never sees Edit buttons."""
+        regatta = Regatta(
+            name="Crew View Regatta",
+            location="Test YC",
+            start_date=date(2026, 8, 1),
+            created_by=skipper_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        resp = logged_in_crew.get("/")
+        assert b"+ Add Regatta" not in resp.data
+        assert b"Delete Selected" not in resp.data


### PR DESCRIPTION
## Summary
- **Profile pictures**: Upload/remove on Profile Settings with image type validation (JPG, PNG, GIF, WEBP). Admin delete-user cleans up stored images. New DB migration for `profile_image_key`.
- **Schedule switcher**: Unified dropdown for skipper+crew users with scoped Edit/Add/Delete actions, page title reflects selected context
- **Schedule filter enhancements**: Dropdown labels append "'s Schedule" for other skippers, Skipper column in All Schedules view, RSVP attendance filter with Yes/Maybe/No toggle buttons
- **Filter state preservation**: Skipper and RSVP filter params survive RSVP form submissions

## Test plan
- [x] 264 tests pass (`pytest`)
- [x] Linting clean (`black`, `isort`, `flake8`)
- [ ] Manual: Profile picture upload, preview, and remove work
- [ ] Manual: Dropdown shows "John's Schedule" not "John"
- [ ] Manual: "All Schedules" view has Skipper column; single skipper view does not
- [ ] Manual: Toggle Yes/Maybe/No buttons to filter; combinations work
- [ ] Manual: Submitting an RSVP while filtered returns to the same filtered view

🤖 Generated with [Claude Code](https://claude.com/claude-code)