### PR TITLE
Auto-assign random Multiavatar to new users (v0.51.0)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.51.0
+- Auto-assign random Multiavatar to every new user at creation time
+- All user creation points (admin invite, crew invite, registration, CLI commands) generate a unique avatar seed
+- Data migration backfills existing users with their email as avatar seed to preserve current avatars
+- Profile page preview shows uploaded profile picture when present instead of always showing avatar SVG
+- File selection preview in profile settings shows chosen image before saving
+- Regenerate button clears file input to avoid conflicting selections
+
 ## 0.50.1
 - Prioritize uploaded profile pictures over generated avatars across navbar, schedules, user lists, and PDF
 - Keep generated avatar visible on crew profile pages while restoring a large top profile icon section

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.50.1"
+__version__ = "0.51.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -126,7 +126,7 @@ def create_app(test_config=None):
                 return Markup(
                     f'<span class="avatar-icon" style="display:inline-block;'
                     f"width:{size}px;height:{size}px;vertical-align:middle;"
-                    '>'
+                    ">"
                     f'<img class="avatar-photo" src="{image_url}" alt="{display_name}" '
                     f'style="width:100%;height:100%;border-radius:50%;object-fit:cover;">'
                     "</span>"

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -135,6 +135,8 @@ def register(token: str):
             user.initials = initials
             user.set_password(password)
             user.invite_token = None  # Mark registration complete
+            if not user.avatar_seed:
+                user.avatar_seed = User.generate_avatar_seed()
 
             # Auto-link to inviting skipper's crew
             if user.invited_by:
@@ -284,6 +286,7 @@ def invite_user():
         invite_token=token,
         is_skipper=is_skipper,
         invited_by=current_user.id,
+        avatar_seed=User.generate_avatar_seed(),
     )
     db.session.add(user)
     db.session.commit()
@@ -526,6 +529,7 @@ def invite_crew():
         initials="??",
         invite_token=token,
         invited_by=current_user.id,
+        avatar_seed=User.generate_avatar_seed(),
     )
     db.session.add(user)
     db.session.flush()

--- a/app/commands.py
+++ b/app/commands.py
@@ -30,6 +30,7 @@ def register_commands(app: Flask) -> None:
             initials="AD",
             is_admin=True,
             is_skipper=True,
+            avatar_seed=User.generate_avatar_seed(),
         )
         user.set_password(password)
         db.session.add(user)
@@ -53,6 +54,7 @@ def register_commands(app: Flask) -> None:
             initials=initials.upper(),
             is_admin=True,
             is_skipper=True,
+            avatar_seed=User.generate_avatar_seed(),
         )
         user.set_password(password)
         db.session.add(user)

--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,4 @@
+import secrets
 from datetime import date, datetime, timezone
 
 import bcrypt
@@ -68,6 +69,11 @@ class User(UserMixin, db.Model):
         return bcrypt.checkpw(
             password.encode("utf-8"), self.password_hash.encode("utf-8")
         )
+
+    @staticmethod
+    def generate_avatar_seed() -> str:
+        """Generate a unique random seed for Multiavatar."""
+        return f"avatar-{secrets.token_hex(12)}"
 
     @property
     def avatar_key(self) -> str:

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -14,7 +14,7 @@
                         <input type="hidden" name="avatar_seed" id="avatar_seed" value="{{ current_user.avatar_seed or '' }}">
                         <div class="d-flex align-items-center gap-3">
                             <div id="avatar-preview" style="width:120px;height:120px;">
-                                {{ current_user|avatar_svg(120) }}
+                                {{ current_user|user_icon(120) }}
                             </div>
                             <button type="button" class="btn btn-sm btn-outline-secondary" id="regenerate-avatar">Regenerate</button>
                         </div>
