### PR TITLE
Fix profile picture/avatar precedence UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A simple web app for organizing sailboat regattas. Track dates, locations, NOR/S
 - Location links to Google Maps
 - Upload/download NOR and SI PDFs (stored in S3)
 - Profile pictures with S3 storage, displayed in navbar and crew profiles
-- Crew RSVP (Yes / No / Maybe) with color-coded initials
+- Crew RSVP (Yes / No / Maybe) with color-coded initials and unique Multiavatar icons
 - AI-powered schedule import: paste text or URL, Claude extracts regattas for review and bulk import, with auto-discovery of NOR/SI/WWW documents from regatta detail pages and regatta websites (including clubspot Parse API integration)
 - Admin: manage all users, site settings, invite skippers
 - Skipper: add/edit/delete own regattas, upload documents, invite crew, import schedules

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,19 @@
 # Version History
 
+## 0.50.1
+- Prioritize uploaded profile pictures over generated avatars across navbar, schedules, user lists, and PDF
+- Keep generated avatar visible on crew profile pages while restoring a large top profile icon section
+- Update Profile Settings so Regenerate replaces uploaded profile pictures on save and removes old S3 image
+- Simplify Profile Settings copy and align avatar preview sizing with crew profile display
+
+## 0.50.0
+- Add unique Multiavatar icons to user profiles for visual crew disambiguation (#73)
+- Each user gets a deterministic avatar generated from their email address
+- Avatars displayed alongside initials in schedule crew badges, PDF, navbar, and all user lists
+- Regenerate avatar button in Profile Settings with live preview
+- Navbar shows initials + avatar instead of profile picture
+- New `avatar_seed` column on User model with database migration
+
 ## 0.49.2
 - Add month labels centered in the existing schedule divider treatment for Upcoming and Past sections (#56)
 - Apply month divider labels in both desktop table and mobile card views

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,10 +3,11 @@ from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
+from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.49.2"
+__version__ = "0.50.1"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -14,6 +15,19 @@ login_manager = LoginManager()
 login_manager.login_view = "auth.login"
 login_manager.login_message = None
 csrf = CSRFProtect()
+
+
+def _avatar_svg_markup(user, size=20):
+    """Render a Multiavatar inline SVG for a user-like object."""
+    from multiavatar.multiavatar import multiavatar
+
+    key = user.avatar_key if hasattr(user, "avatar_key") else str(user)
+    svg = multiavatar(key, None, None)
+    return Markup(
+        f'<span class="avatar-icon" style="display:inline-block;'
+        f"width:{size}px;height:{size}px;vertical-align:middle;"
+        f'">{svg}</span>'
+    )
 
 
 def create_app(test_config=None):
@@ -90,6 +104,38 @@ def create_app(test_config=None):
             "ga_measurement_id": ga_measurement_id,
             "is_dev_or_test": is_dev_or_test,
         }
+
+    @app.template_filter("avatar_svg")
+    def avatar_svg_filter(user, size=20):
+        """Render a Multiavatar inline SVG for a user."""
+        return _avatar_svg_markup(user, size)
+
+    @app.template_filter("user_icon")
+    def user_icon_filter(user, size=20):
+        """Render profile picture when present; otherwise render avatar fallback."""
+        if (
+            user
+            and getattr(user, "profile_image_key", None)
+            and app.config.get("BUCKET_NAME")
+        ):
+            try:
+                from app import storage
+
+                image_url = escape(storage.get_file_url(user.profile_image_key))
+                display_name = escape(getattr(user, "display_name", "User"))
+                return Markup(
+                    f'<span class="avatar-icon" style="display:inline-block;'
+                    f"width:{size}px;height:{size}px;vertical-align:middle;"
+                    '>'
+                    f'<img class="avatar-photo" src="{image_url}" alt="{display_name}" '
+                    f'style="width:100%;height:100%;border-radius:50%;object-fit:cover;">'
+                    "</span>"
+                )
+            except Exception:
+                # Fall through to avatar rendering if image URL generation fails.
+                pass
+
+        return _avatar_svg_markup(user, size)
 
     @app.template_filter("sort_rsvps")
     def sort_rsvps(rsvps):

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -188,6 +188,8 @@ def profile():
                 current_user.email = email
                 current_user.phone = request.form.get("phone", "").strip() or None
                 current_user.email_opt_in = request.form.get("email_opt_in") == "on"
+                avatar_seed = request.form.get("avatar_seed", "").strip()
+                current_user.avatar_seed = avatar_seed or None
                 if password:
                     current_user.set_password(password)
 

--- a/app/models.py
+++ b/app/models.py
@@ -41,6 +41,7 @@ class User(UserMixin, db.Model):
     phone = db.Column(db.String(20), nullable=True)
     email_opt_in = db.Column(db.Boolean, default=True, nullable=False)
     profile_image_key = db.Column(db.String(255), nullable=True)
+    avatar_seed = db.Column(db.String(100), nullable=True)
 
     rsvps = db.relationship("RSVP", backref="user", lazy="dynamic")
     documents = db.relationship("Document", backref="uploaded_by_user", lazy="dynamic")
@@ -67,6 +68,11 @@ class User(UserMixin, db.Model):
         return bcrypt.checkpw(
             password.encode("utf-8"), self.password_hash.encode("utf-8")
         )
+
+    @property
+    def avatar_key(self) -> str:
+        """Return the seed used for Multiavatar generation."""
+        return self.avatar_seed or self.email
 
     @property
     def is_crew(self) -> bool:

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -19,20 +19,28 @@
 .nav-avatar {
     background-color: #0d9488;
     color: #fff !important;
-    border-radius: 50%;
+    border-radius: 20px;
     min-width: 42px;
     height: 42px;
-    padding: 0 8px;
+    padding: 0 10px;
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 4px;
     font-weight: bold;
     font-size: 0.85rem;
 }
 
-.nav-avatar-img {
-    width: 36px;
-    height: 36px;
+.avatar-icon svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.avatar-icon .avatar-photo {
+    display: block;
+    width: 100%;
+    height: 100%;
     border-radius: 50%;
     object-fit: cover;
 }
@@ -49,7 +57,7 @@
     display: inline-block;
     padding: 2px 6px;
     border-radius: 4px;
-    font-size: 0.8rem;
+    font-size: 0.9rem;
     font-weight: bold;
     margin-right: 4px;
     text-decoration: none;

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -65,7 +65,7 @@
                     </td>
                     {% endif %}
                     <td>{{ user.display_name }}</td>
-                    <td class="d-none d-sm-table-cell"><span class="badge bg-secondary">{{ user.initials }}</span></td>
+                    <td class="d-none d-sm-table-cell">{{ user|user_icon(20) }} <span class="badge bg-secondary">{{ user.initials }}</span></td>
                     <td class="d-none d-md-table-cell">{{ user.email }}</td>
                     <td>
                         {% if user.is_admin %}Admin{% endif %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,7 +56,7 @@
                     </li>
                     {% endif %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle nav-avatar" href="#" role="button" data-bs-toggle="dropdown">{% if current_user_profile_image_url %}<img src="{{ current_user_profile_image_url }}" alt="{{ current_user.initials }}" class="nav-avatar-img">{% else %}{{ current_user.initials }}{% endif %}</a>
+                        <a class="nav-link dropdown-toggle nav-avatar" href="#" role="button" data-bs-toggle="dropdown">{{ current_user|user_icon(28) }} {{ current_user.initials }}</a>
                         <ul class="dropdown-menu dropdown-menu-end">
                             <li><a class="dropdown-item" href="{{ url_for('auth.profile') }}">Profile Settings</a></li>
                             {% if not current_user.is_skipper and not current_user.is_admin %}

--- a/app/templates/edit_user.html
+++ b/app/templates/edit_user.html
@@ -15,6 +15,11 @@
                 <input type="text" class="form-control" id="initials" name="initials" required maxlength="3" pattern="[A-Za-z0-9]{2,3}" title="2-3 letters or numbers" value="{{ user.initials }}" style="text-transform: uppercase;">
             </div>
             <div class="mb-3">
+                <label class="form-label">Current Icon</label>
+                <div>{{ user|user_icon(48) }}</div>
+                <div class="form-text">Uploaded profile pictures override avatars. Users can manage both in Profile Settings.</div>
+            </div>
+            <div class="mb-3">
                 <label for="email" class="form-label">Email</label>
                 <input type="email" class="form-control" id="email" name="email" required value="{{ user.email }}">
             </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -128,7 +128,7 @@
                 </td>
                 <td>
                     {% for rsvp in regatta.rsvps|sort_rsvps %}
-                    <a href="{{ url_for('auth.view_profile', user_id=rsvp.user.id) }}" class="crew-badge {{ rsvp.status }}" title="{{ rsvp.user.display_name }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }}</a>
+                    <a href="{{ url_for('auth.view_profile', user_id=rsvp.user.id) }}" class="crew-badge {{ rsvp.status }}" title="{{ rsvp.user.display_name }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }} {{ rsvp.user|user_icon(26) }}</a>
                     {% endfor %}
                 </td>
                 {% if not is_past %}
@@ -217,7 +217,7 @@
                 <a href="{% if doc.url %}{{ doc.url }}{% else %}{{ url_for('regattas.download_doc', doc_id=doc.id) }}{% endif %}" class="badge bg-info text-decoration-none doc-link" target="_blank">{{ doc.doc_type }}</a>
                 {% endfor %}
                 {% for rsvp in regatta.rsvps|sort_rsvps %}
-                <a href="{{ url_for('auth.view_profile', user_id=rsvp.user.id) }}" class="crew-badge {{ rsvp.status }}" title="{{ rsvp.user.display_name }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }}</a>
+                <a href="{{ url_for('auth.view_profile', user_id=rsvp.user.id) }}" class="crew-badge {{ rsvp.status }}" title="{{ rsvp.user.display_name }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }} {{ rsvp.user|user_icon(26) }}</a>
                 {% endfor %}
             </div>
             {% if not is_past %}

--- a/app/templates/my_crew.html
+++ b/app/templates/my_crew.html
@@ -43,7 +43,7 @@
             {% for member in crew %}
             <tr>
                 <td>{{ member.display_name }}</td>
-                <td class="d-none d-sm-table-cell"><span class="badge bg-secondary">{{ member.initials }}</span></td>
+                <td class="d-none d-sm-table-cell">{{ member|user_icon(20) }} <span class="badge bg-secondary">{{ member.initials }}</span></td>
                 <td class="d-none d-md-table-cell">{{ member.email }}</td>
                 <td>
                     {% if member.invite_token %}

--- a/app/templates/pdf_schedule.html
+++ b/app/templates/pdf_schedule.html
@@ -84,7 +84,7 @@
         </td>
         <td>
             {% for rsvp in regatta.rsvps|sort_rsvps %}
-            <span class="crew-{{ rsvp.status }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }}</span>
+            <span class="crew-{{ rsvp.status }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }} {{ rsvp.user|user_icon(18) }}</span>
             {% endfor %}
         </td>
     </tr>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -6,24 +6,23 @@
         <h2 class="mb-4">Profile Settings</h2>
         <form method="POST" enctype="multipart/form-data">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="remove_profile_image" id="remove_profile_image" value="">
             <div class="mb-3">
-                <label for="profile_image" class="form-label">Profile Picture</label>
-                {% if profile_image_url %}
-                <div class="mb-2">
-                    <img
-                        src="{{ profile_image_url }}"
-                        alt="Current profile picture"
-                        class="img-thumbnail"
-                        style="max-width: 160px; max-height: 160px;"
-                    >
+                <label class="form-label">Profile Picture</label>
+                <div class="d-flex flex-wrap align-items-start gap-4 mb-2">
+                    <div>
+                        <input type="hidden" name="avatar_seed" id="avatar_seed" value="{{ current_user.avatar_seed or '' }}">
+                        <div class="d-flex align-items-center gap-3">
+                            <div id="avatar-preview" style="width:120px;height:120px;">
+                                {{ current_user|avatar_svg(120) }}
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" id="regenerate-avatar">Regenerate</button>
+                        </div>
+                    </div>
                 </div>
-                <div class="form-check mb-2">
-                    <input type="checkbox" class="form-check-input" id="remove_profile_image" name="remove_profile_image">
-                    <label class="form-check-label" for="remove_profile_image">Remove current picture</label>
-                </div>
-                {% endif %}
                 <input type="file" class="form-control" id="profile_image" name="profile_image" accept=".jpg,.jpeg,.png,.gif,.webp,image/*">
                 <div class="form-text">Accepted formats: JPG, JPEG, PNG, GIF, WEBP. Maximum file size: {{ profile_image_max_mb }} MB.</div>
+                <div class="form-text">Click Regenerate to replace any uploaded profile picture with the avatar when you save.</div>
             </div>
             <div class="mb-3">
                 <label for="display_name" class="form-label">Display Name</label>
@@ -64,4 +63,17 @@
         </form>
     </div>
 </div>
+{% endblock %}
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/@multiavatar/multiavatar/multiavatar.min.js"></script>
+<script>
+document.getElementById('regenerate-avatar').addEventListener('click', function() {
+    var seed = 'avatar-' + Date.now() + '-' + Math.random().toString(36).substring(2, 8);
+    document.getElementById('avatar_seed').value = seed;
+    document.getElementById('remove_profile_image').value = 'on';
+    var svg = multiavatar(seed);
+    document.getElementById('avatar-preview').innerHTML =
+        '<span class="avatar-icon" style="display:inline-block;width:120px;height:120px;">' + svg + '</span>';
+});
+</script>
 {% endblock %}

--- a/app/templates/view_profile.html
+++ b/app/templates/view_profile.html
@@ -3,16 +3,25 @@
 {% block content %}
 <div class="row justify-content-center mt-3">
     <div class="col-md-5">
-        {% if profile_image_url %}
         <div class="mb-3 text-center">
-            <img src="{{ profile_image_url }}" alt="{{ user.display_name }}" class="rounded-circle" style="width: 120px; height: 120px; object-fit: cover;">
+            {% if user.profile_image_key %}
+            {{ user|user_icon(120) }}
+            <div class="small text-muted mt-2">Profile picture</div>
+            {% else %}
+            {{ user|avatar_svg(120) }}
+            {% endif %}
         </div>
-        {% endif %}
         <h2 class="mb-4">{{ user.display_name }}</h2>
         <table class="table">
             <tr>
                 <th>Initials</th>
-                <td><span class="badge bg-secondary">{{ user.initials }}</span></td>
+                <td>
+                    <span class="badge bg-secondary">{{ user.initials }}</span>
+                    {% if user.profile_image_key %}
+                    {{ user|user_icon(24) }}
+                    {% endif %}
+                    {{ user|avatar_svg(24) }}
+                </td>
             </tr>
             <tr>
                 <th>Email</th>

--- a/migrations/versions/g7c8d9e0f1a2_add_avatar_seed_to_users.py
+++ b/migrations/versions/g7c8d9e0f1a2_add_avatar_seed_to_users.py
@@ -1,0 +1,24 @@
+"""Add avatar_seed to users
+
+Revision ID: g7c8d9e0f1a2
+Revises: f6b7c8d9e0f1
+Create Date: 2026-03-10
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "g7c8d9e0f1a2"
+down_revision = "f6b7c8d9e0f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users", sa.Column("avatar_seed", sa.String(length=100), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("users", "avatar_seed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ gunicorn==23.0.0
 python-dotenv==1.0.1
 icalendar==6.1.3
 weasyprint==68.1
+multiavatar>=1.0.0
 boto3>=1.35.0
 anthropic>=0.43.0
 requests>=2.31.0

--- a/tests/test_multiavatar.py
+++ b/tests/test_multiavatar.py
@@ -1,0 +1,171 @@
+"""Tests for the Multiavatar user icon feature."""
+
+import secrets
+from datetime import date
+from unittest.mock import patch
+
+from app.models import RSVP, Regatta, User
+
+
+class TestAvatarKeyProperty:
+    def test_avatar_key_defaults_to_email(self, db, admin_user):
+        assert admin_user.avatar_seed is None
+        assert admin_user.avatar_key == admin_user.email
+
+    def test_avatar_key_uses_seed_when_set(self, db, admin_user):
+        admin_user.avatar_seed = "custom-seed"
+        db.session.commit()
+        assert admin_user.avatar_key == "custom-seed"
+
+
+class TestAvatarSvgFilter:
+    def test_filter_returns_svg_markup(self, app, db, admin_user):
+        with app.app_context():
+            env = app.jinja_env
+            tmpl = env.from_string("{{ user|avatar_svg(20) }}")
+            result = tmpl.render(user=admin_user)
+            assert "<svg" in result
+            assert "avatar-icon" in result
+
+    def test_filter_different_users_produce_different_svgs(self, app, db, admin_user):
+        user2 = User(
+            email="different@test.com",
+            display_name="Different",
+            initials="DF",
+        )
+        user2.set_password("password")
+        db.session.add(user2)
+        db.session.commit()
+
+        with app.app_context():
+            env = app.jinja_env
+            tmpl = env.from_string("{{ user|avatar_svg(20) }}")
+            svg1 = tmpl.render(user=admin_user)
+            svg2 = tmpl.render(user=user2)
+            assert svg1 != svg2
+
+
+class TestUserIconFilter:
+    def test_user_icon_falls_back_to_avatar_without_profile_picture(
+        self, app, db, admin_user
+    ):
+        with app.app_context():
+            env = app.jinja_env
+            tmpl = env.from_string("{{ user|user_icon(20) }}")
+            result = tmpl.render(user=admin_user)
+            assert "<svg" in result
+            assert "avatar-icon" in result
+
+    @patch("app.storage.get_file_url", return_value="https://s3.example.com/pic.jpg")
+    def test_user_icon_prefers_profile_picture_when_available(
+        self, mock_get_url, app, db, admin_user
+    ):
+        app.config["BUCKET_NAME"] = "test-bucket"
+        admin_user.profile_image_key = "profile-images/admin.jpg"
+        db.session.commit()
+
+        with app.app_context():
+            env = app.jinja_env
+            tmpl = env.from_string("{{ user|user_icon(20) }}")
+            result = tmpl.render(user=admin_user)
+            assert "<img" in result
+            assert "https://s3.example.com/pic.jpg" in result
+            assert "<svg" not in result
+
+        mock_get_url.assert_called_once_with("profile-images/admin.jpg")
+
+
+class TestAvatarInSchedule:
+    def _setup_regatta_with_rsvp(self, db, admin_user):
+        regatta = Regatta(
+            name="Test Regatta",
+            location="Test Location",
+            start_date=date(2026, 6, 15),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.flush()
+        rsvp = RSVP(regatta_id=regatta.id, user_id=admin_user.id, status="yes")
+        db.session.add(rsvp)
+        db.session.commit()
+        return regatta
+
+    def test_avatar_in_schedule_page(self, logged_in_client, admin_user, db):
+        self._setup_regatta_with_rsvp(db, admin_user)
+        resp = logged_in_client.get("/")
+        html = resp.data.decode()
+        assert "avatar-icon" in html
+        assert "<svg" in html
+
+    def test_avatar_in_navbar(self, logged_in_client, admin_user, db):
+        resp = logged_in_client.get("/")
+        html = resp.data.decode()
+        # Navbar should contain avatar + initials
+        assert "avatar-icon" in html
+        assert admin_user.initials in html
+
+
+class TestAvatarRegeneration:
+    def test_profile_saves_avatar_seed(self, logged_in_client, admin_user, db):
+        logged_in_client.post(
+            "/profile",
+            data={
+                "display_name": "Admin",
+                "initials": "AD",
+                "email": "admin@test.com",
+                "avatar_seed": "my-custom-seed",
+            },
+            follow_redirects=True,
+        )
+        db.session.refresh(admin_user)
+        assert admin_user.avatar_seed == "my-custom-seed"
+        assert admin_user.avatar_key == "my-custom-seed"
+
+    def test_profile_clears_avatar_seed_when_empty(
+        self, logged_in_client, admin_user, db
+    ):
+        admin_user.avatar_seed = "old-seed"
+        db.session.commit()
+
+        logged_in_client.post(
+            "/profile",
+            data={
+                "display_name": "Admin",
+                "initials": "AD",
+                "email": "admin@test.com",
+                "avatar_seed": "",
+            },
+            follow_redirects=True,
+        )
+        db.session.refresh(admin_user)
+        assert admin_user.avatar_seed is None
+        assert admin_user.avatar_key == admin_user.email
+
+
+class TestAvatarInViewProfile:
+    def test_view_profile_shows_avatar(self, logged_in_client, admin_user, db):
+        resp = logged_in_client.get(f"/crew/{admin_user.id}")
+        html = resp.data.decode()
+        assert "avatar-icon" in html
+
+
+class TestAvatarInIcal:
+    def test_ical_does_not_break(self, logged_in_client, admin_user, db):
+        """iCal is text-only so just ensure it still works."""
+        admin_user.calendar_token = secrets.token_urlsafe(32)
+        regatta = Regatta(
+            name="Test Regatta",
+            location="Test Location",
+            start_date=date(2026, 6, 15),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.flush()
+        rsvp = RSVP(regatta_id=regatta.id, user_id=admin_user.id, status="yes")
+        db.session.add(rsvp)
+        db.session.commit()
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        data = resp.data.decode()
+        assert "AD" in data

--- a/tests/test_profile_picture.py
+++ b/tests/test_profile_picture.py
@@ -91,7 +91,9 @@ class TestProfilePicture:
         mock_upload.assert_not_called()
 
     @patch("app.auth.routes.storage.delete_file")
-    def test_remove_profile_picture(self, mock_delete, app, client, db):
+    def test_regenerate_replaces_profile_picture_and_deletes_old(
+        self, mock_delete, app, client, db
+    ):
         user = User(
             email="crew@test.com",
             display_name="Crew",
@@ -126,6 +128,29 @@ class TestProfilePicture:
         db.session.refresh(user)
         assert user.profile_image_key is None
         mock_delete.assert_called_once_with("profile-images/old.png")
+
+    def test_profile_page_hides_remove_picture_checkbox(self, app, client, db):
+        user = User(
+            email="crew@test.com",
+            display_name="Crew",
+            initials="CR",
+            is_admin=False,
+            is_skipper=False,
+            profile_image_key="profile-images/old.png",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "crew@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get("/profile")
+        html = resp.data.decode()
+        assert "Remove current picture" not in html
 
     @patch("app.auth.routes.storage.upload_file")
     def test_rejects_oversized_profile_picture(self, mock_upload, app, client, db):

--- a/tests/test_profile_picture_display.py
+++ b/tests/test_profile_picture_display.py
@@ -5,39 +5,42 @@ from unittest.mock import patch
 from app.models import User
 
 
-class TestNavbarProfileImage:
-    @patch("app.storage.get_file_url", return_value="https://s3.example.com/pic.jpg")
-    def test_navbar_shows_profile_image_when_set(self, mock_url, app, client, db):
+class TestNavbarAvatar:
+    def test_navbar_shows_avatar_and_initials(self, app, client, db):
+        user = User(
+            email="user@test.com",
+            display_name="Test User",
+            initials="TU",
+            is_admin=False,
+            is_skipper=False,
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "user@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get("/")
+        html = resp.data.decode()
+        assert "avatar-icon" in html
+        assert "TU</a>" in html
+
+    @patch(
+        "app.storage.get_file_url",
+        return_value="https://s3.example.com/navbar.jpg",
+    )
+    def test_navbar_prefers_uploaded_profile_picture(self, mock_url, app, client, db):
         app.config["BUCKET_NAME"] = "test-bucket"
 
         user = User(
             email="user@test.com",
             display_name="Test User",
             initials="TU",
-            is_admin=False,
-            is_skipper=False,
-            profile_image_key="profile-images/pic.jpg",
-        )
-        user.set_password("password")
-        db.session.add(user)
-        db.session.commit()
-
-        client.post(
-            "/login",
-            data={"email": "user@test.com", "password": "password"},
-            follow_redirects=True,
-        )
-
-        resp = client.get("/")
-        html = resp.data.decode()
-        assert "nav-avatar-img" in html
-        assert 'alt="TU"' in html
-
-    def test_navbar_shows_initials_when_no_image(self, app, client, db):
-        user = User(
-            email="user@test.com",
-            display_name="Test User",
-            initials="TU",
+            profile_image_key="profile-images/user.jpg",
             is_admin=False,
             is_skipper=False,
         )
@@ -53,15 +56,13 @@ class TestNavbarProfileImage:
 
         resp = client.get("/")
         html = resp.data.decode()
-        assert "nav-avatar-img" not in html
-        assert ">TU</a>" in html
+        assert "https://s3.example.com/navbar.jpg" in html
+        assert "avatar-photo" in html
+        mock_url.assert_called()
 
 
 class TestViewProfileImage:
-    @patch(
-        "app.auth.routes.storage.get_file_url",
-        return_value="https://s3.example.com/pic.jpg",
-    )
+    @patch("app.storage.get_file_url", return_value="https://s3.example.com/pic.jpg")
     def test_view_profile_shows_image(self, mock_url, app, client, db):
         app.config["BUCKET_NAME"] = "test-bucket"
 
@@ -92,7 +93,9 @@ class TestViewProfileImage:
         resp = client.get(f"/crew/{target.id}")
         html = resp.data.decode()
         assert "https://s3.example.com/pic.jpg" in html
-        assert 'alt="Target User"' in html
+        assert "avatar-photo" in html
+        assert "<svg" in html
+        assert "Profile picture" in html
 
     def test_view_profile_no_image_no_img_tag(self, app, client, db):
         viewer = User(
@@ -120,4 +123,5 @@ class TestViewProfileImage:
 
         resp = client.get(f"/crew/{target.id}")
         html = resp.data.decode()
-        assert "rounded-circle" not in html
+        assert "avatar-photo" not in html
+        assert "avatar-icon" in html


### PR DESCRIPTION
## Summary
- enforce profile-picture-over-avatar precedence across app render points
- keep generated avatar visible on crew profile details with large top icon treatment
- update Profile Settings regenerate flow to replace uploaded picture on save and remove old S3 image
- polish profile/crew copy and sizing consistency
- add and update tests for precedence, display, and regenerate behavior
- bump version to 0.50.1 and update VERSIONS.md

## Validation
- .venv/bin/python -m pytest -q (299 passed)
