### PR TITLE
Fix profile image upload size UX and 413 handling

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.49.1
+- Clarify profile picture limits in Profile Settings (accepted formats + 10 MB maximum)
+- Add explicit profile upload size validation with a clear error message
+- Handle oversized profile upload requests gracefully instead of generic failure (`Request Entity Too Large`) (#79)
+
 ## 0.49.0
 - Add GNU Affero General Public License v3.0 (AGPL-3.0)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,12 @@
-from flask import Flask, has_request_context, request
+from flask import Flask, flash, has_request_context, redirect, request, url_for
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
+from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.49.0"
+__version__ = "0.49.1"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -110,5 +111,15 @@ def create_app(test_config=None):
             return f"{start_date.strftime('%a')} & {end_date.strftime('%a')}"
 
         return f"{start_date.strftime('%a')} thru {end_date.strftime('%a')}"
+
+    @app.errorhandler(RequestEntityTooLarge)
+    def handle_request_entity_too_large(_exc):
+        max_mb = int(app.config.get("PROFILE_IMAGE_MAX_BYTES", 10 * 1024 * 1024)) // (
+            1024 * 1024
+        )
+        flash(f"Profile picture must be {max_mb} MB or smaller.", "error")
+        if request.path == url_for("auth.profile"):
+            return redirect(url_for("auth.profile"))
+        return redirect(request.referrer or url_for("regattas.index"))
 
     return app

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -6,6 +6,7 @@ import uuid
 from flask import (current_app, flash, redirect, render_template, request,
                    url_for)
 from flask_login import current_user, login_required, login_user, logout_user
+from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.utils import secure_filename
 
 from app import db, storage
@@ -16,6 +17,19 @@ from app.models import RSVP, Document, Regatta, User, skipper_crew
 logger = logging.getLogger(__name__)
 
 ALLOWED_PROFILE_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+
+def _profile_image_limit_bytes() -> int:
+    return int(
+        current_app.config.get(
+            "PROFILE_IMAGE_MAX_BYTES",
+            current_app.config.get("MAX_CONTENT_LENGTH", 10 * 1024 * 1024),
+        )
+    )
+
+
+def _profile_image_limit_mb() -> int:
+    return _profile_image_limit_bytes() // (1024 * 1024)
 
 
 def _build_profile_image_url(image_key: str | None) -> str | None:
@@ -39,6 +53,14 @@ def _upload_profile_image(file_storage) -> str:
     ext = os.path.splitext(safe_name)[1].lower()
     if ext not in ALLOWED_PROFILE_IMAGE_EXTENSIONS:
         raise ValueError("Profile picture must be a JPG, JPEG, PNG, GIF, or WEBP file.")
+
+    file_storage.stream.seek(0, os.SEEK_END)
+    file_size = file_storage.stream.tell()
+    file_storage.stream.seek(0)
+    if file_size > _profile_image_limit_bytes():
+        raise ValueError(
+            f"Profile picture must be {_profile_image_limit_mb()} MB or smaller."
+        )
 
     stored_filename = f"profile-images/{uuid.uuid4().hex}{ext}"
     storage.upload_file(file_storage, stored_filename)
@@ -173,6 +195,12 @@ def profile():
             except ValueError as exc:
                 db.session.rollback()
                 flash(str(exc), "error")
+            except RequestEntityTooLarge:
+                db.session.rollback()
+                flash(
+                    f"Profile picture must be {_profile_image_limit_mb()} MB or smaller.",
+                    "error",
+                )
             except Exception:
                 db.session.rollback()
                 if new_image_key:
@@ -189,6 +217,7 @@ def profile():
 
     return render_template(
         "profile.html",
+        profile_image_max_mb=_profile_image_limit_mb(),
         profile_image_url=_build_profile_image_url(current_user.profile_image_key),
     )
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ class Config:
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB max upload
+    PROFILE_IMAGE_MAX_BYTES = 10 * 1024 * 1024
     UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "uploads")
     BUCKET_NAME = os.environ.get("BUCKET_NAME", "")
     AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -23,7 +23,7 @@
                 </div>
                 {% endif %}
                 <input type="file" class="form-control" id="profile_image" name="profile_image" accept=".jpg,.jpeg,.png,.gif,.webp,image/*">
-                <div class="form-text">Accepted formats: JPG, JPEG, PNG, GIF, WEBP.</div>
+                <div class="form-text">Accepted formats: JPG, JPEG, PNG, GIF, WEBP. Maximum file size: {{ profile_image_max_mb }} MB.</div>
             </div>
             <div class="mb-3">
                 <label for="display_name" class="form-label">Display Name</label>

--- a/tests/test_profile_picture.py
+++ b/tests/test_profile_picture.py
@@ -126,3 +126,86 @@ class TestProfilePicture:
         db.session.refresh(user)
         assert user.profile_image_key is None
         mock_delete.assert_called_once_with("profile-images/old.png")
+
+    @patch("app.auth.routes.storage.upload_file")
+    def test_rejects_oversized_profile_picture(self, mock_upload, app, client, db):
+        app.config["BUCKET_NAME"] = "test-bucket"
+        app.config["PROFILE_IMAGE_MAX_BYTES"] = 1 * 1024 * 1024
+        app.config["MAX_CONTENT_LENGTH"] = 3 * 1024 * 1024
+
+        user = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+            is_admin=False,
+            is_skipper=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.post(
+            "/profile",
+            data={
+                "display_name": "Crew",
+                "initials": "CR",
+                "email": "crew@test.com",
+                "email_opt_in": "on",
+                "profile_image": (BytesIO(b"x" * (2 * 1024 * 1024)), "avatar.png"),
+            },
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert b"Profile picture must be 1 MB or smaller." in resp.data
+        db.session.refresh(user)
+        assert user.profile_image_key is None
+        mock_upload.assert_not_called()
+
+    @patch("app.auth.routes.storage.upload_file")
+    def test_handles_request_entity_too_large_for_profile_upload(
+        self, mock_upload, app, client, db
+    ):
+        app.config["BUCKET_NAME"] = "test-bucket"
+        app.config["PROFILE_IMAGE_MAX_BYTES"] = 1 * 1024 * 1024
+        app.config["MAX_CONTENT_LENGTH"] = 128
+
+        user = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+            is_admin=False,
+            is_skipper=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.post(
+            "/profile",
+            data={
+                "display_name": "Crew",
+                "initials": "CR",
+                "email": "crew@test.com",
+                "profile_image": (BytesIO(b"x" * 2048), "avatar.png"),
+            },
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert b"Profile picture must be 1 MB or smaller." in resp.data
+        mock_upload.assert_not_called()


### PR DESCRIPTION
## Summary\n- add explicit profile image size limit configuration (10 MB)\n- validate profile image file size before upload\n- handle Request Entity Too Large with a clear flash message\n- show max size guidance on Profile Settings\n- add regression tests for oversized uploads and 413 behavior\n- bump patch version and update VERSIONS.md\n\nCloses #79