### PR TITLE
Fix profile pictures, PDF filters, RSVP filters, skipper links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@ Semantic Versioning (SemVer): `MAJOR.MINOR.PATCH`
   - `fix/` branches bump PATCH (e.g. 0.14.0 → 0.14.1)
 - **After merging, tag the merge commit:** `git tag v<version>` and `git push origin --tags`
 
+## Task Tracking
+- When working on complex or multi-step tasks, create a todo list to track progress and remain on track
+- Check off items as they are completed to maintain visibility into what remains
+
 ## Git Workflow
 - `master` branch is production-ready — **never push directly to master**
 - All work must be on a branch: `feature/<name>` for new work, `fix/<name>` for bug fixes

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple web app for organizing sailboat regattas. Track dates, locations, NOR/S
 - Crew members see their skippers' regattas with skipper filter dropdown
 - Location links to Google Maps
 - Upload/download NOR and SI PDFs (stored in S3)
+- Profile pictures with S3 storage, displayed in navbar and crew profiles
 - Crew RSVP (Yes / No / Maybe) with color-coded initials
 - AI-powered schedule import: paste text or URL, Claude extracts regattas for review and bulk import, with auto-discovery of NOR/SI/WWW documents from regatta detail pages and regatta websites (including clubspot Parse API integration)
 - Admin: manage all users, site settings, invite skippers

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.48.1
+- Fix profile picture not displaying in navbar avatar and crew profile pages (#69)
+- Fix PDF print to only include regattas matching current schedule and RSVP filters (#71)
+- Add Skipper column and dynamic title to PDF when viewing All Schedules
+- Fix RSVP filter to match any crew member's RSVP, not just the current user's (#72)
+- Link skipper names to their profile in Combined Schedules view (#70)
+- Rename "All Schedules" to "Combined Schedules" throughout UI and PDF
+
 ## 0.48.0
 - Add profile picture support in Profile Settings with image upload and preview
 - Add optional remove-profile-picture action from Profile Settings

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = "0.48.0"
+__version__ = "0.48.1"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -45,6 +45,24 @@ def create_app(test_config=None):
     @app.context_processor
     def inject_version():
         return {"app_version": __version__}
+
+    @app.context_processor
+    def inject_profile_image():
+        from flask_login import current_user as cu
+
+        url = None
+        if (
+            cu.is_authenticated
+            and cu.profile_image_key
+            and app.config.get("BUCKET_NAME")
+        ):
+            try:
+                from app import storage
+
+                url = storage.get_file_url(cu.profile_image_key)
+            except Exception:
+                pass
+        return {"current_user_profile_image_url": url}
 
     @app.context_processor
     def inject_site_settings():

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -3,14 +3,15 @@ import os
 import secrets
 import uuid
 
-from flask import current_app, flash, redirect, render_template, request, url_for
+from flask import (current_app, flash, redirect, render_template, request,
+                   url_for)
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.utils import secure_filename
 
 from app import db, storage
 from app.admin.email_service import is_email_configured, send_email
 from app.auth import bp
-from app.models import Document, Regatta, RSVP, User, skipper_crew
+from app.models import RSVP, Document, Regatta, User, skipper_crew
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +177,9 @@ def profile():
                 db.session.rollback()
                 if new_image_key:
                     storage.delete_file(new_image_key)
-                logger.exception("Failed to update profile for user %s", current_user.id)
+                logger.exception(
+                    "Failed to update profile for user %s", current_user.id
+                )
                 flash("Unable to update profile right now. Please try again.", "error")
             else:
                 if old_image_key and old_image_key != current_user.profile_image_key:
@@ -197,7 +200,11 @@ def view_profile(user_id: int):
     if not user or user.invite_token:
         flash("User not found.", "error")
         return redirect(url_for("regattas.index"))
-    return render_template("view_profile.html", user=user)
+    return render_template(
+        "view_profile.html",
+        user=user,
+        profile_image_url=_build_profile_image_url(user.profile_image_key),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -14,38 +14,45 @@ from app.permissions import can_manage_regatta, can_rsvp_to_regatta
 from app.regattas import bp
 
 
-@bp.route("/")
-def index():
-    if not current_user.is_authenticated:
-        return render_template("login.html")
-
-    upcoming, past = current_user.visible_regattas_split()
-
-    # Skipper filter: default non-admin skippers to their own schedule
+def _apply_schedule_filters(upcoming, past, user):
+    """Apply skipper and RSVP query-string filters to regatta lists."""
     skipper_id = request.args.get("skipper", type=int)
-    if skipper_id is None and current_user.is_skipper and not current_user.is_admin:
-        skipper_id = current_user.id
+    if skipper_id is None and user.is_skipper and not user.is_admin:
+        skipper_id = user.id
     # skipper_id == 0 means "All Schedules" (explicit selection, no filter)
     if skipper_id:
         upcoming = [r for r in upcoming if r.created_by == skipper_id]
         past = [r for r in past if r.created_by == skipper_id]
 
-    # RSVP attendance filter
     rsvp_filters = [
         v.lower()
         for v in request.args.getlist("rsvp")
         if v.lower() in ("yes", "no", "maybe")
     ]
     if rsvp_filters and set(rsvp_filters) != {"yes", "no", "maybe"}:
+        visible_ids = {r.id for r in upcoming + past}
         rsvp_regatta_ids = {
             r.regatta_id
             for r in RSVP.query.filter(
-                RSVP.user_id == current_user.id,
+                RSVP.regatta_id.in_(visible_ids),
                 RSVP.status.in_(rsvp_filters),
             ).all()
         }
         upcoming = [r for r in upcoming if r.id in rsvp_regatta_ids]
         past = [r for r in past if r.id in rsvp_regatta_ids]
+
+    return upcoming, past, skipper_id, rsvp_filters
+
+
+@bp.route("/")
+def index():
+    if not current_user.is_authenticated:
+        return render_template("login.html")
+
+    upcoming, past = current_user.visible_regattas_split()
+    upcoming, past, skipper_id, rsvp_filters = _apply_schedule_filters(
+        upcoming, past, current_user
+    )
 
     users = (
         User.query.filter(User.invite_token.is_(None)).order_by(User.display_name).all()
@@ -74,6 +81,13 @@ def index():
     else:
         can_manage_any = False
 
+    # Build PDF URL with current filters
+    pdf_args = {}
+    if skipper_id is not None:
+        pdf_args["skipper"] = skipper_id
+    if rsvp_filters:
+        pdf_args["rsvp"] = rsvp_filters
+
     return render_template(
         "index.html",
         upcoming=upcoming,
@@ -83,6 +97,7 @@ def index():
         selected_skipper=skipper_id,
         can_manage_any=can_manage_any,
         rsvp_filters=rsvp_filters,
+        pdf_url=url_for("regattas.pdf", **pdf_args),
     )
 
 
@@ -90,11 +105,32 @@ def index():
 @login_required
 def pdf():
     upcoming, past = current_user.visible_regattas_split()
+    upcoming, past, skipper_id, _rsvp_filters = _apply_schedule_filters(
+        upcoming, past, current_user
+    )
+
+    # Determine title and whether to show skipper column
+    show_skipper = skipper_id == 0 or (
+        skipper_id is None
+        and not (current_user.is_skipper and not current_user.is_admin)
+    )
+    if skipper_id and skipper_id != 0:
+        skipper = db.session.get(User, skipper_id)
+        pdf_title = (
+            f"{skipper.display_name}'s Race Schedule" if skipper else "Race Schedule"
+        )
+    elif show_skipper:
+        pdf_title = "Combined Race Schedules"
+    else:
+        pdf_title = f"{current_user.display_name}'s Race Schedule"
+
     html_str = render_template(
         "pdf_schedule.html",
         upcoming=upcoming,
         past=past,
         generated_date=date.today().strftime("%B %d, %Y"),
+        show_skipper=show_skipper,
+        pdf_title=pdf_title,
     )
     pdf_bytes = HTML(string=html_str).write_pdf()
     response = make_response(pdf_bytes)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -30,6 +30,13 @@
     font-size: 0.85rem;
 }
 
+.nav-avatar-img {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
 .rsvp-yes { color: #198754; font-weight: bold; }
 .rsvp-no { color: #dc3545; }
 .rsvp-maybe { color: #ffc107; font-weight: bold; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,7 +56,7 @@
                     </li>
                     {% endif %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle nav-avatar" href="#" role="button" data-bs-toggle="dropdown">{{ current_user.initials }}</a>
+                        <a class="nav-link dropdown-toggle nav-avatar" href="#" role="button" data-bs-toggle="dropdown">{% if current_user_profile_image_url %}<img src="{{ current_user_profile_image_url }}" alt="{{ current_user.initials }}" class="nav-avatar-img">{% else %}{{ current_user.initials }}{% endif %}</a>
                         <ul class="dropdown-menu dropdown-menu-end">
                             <li><a class="dropdown-item" href="{{ url_for('auth.profile') }}">Profile Settings</a></li>
                             {% if not current_user.is_skipper and not current_user.is_admin %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,10 +2,10 @@
 {% block content %}
 
 <div class="mb-3 d-flex flex-wrap align-items-center">
-    <a href="{{ url_for('regattas.pdf') }}" class="btn btn-outline-secondary btn-sm no-print" target="_blank">Print PDF</a>
+    <a href="{{ pdf_url }}" class="btn btn-outline-secondary btn-sm no-print" target="_blank">Print PDF</a>
     <div class="flex-grow-1 text-center">
         {% if selected_skipper == 0 %}
-        <h2 class="mb-0">Race Schedule</h2>
+        <h2 class="mb-0">Combined Race Schedules</h2>
         {% elif selected_skipper == current_user.id %}
         <h2 class="mb-0">{{ current_user.display_name }}'s Race Schedule</h2>
         {% elif selected_skipper %}
@@ -33,7 +33,7 @@
     <form method="GET" id="filter-form" class="d-inline-flex flex-wrap align-items-center gap-2 ms-auto">
         {% if schedules|length > 1 %}
         <select name="skipper" class="form-select form-select-sm" style="width:auto" onchange="this.form.submit()">
-            <option value="0" {% if selected_skipper == 0 %}selected{% endif %}>All Schedules</option>
+            <option value="0" {% if selected_skipper == 0 %}selected{% endif %}>Combined Schedules</option>
             {% if current_user.is_skipper %}
             <option value="{{ current_user.id }}" {% if selected_skipper == current_user.id %}selected{% endif %}>My Schedule</option>
             {% endif %}
@@ -94,7 +94,7 @@
                     <br><small class="text-muted">{{ regatta.start_date|regatta_days(regatta.end_date) }}</small>
                 </td>
                 <td>{{ regatta.boat_class }}</td>
-                {% if show_skipper %}<td>{{ regatta.creator.display_name }}</td>{% endif %}
+                {% if show_skipper %}<td><a href="{{ url_for('auth.view_profile', user_id=regatta.created_by) }}" class="location-link">{{ regatta.creator.display_name }}</a></td>{% endif %}
                 <td>
                     <strong>{{ regatta.name }}</strong>
                     {% if regatta.notes %}
@@ -177,7 +177,7 @@
                 {{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}
                 <br>{{ regatta.start_date|regatta_days(regatta.end_date) }}
                 {% if show_skipper %}
-                &middot; Skipper: {{ regatta.creator.display_name }}
+                &middot; Skipper: <a href="{{ url_for('auth.view_profile', user_id=regatta.created_by) }}" class="location-link">{{ regatta.creator.display_name }}</a>
                 {% endif %}
                 {% if regatta.location %}
                 &middot;

--- a/app/templates/pdf_schedule.html
+++ b/app/templates/pdf_schedule.html
@@ -58,7 +58,7 @@
     </style>
 </head>
 <body>
-    <h1>Race Crew Network</h1>
+    <h1>{{ pdf_title }}</h1>
     <div class="subtitle">Generated {{ generated_date }}</div>
 
     {% macro regatta_rows(regattas) %}
@@ -69,6 +69,7 @@
             <br><span class="notes">{{ regatta.start_date|regatta_days(regatta.end_date) }}</span>
         </td>
         <td>{{ regatta.boat_class }}</td>
+        {% if show_skipper %}<td>{{ regatta.creator.display_name }}</td>{% endif %}
         <td>
             <strong>{{ regatta.name }}</strong>
             {% if regatta.notes %}
@@ -90,18 +91,23 @@
     {% endfor %}
     {% endmacro %}
 
+    {% macro table_header() %}
+    <tr>
+        <th>Date(s)</th>
+        <th>Class</th>
+        {% if show_skipper %}<th>Skipper</th>{% endif %}
+        <th>Regatta</th>
+        <th>Location</th>
+        <th>Docs</th>
+        <th>Crew</th>
+    </tr>
+    {% endmacro %}
+
     {% if upcoming %}
     <h2>Upcoming</h2>
     <table>
         <thead>
-            <tr>
-                <th>Date(s)</th>
-                <th>Class</th>
-                <th>Regatta</th>
-                <th>Location</th>
-                <th>Docs</th>
-                <th>Crew</th>
-            </tr>
+            {{ table_header() }}
         </thead>
         <tbody>
             {{ regatta_rows(upcoming) }}
@@ -113,14 +119,7 @@
     <h2>Past</h2>
     <table class="past-table">
         <thead>
-            <tr>
-                <th>Date(s)</th>
-                <th>Class</th>
-                <th>Regatta</th>
-                <th>Location</th>
-                <th>Docs</th>
-                <th>Crew</th>
-            </tr>
+            {{ table_header() }}
         </thead>
         <tbody>
             {{ regatta_rows(past) }}

--- a/app/templates/view_profile.html
+++ b/app/templates/view_profile.html
@@ -3,6 +3,11 @@
 {% block content %}
 <div class="row justify-content-center mt-3">
     <div class="col-md-5">
+        {% if profile_image_url %}
+        <div class="mb-3 text-center">
+            <img src="{{ profile_image_url }}" alt="{{ user.display_name }}" class="rounded-circle" style="width: 120px; height: 120px; object-fit: cover;">
+        </div>
+        {% endif %}
         <h2 class="mb-4">{{ user.display_name }}</h2>
         <table class="table">
             <tr>

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -205,7 +205,9 @@ class TestAdminUsersPage:
 
 class TestDeleteUser:
     @patch("app.auth.routes.storage.delete_file")
-    def test_delete_user_removes_profile_image(self, mock_delete_file, logged_in_client, db):
+    def test_delete_user_removes_profile_image(
+        self, mock_delete_file, logged_in_client, db
+    ):
         user = User(
             email="delete-me@test.com",
             password_hash="pending",
@@ -226,7 +228,9 @@ class TestDeleteUser:
         mock_delete_file.assert_called_once_with("profile-images/avatar.png")
 
     @patch("app.auth.routes.storage.delete_file")
-    def test_delete_user_without_profile_image(self, mock_delete_file, logged_in_client, db):
+    def test_delete_user_without_profile_image(
+        self, mock_delete_file, logged_in_client, db
+    ):
         user = User(
             email="no-image@test.com",
             password_hash="pending",

--- a/tests/test_pdf_filters.py
+++ b/tests/test_pdf_filters.py
@@ -1,0 +1,179 @@
+"""Tests for PDF schedule respecting schedule and RSVP filters (#71)."""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from app.models import RSVP, Regatta, User
+
+
+def _create_regatta(db, name, created_by, days_offset=7):
+    r = Regatta(
+        name=name,
+        location="Test Location",
+        start_date=date.today() + timedelta(days=days_offset),
+        created_by=created_by,
+    )
+    db.session.add(r)
+    db.session.commit()
+    return r
+
+
+class TestPDFFilters:
+    @patch("app.regattas.routes.HTML")
+    def test_pdf_no_filters_includes_all(
+        self, mock_html, app, db, logged_in_client, admin_user
+    ):
+        mock_html.return_value.write_pdf.return_value = b"%PDF-fake"
+
+        _create_regatta(db, "Regatta A", admin_user.id, days_offset=10)
+        _create_regatta(db, "Regatta B", admin_user.id, days_offset=11)
+
+        resp = logged_in_client.get("/schedule.pdf")
+        assert resp.status_code == 200
+        rendered_html = mock_html.call_args[1]["string"]
+        assert "Regatta A" in rendered_html
+        assert "Regatta B" in rendered_html
+
+    @patch("app.regattas.routes.HTML")
+    def test_pdf_skipper_filter(self, mock_html, app, db, logged_in_client, admin_user):
+        mock_html.return_value.write_pdf.return_value = b"%PDF-fake"
+
+        other = User(
+            email="skipper2@test.com",
+            display_name="Other",
+            initials="OT",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        _create_regatta(db, "Admin Regatta", admin_user.id, days_offset=10)
+        _create_regatta(db, "Other Regatta", other.id, days_offset=11)
+
+        resp = logged_in_client.get(f"/schedule.pdf?skipper={admin_user.id}")
+        assert resp.status_code == 200
+        rendered_html = mock_html.call_args[1]["string"]
+        assert "Admin Regatta" in rendered_html
+        assert "Other Regatta" not in rendered_html
+
+    @patch("app.regattas.routes.HTML")
+    def test_pdf_rsvp_filter(self, mock_html, app, db, logged_in_client, admin_user):
+        mock_html.return_value.write_pdf.return_value = b"%PDF-fake"
+
+        r1 = _create_regatta(db, "Yes Regatta", admin_user.id, days_offset=10)
+        r2 = _create_regatta(db, "No Regatta", admin_user.id, days_offset=11)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r2.id, user_id=admin_user.id, status="no"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/schedule.pdf?rsvp=yes")
+        assert resp.status_code == 200
+        rendered_html = mock_html.call_args[1]["string"]
+        assert "Yes Regatta" in rendered_html
+        assert "No Regatta" not in rendered_html
+
+    @patch("app.regattas.routes.HTML")
+    def test_pdf_combined_skipper_and_rsvp_filter(
+        self, mock_html, app, db, logged_in_client, admin_user
+    ):
+        mock_html.return_value.write_pdf.return_value = b"%PDF-fake"
+
+        other = User(
+            email="skipper2@test.com",
+            display_name="Other",
+            initials="OT",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        r1 = _create_regatta(db, "Admin Yes", admin_user.id, days_offset=10)
+        r2 = _create_regatta(db, "Other Yes", other.id, days_offset=11)
+
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r2.id, user_id=admin_user.id, status="yes"))
+        db.session.commit()
+
+        resp = logged_in_client.get(f"/schedule.pdf?skipper={admin_user.id}&rsvp=yes")
+        assert resp.status_code == 200
+        rendered_html = mock_html.call_args[1]["string"]
+        assert "Admin Yes" in rendered_html
+        assert "Other Yes" not in rendered_html
+
+
+class TestPDFSkipperColumnAndTitle:
+    @patch("app.regattas.routes.HTML")
+    def test_all_schedules_shows_skipper_column(
+        self, mock_html, app, db, logged_in_client, admin_user
+    ):
+        mock_html.return_value.write_pdf.return_value = b"%PDF-fake"
+        _create_regatta(db, "Regatta A", admin_user.id, days_offset=10)
+
+        resp = logged_in_client.get("/schedule.pdf?skipper=0")
+        assert resp.status_code == 200
+        rendered_html = mock_html.call_args[1]["string"]
+        assert "<th>Skipper</th>" in rendered_html
+        assert "Combined Race Schedules" in rendered_html
+
+    @patch("app.regattas.routes.HTML")
+    def test_single_skipper_hides_skipper_column(
+        self, mock_html, app, db, logged_in_client, admin_user
+    ):
+        mock_html.return_value.write_pdf.return_value = b"%PDF-fake"
+        _create_regatta(db, "Regatta A", admin_user.id, days_offset=10)
+
+        resp = logged_in_client.get(f"/schedule.pdf?skipper={admin_user.id}")
+        assert resp.status_code == 200
+        rendered_html = mock_html.call_args[1]["string"]
+        assert "<th>Skipper</th>" not in rendered_html
+        assert "Admin&#39;s Race Schedule" in rendered_html
+
+    @patch("app.regattas.routes.HTML")
+    def test_all_schedules_includes_skipper_names(
+        self, mock_html, app, db, logged_in_client, admin_user
+    ):
+        mock_html.return_value.write_pdf.return_value = b"%PDF-fake"
+
+        other = User(
+            email="skipper2@test.com",
+            display_name="Jane Doe",
+            initials="JD",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        _create_regatta(db, "Admin Regatta", admin_user.id, days_offset=10)
+        _create_regatta(db, "Jane Regatta", other.id, days_offset=11)
+
+        resp = logged_in_client.get("/schedule.pdf?skipper=0")
+        assert resp.status_code == 200
+        rendered_html = mock_html.call_args[1]["string"]
+        assert "Admin" in rendered_html
+        assert "Jane Doe" in rendered_html
+
+
+class TestPDFLinkCarriesFilters:
+    def test_pdf_link_includes_skipper_param(
+        self, app, db, logged_in_client, admin_user
+    ):
+        resp = logged_in_client.get(f"/?skipper={admin_user.id}")
+        html = resp.data.decode()
+        assert f"schedule.pdf?skipper={admin_user.id}" in html
+
+    def test_pdf_link_includes_rsvp_params(self, app, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/?rsvp=yes&rsvp=maybe")
+        html = resp.data.decode()
+        assert "schedule.pdf?" in html
+        assert "rsvp=yes" in html
+        assert "rsvp=maybe" in html
+
+    def test_pdf_link_no_filters_is_plain(self, app, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/?skipper=0")
+        html = resp.data.decode()
+        # skipper=0 means "All Schedules" — should still be in the URL
+        assert "schedule.pdf?skipper=0" in html

--- a/tests/test_profile_picture.py
+++ b/tests/test_profile_picture.py
@@ -83,7 +83,9 @@ class TestProfilePicture:
         )
 
         assert resp.status_code == 200
-        assert b"Profile picture must be a JPG, JPEG, PNG, GIF, or WEBP file." in resp.data
+        assert (
+            b"Profile picture must be a JPG, JPEG, PNG, GIF, or WEBP file." in resp.data
+        )
         db.session.refresh(user)
         assert user.profile_image_key is None
         mock_upload.assert_not_called()

--- a/tests/test_profile_picture_display.py
+++ b/tests/test_profile_picture_display.py
@@ -1,0 +1,123 @@
+"""Tests for profile picture display in navbar and profile pages (#69)."""
+
+from unittest.mock import patch
+
+from app.models import User
+
+
+class TestNavbarProfileImage:
+    @patch("app.storage.get_file_url", return_value="https://s3.example.com/pic.jpg")
+    def test_navbar_shows_profile_image_when_set(self, mock_url, app, client, db):
+        app.config["BUCKET_NAME"] = "test-bucket"
+
+        user = User(
+            email="user@test.com",
+            display_name="Test User",
+            initials="TU",
+            is_admin=False,
+            is_skipper=False,
+            profile_image_key="profile-images/pic.jpg",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "user@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get("/")
+        html = resp.data.decode()
+        assert "nav-avatar-img" in html
+        assert 'alt="TU"' in html
+
+    def test_navbar_shows_initials_when_no_image(self, app, client, db):
+        user = User(
+            email="user@test.com",
+            display_name="Test User",
+            initials="TU",
+            is_admin=False,
+            is_skipper=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "user@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get("/")
+        html = resp.data.decode()
+        assert "nav-avatar-img" not in html
+        assert ">TU</a>" in html
+
+
+class TestViewProfileImage:
+    @patch(
+        "app.auth.routes.storage.get_file_url",
+        return_value="https://s3.example.com/pic.jpg",
+    )
+    def test_view_profile_shows_image(self, mock_url, app, client, db):
+        app.config["BUCKET_NAME"] = "test-bucket"
+
+        viewer = User(
+            email="viewer@test.com",
+            display_name="Viewer",
+            initials="VW",
+        )
+        viewer.set_password("password")
+        db.session.add(viewer)
+
+        target = User(
+            email="target@test.com",
+            display_name="Target User",
+            initials="TG",
+            profile_image_key="profile-images/target.jpg",
+        )
+        target.set_password("password")
+        db.session.add(target)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "viewer@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get(f"/crew/{target.id}")
+        html = resp.data.decode()
+        assert "https://s3.example.com/pic.jpg" in html
+        assert 'alt="Target User"' in html
+
+    def test_view_profile_no_image_no_img_tag(self, app, client, db):
+        viewer = User(
+            email="viewer@test.com",
+            display_name="Viewer",
+            initials="VW",
+        )
+        viewer.set_password("password")
+        db.session.add(viewer)
+
+        target = User(
+            email="target@test.com",
+            display_name="Target User",
+            initials="TG",
+        )
+        target.set_password("password")
+        db.session.add(target)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "viewer@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get(f"/crew/{target.id}")
+        html = resp.data.decode()
+        assert "rounded-circle" not in html

--- a/tests/test_schedule_filters.py
+++ b/tests/test_schedule_filters.py
@@ -67,7 +67,7 @@ class TestDropdownLabels:
         db.session.commit()
 
         resp = logged_in_client.get("/?skipper=0")
-        assert b"All Schedules" in resp.data
+        assert b"Combined Schedules" in resp.data
 
 
 class TestSkipperColumn:
@@ -94,6 +94,24 @@ class TestSkipperColumn:
         assert b"Jane Doe" in resp.data
         assert b"Admin" in resp.data
 
+    def test_skipper_name_links_to_profile(self, app, db, logged_in_client, admin_user):
+        other = User(
+            email="skipper2@test.com",
+            display_name="Jane Doe",
+            initials="JD",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        _create_regatta(db, "Regatta A", other.id)
+
+        resp = logged_in_client.get("/?skipper=0")
+        html = resp.data.decode()
+        assert f'/crew/{other.id}"' in html
+        assert "Jane Doe</a>" in html
+
     def test_single_skipper_hides_skipper_column(
         self, app, db, logged_in_client, admin_user
     ):
@@ -118,7 +136,9 @@ class TestSkipperColumn:
         _create_regatta(db, "Regatta A", other.id)
 
         resp = logged_in_client.get("/?skipper=0")
-        assert b"Skipper: Jane Doe" in resp.data
+        html = resp.data.decode()
+        assert "Skipper:" in html
+        assert "Jane Doe</a>" in html
 
 
 class TestRSVPFilter:
@@ -215,6 +235,54 @@ class TestRSVPFilter:
         resp = logged_in_client.get(f"/?skipper={admin_user.id}&rsvp=yes")
         assert b"Admin Yes" in resp.data
         assert b"Other Yes" not in resp.data
+
+    def test_filter_yes_includes_regatta_with_mixed_rsvps(
+        self, app, db, logged_in_client, admin_user
+    ):
+        """A regatta with a Yes AND a No RSVP should appear when filtering Yes."""
+        crew = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+        )
+        crew.set_password("password")
+        db.session.add(crew)
+        db.session.commit()
+
+        r1 = _create_regatta(db, "Mixed Regatta", admin_user.id, days_offset=10)
+        r2 = _create_regatta(db, "Only No Regatta", admin_user.id, days_offset=11)
+
+        # Mixed: admin says Yes, crew says No
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r1.id, user_id=crew.id, status="no"))
+        # Only No
+        db.session.add(RSVP(regatta_id=r2.id, user_id=crew.id, status="no"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/?rsvp=yes")
+        assert b"Mixed Regatta" in resp.data
+        assert b"Only No Regatta" not in resp.data
+
+    def test_filter_no_includes_regatta_with_mixed_rsvps(
+        self, app, db, logged_in_client, admin_user
+    ):
+        """A regatta with a Yes AND a No RSVP should also appear when filtering No."""
+        crew = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+        )
+        crew.set_password("password")
+        db.session.add(crew)
+        db.session.commit()
+
+        r1 = _create_regatta(db, "Mixed Regatta", admin_user.id, days_offset=10)
+        db.session.add(RSVP(regatta_id=r1.id, user_id=admin_user.id, status="yes"))
+        db.session.add(RSVP(regatta_id=r1.id, user_id=crew.id, status="no"))
+        db.session.commit()
+
+        resp = logged_in_client.get("/?rsvp=no")
+        assert b"Mixed Regatta" in resp.data
 
 
 class TestRSVPToggleButtons:

--- a/tests/test_skipper_crew.py
+++ b/tests/test_skipper_crew.py
@@ -536,7 +536,7 @@ class TestScheduleSwitcher:
         resp = client.get("/")
         assert b"My Schedule" in resp.data
         assert b"Other Skipper" in resp.data
-        assert b"All Schedules" in resp.data
+        assert b"Combined Schedules" in resp.data
 
     def test_skipper_crew_own_schedule_shows_management(self, app, db, skipper_user):
         """Filtering to own schedule shows Add Regatta and Edit buttons."""
@@ -656,7 +656,7 @@ class TestScheduleSwitcher:
             follow_redirects=True,
         )
         resp = client.get("/")
-        assert b"All Schedules" in resp.data
+        assert b"Combined Schedules" in resp.data
         assert b"Skipper" in resp.data
         assert b"Other Skipper" in resp.data
         # Pure crew: dropdown should not include "My Schedule" option


### PR DESCRIPTION
## Summary
- **#69** Display profile pictures in navbar avatar and crew profile pages (context processor + template updates)
- **#71** PDF print now respects skipper and RSVP filters, with dynamic title and Skipper column for Combined Schedules
- **#72** RSVP filter matches any crew member's status on a regatta, not just the current user's
- **#70** Skipper names link to their profile in Combined Schedules view; renamed "All Schedules" to "Combined Schedules"

## Test plan
- [x] 281 tests pass (17 new tests added)
- [x] `black . && isort . && flake8` clean
- [ ] Verify profile picture displays in navbar when uploaded
- [ ] Verify PDF only includes filtered regattas and shows Skipper column on Combined view
- [ ] Verify RSVP filter shows regattas with mixed crew RSVPs correctly
- [ ] Verify skipper name links to profile page

Closes #69, closes #70, closes #71, closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)