@@ -71,9 +71,22 @@ document.getElementById('regenerate-avatar').addEventListener('click', function(
     var seed = 'avatar-' + Date.now() + '-' + Math.random().toString(36).substring(2, 8);
     document.getElementById('avatar_seed').value = seed;
     document.getElementById('remove_profile_image').value = 'on';
+    document.getElementById('profile_image').value = '';
     var svg = multiavatar(seed);
     document.getElementById('avatar-preview').innerHTML =
         '<span class="avatar-icon" style="display:inline-block;width:120px;height:120px;">' + svg + '</span>';
+});
+document.getElementById('profile_image').addEventListener('change', function(e) {
+    var file = e.target.files[0];
+    if (file) {
+        var url = URL.createObjectURL(file);
+        document.getElementById('avatar-preview').innerHTML =
+            '<span class="avatar-icon" style="display:inline-block;width:120px;height:120px;">' +
+            '<img class="avatar-photo" src="' + url + '" alt="Preview" ' +
+            'style="width:100%;height:100%;border-radius:50%;object-fit:cover;">' +
+            '</span>';
+        document.getElementById('remove_profile_image').value = '';
+    }
 });
 </script>
 {% endblock %}

--- a/migrations/versions/h8d9e0f1a2b3_backfill_avatar_seed.py
+++ b/migrations/versions/h8d9e0f1a2b3_backfill_avatar_seed.py
@@ -1,0 +1,21 @@
+"""Backfill avatar_seed for existing users
+
+Revision ID: h8d9e0f1a2b3
+Revises: g7c8d9e0f1a2
+Create Date: 2026-03-11
+"""
+
+from alembic import op
+
+revision = "h8d9e0f1a2b3"
+down_revision = "g7c8d9e0f1a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE users SET avatar_seed = email WHERE avatar_seed IS NULL")
+
+
+def downgrade():
+    op.execute("UPDATE users SET avatar_seed = NULL WHERE avatar_seed = email")

--- a/tests/test_multiavatar.py
+++ b/tests/test_multiavatar.py
@@ -7,6 +7,21 @@ from unittest.mock import patch
 from app.models import RSVP, Regatta, User
 
 
+class TestGenerateAvatarSeed:
+    def test_returns_prefixed_string(self):
+        seed = User.generate_avatar_seed()
+        assert seed.startswith("avatar-")
+
+    def test_returns_unique_values(self):
+        seeds = {User.generate_avatar_seed() for _ in range(50)}
+        assert len(seeds) == 50
+
+    def test_seed_has_expected_length(self):
+        seed = User.generate_avatar_seed()
+        # "avatar-" (7) + 24 hex chars = 31
+        assert len(seed) == 31
+
+
 class TestAvatarKeyProperty:
     def test_avatar_key_defaults_to_email(self, db, admin_user):
         assert admin_user.avatar_seed is None
@@ -169,3 +184,125 @@ class TestAvatarInIcal:
         assert resp.status_code == 200
         data = resp.data.decode()
         assert "AD" in data
