### PR TITLE
Render month label on single schedule divider line

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.49.2
+- Add month labels centered in the existing schedule divider treatment for Upcoming and Past sections (#56)
+- Apply month divider labels in both desktop table and mobile card views
+- Emphasize the modified divider line and month label text with bold styling
+
 ## 0.49.1
 - Clarify profile picture limits in Profile Settings (accepted formats + 10 MB maximum)
 - Add explicit profile upload size validation with a clear error message

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.49.1"
+__version__ = "0.49.2"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -80,6 +80,34 @@
     color: #333;
 }
 
+.month-divider-row td {
+    padding: 0.15rem 0.5rem;
+    border-top: 1px solid #dee2e6 !important;
+    border-bottom: 0 !important;
+}
+
+.month-divider-row + tr td {
+    border-top: 0 !important;
+}
+
+.month-divider {
+    text-align: center;
+    line-height: 0;
+    margin: 0;
+}
+
+.month-divider-text {
+    display: inline-block;
+    padding: 0 0.5rem;
+    background-color: #fff;
+    color: #6c757d;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    line-height: 1;
+    transform: translateY(-0.58em);
+}
+
 /* Responsive logo */
 .navbar-logo {
     height: 80px;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -66,6 +66,7 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 </form>
 {% endif %}
+{% set divider_colspan = 6 + (1 if show_skipper else 0) + (0 if is_past else 1) + (2 if can_manage_any else 0) %}
 <div class="table-responsive regatta-table-desktop">
     <table class="table table-hover align-middle{% if is_past %} regatta-past{% endif %}">
         <thead>
@@ -87,7 +88,19 @@
             </tr>
         </thead>
         <tbody>
+            {% set month_ns = namespace(current_month='') %}
             {% for regatta in regattas %}
+            {% set month_label = regatta.start_date.strftime('%B') %}
+            {% if month_label != month_ns.current_month %}
+            <tr class="month-divider-row">
+                <td colspan="{{ divider_colspan }}">
+                    <div class="month-divider" aria-hidden="true">
+                        <span class="month-divider-text">{{ month_label }}</span>
+                    </div>
+                </td>
+            </tr>
+            {% set month_ns.current_month = month_label %}
+            {% endif %}
             <tr>
                 <td class="text-nowrap">
                     {{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}
@@ -159,7 +172,15 @@
 {% endif %}
 
 <div class="regatta-cards-mobile">
+    {% set month_mobile_ns = namespace(current_month='') %}
     {% for regatta in regattas %}
+    {% set month_label = regatta.start_date.strftime('%B') %}
+    {% if month_label != month_mobile_ns.current_month %}
+    <div class="month-divider" aria-hidden="true">
+        <span class="month-divider-text">{{ month_label }}</span>
+    </div>
+    {% set month_mobile_ns.current_month = month_label %}
+    {% endif %}
     <div class="card mb-2{% if is_past %} regatta-past{% endif %}">
         <div class="card-body py-2 px-3">
             <div class="d-flex justify-content-between align-items-start">

--- a/tests/test_schedule_filters.py
+++ b/tests/test_schedule_filters.py
@@ -18,6 +18,19 @@ def _create_regatta(db, name, created_by, days_offset=7):
     return r
 
 
+def _create_regatta_on(db, name, created_by, start_date):
+    """Helper to create a regatta on an explicit date."""
+    r = Regatta(
+        name=name,
+        location="Test Location",
+        start_date=start_date,
+        created_by=created_by,
+    )
+    db.session.add(r)
+    db.session.commit()
+    return r
+
+
 class TestDropdownLabels:
     """Dropdown shows "'s Schedule" suffix for other skippers."""
 
@@ -360,3 +373,70 @@ class TestRSVPFilterStatePreservation:
         location = resp.headers["Location"]
         assert "skipper=0" in location
         assert "rsvp=yes" in location
+
+
+class TestMonthDividerLabels:
+    """Month divider labels render once per month group per view."""
+
+    def test_upcoming_shows_month_dividers_for_each_month(
+        self, app, db, logged_in_client, admin_user
+    ):
+        today = date.today()
+        first_next_month = (today.replace(day=28) + timedelta(days=4)).replace(day=1)
+        first_after_next_month = (
+            first_next_month.replace(day=28) + timedelta(days=4)
+        ).replace(day=1)
+
+        first_month_date = first_next_month + timedelta(days=2)
+        second_month_date = first_after_next_month + timedelta(days=2)
+
+        _create_regatta_on(db, "Month One", admin_user.id, first_month_date)
+        _create_regatta_on(db, "Month Two", admin_user.id, second_month_date)
+
+        resp = logged_in_client.get("/")
+        html = resp.data.decode()
+
+        month_one = first_month_date.strftime("%B")
+        month_two = second_month_date.strftime("%B")
+
+        assert html.count(f'class="month-divider-text">{month_one}<') == 2
+        assert html.count(f'class="month-divider-text">{month_two}<') == 2
+
+    def test_past_shows_month_dividers_for_each_month(
+        self, app, db, logged_in_client, admin_user
+    ):
+        today = date.today()
+        first_last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+        first_two_months_ago = (first_last_month - timedelta(days=1)).replace(day=1)
+
+        last_month_date = first_last_month + timedelta(days=2)
+        two_months_ago_date = first_two_months_ago + timedelta(days=2)
+
+        _create_regatta_on(db, "Past One", admin_user.id, two_months_ago_date)
+        _create_regatta_on(db, "Past Two", admin_user.id, last_month_date)
+
+        resp = logged_in_client.get("/")
+        html = resp.data.decode()
+
+        month_one = two_months_ago_date.strftime("%B")
+        month_two = last_month_date.strftime("%B")
+
+        assert html.count(f'class="month-divider-text">{month_one}<') == 2
+        assert html.count(f'class="month-divider-text">{month_two}<') == 2
+
+    def test_same_month_renders_single_divider_per_view(
+        self, app, db, logged_in_client, admin_user
+    ):
+        today = date.today()
+        first_next_month = (today.replace(day=28) + timedelta(days=4)).replace(day=1)
+        first_date = first_next_month + timedelta(days=2)
+        second_date = first_next_month + timedelta(days=8)
+
+        _create_regatta_on(db, "Same Month One", admin_user.id, first_date)
+        _create_regatta_on(db, "Same Month Two", admin_user.id, second_date)
+
+        resp = logged_in_client.get("/")
+        html = resp.data.decode()
+
+        month_label = first_date.strftime("%B")
+        assert html.count(f'class="month-divider-text">{month_label}<') == 2


### PR DESCRIPTION
## Summary\n- add month transition labels in schedule table and mobile cards\n- place month label on a single divider line and remove double-line effect\n- add schedule tests for month divider grouping\n- bump patch version and update changelog\n\nCloses #56