### PR TITLE
Add 30s timeout to Anthropic API calls (#77) (v0.54.1)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.54.1
+- Add 30-second timeout to all Anthropic API calls in document discovery and regatta extraction (#77)
+- Catch `APITimeoutError` explicitly with clear error message instead of hanging indefinitely
+- Existing error handling for connection, rate-limit, and status errors unchanged
+
 ## 0.54.0
 - Add scheduled email reminders (Phase 2): RSVP daily digest, RSVP reminders (14 days before), and coming-up reminders (3 days before)
 - Skippers can switch to daily digest mode for batched RSVP summary emails

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.54.0"
+__version__ = "0.54.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/ai_service.py
+++ b/app/admin/ai_service.py
@@ -116,7 +116,10 @@ def extract_regattas(content: str, year: int) -> list[dict]:
             model="claude-sonnet-4-20250514",
             max_tokens=4096,
             messages=[{"role": "user", "content": prompt}],
+            timeout=30.0,
         )
+    except anthropic.APITimeoutError:
+        raise ConnectionError("Claude API request timed out. Please try again.")
     except anthropic.APIConnectionError:
         raise ConnectionError("Could not connect to the Claude API.")
     except anthropic.RateLimitError:
@@ -188,7 +191,10 @@ def discover_documents(content: str, regatta_name: str, source_url: str) -> list
             model="claude-sonnet-4-20250514",
             max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
+            timeout=30.0,
         )
+    except anthropic.APITimeoutError:
+        raise ConnectionError("Claude API request timed out. Please try again.")
     except anthropic.APIConnectionError:
         raise ConnectionError("Could not connect to the Claude API.")
     except anthropic.RateLimitError:
@@ -221,7 +227,10 @@ def discover_documents_deep(
             model="claude-sonnet-4-20250514",
             max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
+            timeout=30.0,
         )
+    except anthropic.APITimeoutError:
+        raise ConnectionError("Claude API request timed out. Please try again.")
     except anthropic.APIConnectionError:
         raise ConnectionError("Could not connect to the Claude API.")
     except anthropic.RateLimitError:

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import anthropic
 import pytest
 
 from app.admin.ai_service import (_parse_json_response, discover_documents,
@@ -82,6 +83,31 @@ class TestExtractRegattas:
             result = extract_regattas("content", 2026)
             assert result[0]["name"] == "Fenced"
 
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_timeout_raises_connection_error(self, mock_cls, app):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.side_effect = anthropic.APITimeoutError(
+            request=MagicMock()
+        )
+
+        with app.app_context():
+            with pytest.raises(ConnectionError, match="timed out"):
+                extract_regattas("content", 2026)
+
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_passes_timeout_to_api(self, mock_cls, app):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text='[{"name": "Test"}]')]
+        mock_client.messages.create.return_value = mock_msg
+
+        with app.app_context():
+            extract_regattas("content", 2026)
+            _, kwargs = mock_client.messages.create.call_args
+            assert kwargs["timeout"] == 30.0
+
 
 # --- discover_documents ---
 
@@ -117,6 +143,31 @@ class TestDiscoverDocuments:
             result = discover_documents("content", "Test", "http://example.com")
             assert result == []
 
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_timeout_raises_connection_error(self, mock_cls, app):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.side_effect = anthropic.APITimeoutError(
+            request=MagicMock()
+        )
+
+        with app.app_context():
+            with pytest.raises(ConnectionError, match="timed out"):
+                discover_documents("content", "Test", "http://example.com")
+
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_passes_timeout_to_api(self, mock_cls, app):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="[]")]
+        mock_client.messages.create.return_value = mock_msg
+
+        with app.app_context():
+            discover_documents("content", "Test", "http://example.com")
+            _, kwargs = mock_client.messages.create.call_args
+            assert kwargs["timeout"] == 30.0
+
 
 # --- discover_documents_deep ---
 
@@ -143,3 +194,28 @@ class TestDiscoverDocumentsDeep:
             )
             assert len(result) == 2
             assert {d["doc_type"] for d in result} == {"NOR", "SI"}
+
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_timeout_raises_connection_error(self, mock_cls, app):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.side_effect = anthropic.APITimeoutError(
+            request=MagicMock()
+        )
+
+        with app.app_context():
+            with pytest.raises(ConnectionError, match="timed out"):
+                discover_documents_deep("content", "Test", "http://example.com")
+
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_passes_timeout_to_api(self, mock_cls, app):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="[]")]
+        mock_client.messages.create.return_value = mock_msg
+
+        with app.app_context():
+            discover_documents_deep("content", "Test", "http://example.com")
+            _, kwargs = mock_client.messages.create.call_args
+            assert kwargs["timeout"] == 30.0


### PR DESCRIPTION
## Summary
- Add `timeout=30.0` to all three `client.messages.create()` calls in `ai_service.py` (extract_regattas, discover_documents, discover_documents_deep)
- Catch `anthropic.APITimeoutError` explicitly with a clear "timed out" error message
- Prevents indefinite hangs when the Anthropic API is slow or unresponsive during document discovery and regatta import

## Test plan
- [x] 6 new tests: timeout raises `ConnectionError`, and `timeout=30.0` is passed to the API (2 per function)
- [x] All 394 tests pass
- [x] `black . && isort . && flake8` passes

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)