+
+
+class TestAutoAvatarSeedOnInvite:
+    def test_invite_user_sets_avatar_seed(self, logged_in_client, admin_user, db):
+        resp = logged_in_client.post(
+            "/admin/users/invite",
+            data={"email": "newuser@test.com"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        user = User.query.filter_by(email="newuser@test.com").first()
+        assert user is not None
+        assert user.avatar_seed is not None
+        assert user.avatar_seed.startswith("avatar-")
+
+    def test_invite_crew_sets_avatar_seed(self, logged_in_client, admin_user, db):
+        resp = logged_in_client.post(
+            "/my-crew/invite",
+            data={"email": "crewnew@test.com"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        user = User.query.filter_by(email="crewnew@test.com").first()
+        assert user is not None
+        assert user.avatar_seed is not None
+        assert user.avatar_seed.startswith("avatar-")
+
+
+class TestAutoAvatarSeedOnRegister:
+    def test_register_backfills_seed_if_missing(self, client, db, admin_user):
+        """Legacy invited users without avatar_seed get one on registration."""
+        user = User(
+            email="legacy@test.com",
+            password_hash="pending",
+            display_name="legacy@test.com",
+            initials="??",
+            invite_token="legacy-token-123",
+            invited_by=admin_user.id,
+        )
+        db.session.add(user)
+        db.session.commit()
+        assert user.avatar_seed is None
+
+        client.post(
+            "/register/legacy-token-123",
+            data={
+                "display_name": "Legacy User",
+                "initials": "LU",
+                "password": "password123",
+                "password2": "password123",
+            },
+            follow_redirects=True,
+        )
+        db.session.refresh(user)
+        assert user.invite_token is None
+        assert user.avatar_seed is not None
+        assert user.avatar_seed.startswith("avatar-")
+
+    def test_register_preserves_existing_seed(self, client, db, admin_user):
+        """Users who already have avatar_seed keep it on registration."""
+        user = User(
+            email="seeded@test.com",
+            password_hash="pending",
+            display_name="seeded@test.com",
+            initials="??",
+            invite_token="seeded-token-456",
+            invited_by=admin_user.id,
+            avatar_seed="avatar-existing-seed",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/register/seeded-token-456",
+            data={
+                "display_name": "Seeded User",
+                "initials": "SU",
+                "password": "password123",
+                "password2": "password123",
+            },
+            follow_redirects=True,
+        )
+        db.session.refresh(user)
+        assert user.avatar_seed == "avatar-existing-seed"
+
+
+class TestCliAvatarSeed:
+    def test_init_admin_sets_avatar_seed(self, app, db):
+        runner = app.test_cli_runner()
+        result = runner.invoke(
+            args=["init-admin"],
+            env={
+                "INIT_ADMIN_EMAIL": "cliadmin@test.com",
+                "INIT_ADMIN_PASSWORD": "password123",
+            },
+        )
+        assert result.exit_code == 0
+        user = User.query.filter_by(email="cliadmin@test.com").first()
+        assert user is not None
+        assert user.avatar_seed is not None
+        assert user.avatar_seed.startswith("avatar-")
+
+    def test_create_admin_sets_avatar_seed(self, app, db):
+        runner = app.test_cli_runner()
+        result = runner.invoke(
+            args=[
+                "create-admin",
+                "--email",
+                "cliadmin2@test.com",
+                "--password",
+                "password123",
+                "--name",
+                "CLI Admin",
+                "--initials",
+                "CA",
+            ],
+        )
+        assert result.exit_code == 0
+        user = User.query.filter_by(email="cliadmin2@test.com").first()
+        assert user is not None
+        assert user.avatar_seed is not None
+        assert user.avatar_seed.startswith("avatar-")

--- a/tests/test_profile_picture_display.py
+++ b/tests/test_profile_picture_display.py
@@ -125,3 +125,54 @@ class TestViewProfileImage:
         html = resp.data.decode()
         assert "avatar-photo" not in html
         assert "avatar-icon" in html
+
+
+class TestProfilePagePreview:
+    @patch("app.storage.get_file_url", return_value="https://s3.example.com/pic.jpg")
+    def test_profile_preview_shows_uploaded_picture(self, mock_url, app, client, db):
+        """Profile page preview should show uploaded picture, not avatar SVG."""
+        app.config["BUCKET_NAME"] = "test-bucket"
+
+        user = User(
+            email="picuser@test.com",
+            display_name="Pic User",
+            initials="PU",
+            profile_image_key="profile-images/pic.jpg",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "picuser@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get("/profile")
+        html = resp.data.decode()
+        # The avatar-preview div should contain an img tag, not an SVG
+        assert "avatar-photo" in html
+        assert "https://s3.example.com/pic.jpg" in html
+
+    def test_profile_preview_shows_avatar_when_no_picture(self, app, client, db):
+        """Profile page preview should show avatar SVG when no picture uploaded."""
+        user = User(
+            email="nopic@test.com",
+            display_name="No Pic",
+            initials="NP",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "nopic@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get("/profile")
+        html = resp.data.decode()
+        assert "<svg" in html
+        assert "avatar-icon" in html


### PR DESCRIPTION
## Summary
- Auto-generate unique avatar seeds at all user creation points (admin invite, crew invite, registration, CLI commands)
- Add data migration to backfill existing users with their email as seed (preserves current avatars)
- Fix profile page preview to show uploaded profile picture instead of always showing avatar SVG
- Add file selection preview and clear file input on regenerate in profile settings

## Test plan
- [x] Full test suite passes (310 tests)
- [ ] Invite a user via admin → verify user has `avatar_seed` set
- [ ] Invite a user via my-crew → verify user has `avatar_seed` set
- [ ] Register as invited user → verify avatar_seed persists
- [ ] Profile page with uploaded picture → preview shows picture, not avatar
- [ ] Click Regenerate → preview switches to new avatar, file input cleared
- [ ] Select file → preview shows file preview
- [ ] Migration backfills existing users with email as seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)