### PR TITLE
Add local filesystem storage fallback (v0.52.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,8 @@ MYSQL_ROOT_PASSWORD=rootpassword
 MYSQL_DATABASE=racecrew
 MYSQL_USER=racecrew
 MYSQL_PASSWORD=racecrew
-BUCKET_NAME=racecrew-attachment-bucket
+# Leave empty for local filesystem storage (uses UPLOAD_FOLDER)
+BUCKET_NAME=
 AWS_REGION=us-east-1
 INIT_ADMIN_EMAIL=admin@racecrew.net
 INIT_ADMIN_PASSWORD=change-me

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ cp .env.example .env
 ```
 
 Edit `.env` and set `SECRET_KEY`, `INIT_ADMIN_EMAIL`, `INIT_ADMIN_PASSWORD`, and
-optionally `ANTHROPIC_API_KEY` for the AI schedule import feature.
+optionally `ANTHROPIC_API_KEY` for the AI schedule import feature. Leave
+`BUCKET_NAME` empty to use local filesystem storage for uploads (files are saved
+to the `uploads/` directory); set it to an S3 bucket name for production.
 
 ```bash
 ./dev.sh start

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,12 @@
 # Version History
 
+## 0.52.0
+- Add local filesystem storage fallback when BUCKET_NAME is not set
+- Uploads automatically use local disk (UPLOAD_FOLDER) in local dev, S3 in production
+- New storage blueprint serves locally stored files at /uploads/ (login required)
+- Remove BUCKET_NAME guards so profile pictures and documents work without S3
+- Zero configuration needed for local development — just leave BUCKET_NAME empty
+
 ## 0.51.0
 - Auto-assign random Multiavatar to every new user at creation time
 - All user creation points (admin invite, crew invite, registration, CLI commands) generate a unique avatar seed

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -46,12 +46,14 @@ def create_app(test_config=None):
     from app.calendar import bp as calendar_bp
     from app.email import bp as email_bp
     from app.regattas import bp as regattas_bp
+    from app.storage_routes import bp as storage_bp
 
     app.register_blueprint(admin_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(calendar_bp)
     app.register_blueprint(email_bp)
     app.register_blueprint(regattas_bp)
+    app.register_blueprint(storage_bp)
 
     from app.commands import register_commands
 
@@ -66,11 +68,7 @@ def create_app(test_config=None):
         from flask_login import current_user as cu
 
         url = None
-        if (
-            cu.is_authenticated
-            and cu.profile_image_key
-            and app.config.get("BUCKET_NAME")
-        ):
+        if cu.is_authenticated and cu.profile_image_key:
             try:
                 from app import storage
 
@@ -113,11 +111,7 @@ def create_app(test_config=None):
     @app.template_filter("user_icon")
     def user_icon_filter(user, size=20):
         """Render profile picture when present; otherwise render avatar fallback."""
-        if (
-            user
-            and getattr(user, "profile_image_key", None)
-            and app.config.get("BUCKET_NAME")
-        ):
+        if user and getattr(user, "profile_image_key", None):
             try:
                 from app import storage
 
@@ -126,7 +120,7 @@ def create_app(test_config=None):
                 return Markup(
                     f'<span class="avatar-icon" style="display:inline-block;'
                     f"width:{size}px;height:{size}px;vertical-align:middle;"
-                    ">"
+                    '">'
                     f'<img class="avatar-photo" src="{image_url}" alt="{display_name}" '
                     f'style="width:100%;height:100%;border-radius:50%;object-fit:cover;">'
                     "</span>"

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -34,7 +34,7 @@ def _profile_image_limit_mb() -> int:
 
 def _build_profile_image_url(image_key: str | None) -> str | None:
     """Return a temporary URL for a stored profile image key."""
-    if not image_key or not current_app.config.get("BUCKET_NAME"):
+    if not image_key:
         return None
 
     try:
@@ -46,9 +46,6 @@ def _build_profile_image_url(image_key: str | None) -> str | None:
 
 def _upload_profile_image(file_storage) -> str:
     """Validate and upload a profile image, returning its storage key."""
-    if not current_app.config.get("BUCKET_NAME"):
-        raise ValueError("Profile image storage is not configured.")
-
     safe_name = secure_filename(file_storage.filename or "")
     ext = os.path.splitext(safe_name)[1].lower()
     if ext not in ALLOWED_PROFILE_IMAGE_EXTENSIONS:

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,6 +1,13 @@
+from pathlib import Path
+
 import boto3
 from botocore.exceptions import ClientError
-from flask import current_app
+from flask import current_app, url_for
+
+
+def _use_s3() -> bool:
+    """Return True when S3 storage is configured (BUCKET_NAME is set)."""
+    return bool(current_app.config.get("BUCKET_NAME"))
 
 
 def _get_client():
@@ -13,29 +20,60 @@ def _get_client():
     )
 
 
+def _get_upload_path(key: str) -> Path:
+    """Resolve a storage key to a full local filesystem path.
+
+    Raises ValueError if the resolved path escapes the upload directory
+    (path traversal protection).
+    """
+    upload_folder = current_app.config.get("UPLOAD_FOLDER", "uploads")
+    base = Path(upload_folder)
+    if not base.is_absolute():
+        base = Path(current_app.root_path).parent / upload_folder
+    full_path = (base / key).resolve()
+    if not str(full_path).startswith(str(base.resolve())):
+        raise ValueError("Invalid file path")
+    return full_path
+
+
 def upload_file(file, stored_filename: str) -> None:
-    """Upload a file-like object to the S3 bucket."""
-    bucket = current_app.config["BUCKET_NAME"]
-    client = _get_client()
-    client.upload_fileobj(file, bucket, stored_filename)
+    """Upload a file-like object to S3 or the local filesystem."""
+    if _use_s3():
+        bucket = current_app.config["BUCKET_NAME"]
+        client = _get_client()
+        client.upload_fileobj(file, bucket, stored_filename)
+    else:
+        full_path = _get_upload_path(stored_filename)
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        file.save(full_path)
 
 
 def get_file_url(stored_filename: str) -> str:
-    """Return a presigned URL (valid 1 hour) for downloading a file."""
-    bucket = current_app.config["BUCKET_NAME"]
-    client = _get_client()
-    return client.generate_presigned_url(
-        "get_object",
-        Params={"Bucket": bucket, "Key": stored_filename},
-        ExpiresIn=3600,
-    )
+    """Return a URL for downloading a file.
+
+    S3: presigned URL valid for 1 hour.
+    Local: route URL served by the storage blueprint.
+    """
+    if _use_s3():
+        bucket = current_app.config["BUCKET_NAME"]
+        client = _get_client()
+        return client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": stored_filename},
+            ExpiresIn=3600,
+        )
+    return url_for("storage_bp.serve_file", filename=stored_filename)
 
 
 def delete_file(stored_filename: str) -> None:
-    """Delete a file from the S3 bucket. Silently ignores missing files."""
-    bucket = current_app.config["BUCKET_NAME"]
-    client = _get_client()
-    try:
-        client.delete_object(Bucket=bucket, Key=stored_filename)
-    except ClientError:
-        pass
+    """Delete a file from S3 or the local filesystem. Silently ignores missing files."""
+    if _use_s3():
+        bucket = current_app.config["BUCKET_NAME"]
+        client = _get_client()
+        try:
+            client.delete_object(Bucket=bucket, Key=stored_filename)
+        except ClientError:
+            pass
+    else:
+        full_path = _get_upload_path(stored_filename)
+        full_path.unlink(missing_ok=True)

--- a/app/storage_routes.py
+++ b/app/storage_routes.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from flask import Blueprint, current_app, send_from_directory
+from flask_login import login_required
+
+bp = Blueprint("storage_bp", __name__)
+
+
+@bp.route("/uploads/<path:filename>")
+@login_required
+def serve_file(filename: str):
+    """Serve a locally stored file. Only used when S3 is not configured."""
+    upload_folder = current_app.config.get("UPLOAD_FOLDER", "uploads")
+    base = Path(upload_folder)
+    if not base.is_absolute():
+        base = Path(current_app.root_path).parent / upload_folder
+    return send_from_directory(str(base), filename)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,243 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestBackendSelection:
+    """_use_s3() returns True when BUCKET_NAME is set, False otherwise."""
+
+    def test_s3_when_bucket_name_set(self, app):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = "my-bucket"
+            from app.storage import _use_s3
+
+            assert _use_s3() is True
+
+    def test_local_when_bucket_name_empty(self, app):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = ""
+            from app.storage import _use_s3
+
+            assert _use_s3() is False
+
+    def test_local_when_bucket_name_missing(self, app):
+        with app.app_context():
+            app.config.pop("BUCKET_NAME", None)
+            from app.storage import _use_s3
+
+            assert _use_s3() is False
+
+
+class TestLocalUpload:
+    """upload_file() saves to disk when BUCKET_NAME is empty."""
+
+    def test_creates_file_on_disk(self, app, tmp_path):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = ""
+            app.config["UPLOAD_FOLDER"] = str(tmp_path)
+            from app.storage import upload_file
+
+            fake_file = MagicMock()
+            upload_file(fake_file, "test.txt")
+
+            expected = tmp_path / "test.txt"
+            fake_file.save.assert_called_once_with(expected)
+
+    def test_creates_subdirectories(self, app, tmp_path):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = ""
+            app.config["UPLOAD_FOLDER"] = str(tmp_path)
+            from app.storage import upload_file
+
+            fake_file = MagicMock()
+            upload_file(fake_file, "profile-images/abc.png")
+
+            expected = tmp_path / "profile-images" / "abc.png"
+            fake_file.save.assert_called_once_with(expected)
+            assert (tmp_path / "profile-images").is_dir()
+
+    def test_rejects_path_traversal(self, app, tmp_path):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = ""
+            app.config["UPLOAD_FOLDER"] = str(tmp_path)
+            from app.storage import upload_file
+
+            fake_file = MagicMock()
+            with pytest.raises(ValueError, match="Invalid file path"):
+                upload_file(fake_file, "../../../etc/passwd")
+
+
+class TestLocalGetFileUrl:
+    """get_file_url() returns a /uploads/... URL when BUCKET_NAME is empty."""
+
+    def test_returns_upload_route_url(self, app):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = ""
+            from app.storage import get_file_url
+
+            url = get_file_url("profile-images/abc.png")
+            assert url.endswith("/uploads/profile-images/abc.png")
+
+
+class TestLocalDeleteFile:
+    """delete_file() removes file from disk when BUCKET_NAME is empty."""
+
+    def test_deletes_existing_file(self, app, tmp_path):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = ""
+            app.config["UPLOAD_FOLDER"] = str(tmp_path)
+            from app.storage import delete_file
+
+            target = tmp_path / "test.txt"
+            target.write_text("hello")
+            assert target.exists()
+
+            delete_file("test.txt")
+            assert not target.exists()
+
+    def test_no_error_on_missing_file(self, app, tmp_path):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = ""
+            app.config["UPLOAD_FOLDER"] = str(tmp_path)
+            from app.storage import delete_file
+
+            # Should not raise
+            delete_file("nonexistent.txt")
+
+
+class TestS3Backend:
+    """S3 functions are called when BUCKET_NAME is set."""
+
+    @patch("app.storage._get_client")
+    def test_upload_uses_s3(self, mock_get_client, app):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = "my-bucket"
+            from app.storage import upload_file
+
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+
+            fake_file = MagicMock()
+            upload_file(fake_file, "test.txt")
+
+            mock_client.upload_fileobj.assert_called_once_with(
+                fake_file, "my-bucket", "test.txt"
+            )
+
+    @patch("app.storage._get_client")
+    def test_get_file_url_uses_s3(self, mock_get_client, app):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = "my-bucket"
+            from app.storage import get_file_url
+
+            mock_client = MagicMock()
+            mock_client.generate_presigned_url.return_value = (
+                "https://s3.example.com/test.txt"
+            )
+            mock_get_client.return_value = mock_client
+
+            url = get_file_url("test.txt")
+
+            assert url == "https://s3.example.com/test.txt"
+            mock_client.generate_presigned_url.assert_called_once()
+
+    @patch("app.storage._get_client")
+    def test_delete_uses_s3(self, mock_get_client, app):
+        with app.app_context():
+            app.config["BUCKET_NAME"] = "my-bucket"
+            from app.storage import delete_file
+
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+
+            delete_file("test.txt")
+
+            mock_client.delete_object.assert_called_once_with(
+                Bucket="my-bucket", Key="test.txt"
+            )
+
+
+class TestServeRoute:
+    """The /uploads/<path:filename> route serves local files."""
+
+    def test_serves_file_when_logged_in(self, app, tmp_path, db):
+        app.config["UPLOAD_FOLDER"] = str(tmp_path)
+        target = tmp_path / "test.txt"
+        target.write_text("file content")
+
+        from app.models import User
+
+        user = User(
+            email="storage@test.com",
+            display_name="Storage Tester",
+            initials="ST",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "storage@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/uploads/test.txt")
+        assert resp.status_code == 200
+        assert resp.data == b"file content"
+
+    def test_redirects_anonymous_to_login(self, client):
+        resp = client.get("/uploads/test.txt")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_404_for_missing_file(self, app, tmp_path, db):
+        app.config["UPLOAD_FOLDER"] = str(tmp_path)
+
+        from app.models import User
+
+        user = User(
+            email="storage404@test.com",
+            display_name="Storage 404",
+            initials="S4",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "storage404@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/uploads/nonexistent.txt")
+        assert resp.status_code == 404
+
+    def test_serves_nested_path(self, app, tmp_path, db):
+        app.config["UPLOAD_FOLDER"] = str(tmp_path)
+        subdir = tmp_path / "profile-images"
+        subdir.mkdir()
+        target = subdir / "abc.png"
+        target.write_bytes(b"\x89PNG")
+
+        from app.models import User
+
+        user = User(
+            email="nested@test.com",
+            display_name="Nested Tester",
+            initials="NT",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client = app.test_client()
+        client.post(
+            "/login",
+            data={"email": "nested@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+        resp = client.get("/uploads/profile-images/abc.png")
+        assert resp.status_code == 200
+        assert resp.data == b"\x89PNG"


### PR DESCRIPTION
## Summary
- When `BUCKET_NAME` is empty (local dev), uploads save to `UPLOAD_FOLDER` on disk instead of failing
- New storage blueprint serves local files at `/uploads/` behind `@login_required`
- Removed `BUCKET_NAME` guards from profile image and document upload flows — storage now always works (S3 or local)
- Fixed pre-existing broken style attribute in `user_icon_filter` that prevented profile pictures from rendering

Closes #73

## Test plan
- [x] `pytest` — 326 tests pass (16 new storage tests)
- [x] Local dev: uploaded profile picture saves to `uploads/profile-images/` and displays correctly
- [x] Local dev: profile picture visible in navbar, schedule crew badges, and profile pages
- [x] S3 path unchanged — when `BUCKET_NAME` is set, all uploads go to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)