### PR TITLE
Add dedicated calendar subscription page with webcal:// support

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.55.0
+- Replace flash+redirect calendar subscribe flow with dedicated subscription page
+- Add "Open in Calendar App" button using webcal:// protocol for one-tap subscribe (Apple Calendar, Outlook)
+- Add step-by-step setup instructions for Apple Calendar (iPhone/iPad/Mac), Google Calendar, and Outlook
+- Subscription URL with copy button for manual setup
+- Rename navbar link from "iCal" to "Calendar"
+- Add comprehensive tests for subscribe page
+
 ## 0.54.1
 - Add 30-second timeout to all Anthropic API calls in document discovery and regatta extraction (#77)
 - Catch `APITimeoutError` explicitly with clear error message instead of hanging indefinitely

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.54.1"
+__version__ = "0.55.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/calendar/routes.py
+++ b/app/calendar/routes.py
@@ -1,10 +1,9 @@
 import secrets
 from datetime import timedelta
 
-from flask import Response, flash, redirect, url_for
+from flask import Response, render_template, url_for
 from flask_login import current_user, login_required
 from icalendar import Calendar, Event
-from markupsafe import Markup
 
 from app import db
 from app.calendar import bp
@@ -22,13 +21,12 @@ def subscribe():
     feed_url = url_for(
         "calendar.ical_feed", token=current_user.calendar_token, _external=True
     )
-    flash(
-        Markup(
-            f'Subscribe to this URL in your calendar app: <a href="{feed_url}" class="alert-link">{feed_url}</a>'
-        ),
-        "success",
+    webcal_url = feed_url.replace("https://", "webcal://", 1).replace(
+        "http://", "webcal://", 1
     )
-    return redirect(url_for("regattas.index"))
+    return render_template(
+        "calendar/subscribe.html", feed_url=feed_url, webcal_url=webcal_url
+    )
 
 
 @bp.route("/calendar/<token>.ics")
@@ -43,7 +41,13 @@ def ical_feed(token: str):
     cal.add("x-wr-calname", "Race Crew Network")
     cal.add("method", "PUBLISH")
 
-    regattas = user.visible_regattas().order_by(Regatta.start_date).all()
+    regattas = (
+        user.visible_regattas()
+        .join(RSVP, (RSVP.regatta_id == Regatta.id) & (RSVP.user_id == user.id))
+        .filter(RSVP.status.in_(["yes", "maybe"]))
+        .order_by(Regatta.start_date)
+        .all()
+    )
 
     for regatta in regattas:
         event = Event()

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -33,7 +33,7 @@
             <div class="collapse navbar-collapse" id="navMenu">
                 <div class="navbar-nav ms-auto align-items-center gap-2">
                     <a class="nav-link nav-pill-link" href="{{ url_for('regattas.index') }}">Home</a>
-                    <a class="nav-link nav-pill-link" href="{{ url_for('calendar.subscribe') }}">iCal</a>
+                    <a class="nav-link nav-pill-link" href="{{ url_for('calendar.subscribe') }}">Calendar</a>
                     {% if current_user.is_admin or current_user.is_skipper %}
                     <a class="nav-link nav-pill-link" href="{{ url_for('auth.my_crew') }}">My Crew</a>
                     <li class="nav-item dropdown">

--- a/app/templates/calendar/subscribe.html
+++ b/app/templates/calendar/subscribe.html
@@ -1,0 +1,143 @@
+{% extends "base.html" %}
+
+{% block title %}Calendar Subscription — Race Crew Network{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <h2>Calendar Subscription</h2>
+            <p>Subscribe to keep your calendar in sync with your race schedule. Regattas you've RSVP'd <strong>Yes</strong> or <strong>Maybe</strong> to will appear automatically, and updates sync whenever your calendar app refreshes.</p>
+
+            <div class="card mb-4">
+                <div class="card-body">
+                    <h5 class="card-title">Quick Subscribe</h5>
+                    <p class="card-text">If you use <strong>Apple Calendar</strong> or <strong>Outlook</strong>, click the button below to subscribe instantly. Your calendar app will open and ask you to confirm the subscription.</p>
+                    <a href="{{ webcal_url }}" class="btn btn-primary" id="webcal-subscribe">Open in Calendar App</a>
+                    <div class="form-text mt-2">Works with Apple Calendar (iPhone, iPad, Mac) and Outlook (desktop and mobile). For Google Calendar, follow the manual steps below.</div>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-body">
+                    <h5 class="card-title">Subscription URL</h5>
+                    <p class="card-text">If the button above doesn't work for your calendar app, copy this URL and add it manually using the instructions below.</p>
+                    <div class="input-group">
+                        <input type="text" class="form-control" id="ical-url" readonly value="{{ feed_url }}">
+                        <button class="btn btn-outline-secondary" type="button" id="copy-ical-url"
+                                onclick="navigator.clipboard.writeText(document.getElementById('ical-url').value); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy', 2000);">Copy</button>
+                    </div>
+                    <div class="form-text mt-2">This URL is private to you. Don't share it with others.</div>
+                </div>
+            </div>
+
+            <h5 class="mb-3">Setup Instructions</h5>
+            <div class="accordion mb-4" id="calendarInstructions">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#appleInstructions">
+                            Apple Calendar (iPhone / iPad)
+                        </button>
+                    </h2>
+                    <div id="appleInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
+                        <div class="accordion-body">
+                            <p><strong>Easiest way:</strong> Tap the <strong>"Open in Calendar App"</strong> button above. Your iPhone will ask you to confirm the subscription — tap <strong>Subscribe</strong> and you're done.</p>
+                            <hr>
+                            <p><strong>Manual setup:</strong></p>
+                            <ol>
+                                <li>Tap the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Open the <strong>Settings</strong> app on your iPhone or iPad.</li>
+                                <li>Scroll down and tap <strong>Calendar</strong> (or <strong>Mail</strong> on older iOS versions).</li>
+                                <li>Tap <strong>Accounts</strong> &gt; <strong>Add Account</strong> &gt; <strong>Other</strong>.</li>
+                                <li>Under Calendars, tap <strong>Add Subscribed Calendar</strong>.</li>
+                                <li>Paste the URL into the <strong>Server</strong> field and tap <strong>Next</strong>.</li>
+                                <li>Review the settings and tap <strong>Save</strong>.</li>
+                            </ol>
+                            <p class="text-muted small mb-0">Your subscribed calendar will appear in the Calendar app. iOS typically refreshes subscribed calendars every few hours.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#macInstructions">
+                            Apple Calendar (Mac)
+                        </button>
+                    </h2>
+                    <div id="macInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
+                        <div class="accordion-body">
+                            <p><strong>Easiest way:</strong> Click the <strong>"Open in Calendar App"</strong> button above. Calendar will open and ask you to confirm — click <strong>Subscribe</strong>.</p>
+                            <hr>
+                            <p><strong>Manual setup:</strong></p>
+                            <ol>
+                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Open the <strong>Calendar</strong> app on your Mac.</li>
+                                <li>From the menu bar, click <strong>File</strong> &gt; <strong>New Calendar Subscription...</strong></li>
+                                <li>Paste the URL into the <strong>Calendar URL</strong> field and click <strong>Subscribe</strong>.</li>
+                                <li>Choose a name, color, and how often to auto-refresh (every hour is recommended).</li>
+                                <li>Click <strong>OK</strong>.</li>
+                            </ol>
+                            <p class="text-muted small mb-0">If you use iCloud, the subscription will sync to all your Apple devices automatically.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#googleInstructions">
+                            Google Calendar
+                        </button>
+                    </h2>
+                    <div id="googleInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
+                        <div class="accordion-body">
+                            <p class="text-muted">Google Calendar does not support the subscribe button — you'll need to add the URL manually. This must be done from a computer, not the mobile app.</p>
+                            <ol>
+                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Open <a href="https://calendar.google.com" target="_blank" rel="noopener">Google Calendar</a> in a web browser on your computer.</li>
+                                <li>In the left sidebar, find <strong>"Other calendars"</strong> and click the <strong>+</strong> icon next to it.</li>
+                                <li>Select <strong>From URL</strong>.</li>
+                                <li>Paste the subscription URL into the <strong>URL of calendar</strong> field.</li>
+                                <li>Click <strong>Add calendar</strong>.</li>
+                            </ol>
+                            <p class="text-muted small mb-0">Google Calendar typically refreshes subscribed calendars once every 12–24 hours. There is no way to force a manual refresh.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#outlookInstructions">
+                            Outlook
+                        </button>
+                    </h2>
+                    <div id="outlookInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
+                        <div class="accordion-body">
+                            <p><strong>Easiest way:</strong> Click the <strong>"Open in Calendar App"</strong> button above. Outlook will open and ask you to confirm the subscription.</p>
+                            <hr>
+                            <p><strong>Outlook on the web (outlook.com):</strong></p>
+                            <ol>
+                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Open <a href="https://outlook.live.com/calendar" target="_blank" rel="noopener">Outlook Calendar</a> in your browser.</li>
+                                <li>Click <strong>Add calendar</strong> in the left sidebar.</li>
+                                <li>Select <strong>Subscribe from web</strong>.</li>
+                                <li>Paste the URL, give the calendar a name, and click <strong>Import</strong>.</li>
+                            </ol>
+                            <hr>
+                            <p><strong>Outlook desktop app (Windows/Mac):</strong></p>
+                            <ol>
+                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Open Outlook and switch to the <strong>Calendar</strong> view.</li>
+                                <li>Click <strong>Add calendar</strong> (or <strong>Open Calendar</strong> on older versions).</li>
+                                <li>Select <strong>From Internet...</strong> or <strong>Subscribe from web</strong>.</li>
+                                <li>Paste the URL and click <strong>OK</strong>.</li>
+                            </ol>
+                            <p class="text-muted small mb-0">Outlook typically refreshes subscribed calendars every 3 hours.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <p class="text-muted small">Your calendar app will refresh automatically (typically every few hours, depending on the app). Changes to your RSVPs will appear at the next refresh.</p>
+
+            <a href="{{ url_for('regattas.index') }}" class="btn btn-outline-secondary">&larr; Back to Schedule</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,247 @@
+"""Tests for iCal feed RSVP filtering and calendar awareness features."""
+
+from datetime import date, timedelta
+
+from app.models import RSVP, Regatta
+
+# ---------------------------------------------------------------------------
+# iCal Feed Filtering
+# ---------------------------------------------------------------------------
+
+
+def _create_regatta(db, skipper, name="Test Regatta", days_ahead=30):
+    """Helper to create a regatta owned by the given skipper."""
+    r = Regatta(
+        name=name,
+        location="Test Location",
+        start_date=date.today() + timedelta(days=days_ahead),
+        created_by=skipper.id,
+    )
+    db.session.add(r)
+    db.session.commit()
+    return r
+
+
+def _rsvp(db, user, regatta, status):
+    """Helper to create an RSVP record."""
+    rsvp = RSVP(user_id=user.id, regatta_id=regatta.id, status=status)
+    db.session.add(rsvp)
+    db.session.commit()
+    return rsvp
+
+
+def _subscribe(client):
+    """Hit subscribe endpoint to generate a calendar token, return the response."""
+    resp = client.get("/calendar/subscribe")
+    assert resp.status_code == 200
+    return resp
+
+
+class TestIcalFeedFiltering:
+    """Feed only includes regattas with yes/maybe RSVP."""
+
+    def test_feed_includes_yes_rsvp(self, db, logged_in_client, admin_user):
+        r = _create_regatta(db, admin_user)
+        _rsvp(db, admin_user, r, "yes")
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"Test Regatta" in resp.data
+
+    def test_feed_includes_maybe_rsvp(self, db, logged_in_client, admin_user):
+        r = _create_regatta(db, admin_user)
+        _rsvp(db, admin_user, r, "maybe")
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"Test Regatta" in resp.data
+
+    def test_feed_excludes_no_rsvp(self, db, logged_in_client, admin_user):
+        r = _create_regatta(db, admin_user)
+        _rsvp(db, admin_user, r, "no")
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"Test Regatta" not in resp.data
+
+    def test_feed_excludes_no_rsvp_record(self, db, logged_in_client, admin_user):
+        _create_regatta(db, admin_user)
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"Test Regatta" not in resp.data
+
+    def test_mixed_rsvps_only_yes_maybe(self, db, logged_in_client, admin_user):
+        r1 = _create_regatta(db, admin_user, name="Yes Regatta", days_ahead=10)
+        r2 = _create_regatta(db, admin_user, name="Maybe Regatta", days_ahead=20)
+        r3 = _create_regatta(db, admin_user, name="No Regatta", days_ahead=30)
+        _create_regatta(db, admin_user, name="No RSVP Regatta", days_ahead=40)
+        _rsvp(db, admin_user, r1, "yes")
+        _rsvp(db, admin_user, r2, "maybe")
+        _rsvp(db, admin_user, r3, "no")
+        # r4 has no RSVP
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"Yes Regatta" in resp.data
+        assert b"Maybe Regatta" in resp.data
+        assert b"No Regatta" not in resp.data
+        assert b"No RSVP Regatta" not in resp.data
+
+    def test_skipper_own_regatta_excluded_without_rsvp(
+        self, db, logged_in_skipper, skipper_user
+    ):
+        _create_regatta(db, skipper_user)
+        _subscribe(logged_in_skipper)
+        db.session.refresh(skipper_user)
+
+        resp = logged_in_skipper.get(f"/calendar/{skipper_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"Test Regatta" not in resp.data
+
+    def test_skipper_own_regatta_included_with_yes(
+        self, db, logged_in_skipper, skipper_user
+    ):
+        r = _create_regatta(db, skipper_user)
+        _rsvp(db, skipper_user, r, "yes")
+        _subscribe(logged_in_skipper)
+        db.session.refresh(skipper_user)
+
+        resp = logged_in_skipper.get(f"/calendar/{skipper_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"Test Regatta" in resp.data
+
+    def test_feed_content_type(self, db, logged_in_client, admin_user):
+        r = _create_regatta(db, admin_user)
+        _rsvp(db, admin_user, r, "yes")
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert "text/calendar" in resp.content_type
+
+    def test_invalid_token_returns_404(self, client):
+        resp = client.get("/calendar/invalid-token-12345.ics")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Subscribe Page
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribePage:
+    """Dedicated calendar subscription page."""
+
+    def test_page_renders_200(self, db, logged_in_client):
+        resp = logged_in_client.get("/calendar/subscribe")
+        assert resp.status_code == 200
+        assert b"Calendar Subscription" in resp.data
+
+    def test_generates_token_on_first_visit(self, db, logged_in_client, admin_user):
+        assert admin_user.calendar_token is None
+        logged_in_client.get("/calendar/subscribe")
+        db.session.refresh(admin_user)
+        assert admin_user.calendar_token is not None
+
+    def test_shows_ics_url_with_token(self, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/calendar/subscribe")
+        db.session.refresh(admin_user)
+        assert admin_user.calendar_token.encode() in resp.data
+        assert b".ics" in resp.data
+
+    def test_shows_copy_button(self, db, logged_in_client):
+        resp = logged_in_client.get("/calendar/subscribe")
+        assert b"Copy" in resp.data
+
+    def test_shows_webcal_subscribe_button(self, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/calendar/subscribe")
+        db.session.refresh(admin_user)
+        assert b"Open in Calendar App" in resp.data
+        assert b"webcal://" in resp.data
+        assert admin_user.calendar_token.encode() in resp.data
+
+    def test_shows_apple_instructions(self, db, logged_in_client):
+        resp = logged_in_client.get("/calendar/subscribe")
+        assert b"Apple Calendar (iPhone / iPad)" in resp.data
+        assert b"Apple Calendar (Mac)" in resp.data
+
+    def test_shows_google_instructions(self, db, logged_in_client):
+        resp = logged_in_client.get("/calendar/subscribe")
+        assert b"Google Calendar" in resp.data
+        assert b"calendar.google.com" in resp.data
+
+    def test_shows_outlook_instructions(self, db, logged_in_client):
+        resp = logged_in_client.get("/calendar/subscribe")
+        assert b"Outlook" in resp.data
+        assert b"outlook.live.com" in resp.data
+
+    def test_preserves_existing_token(self, db, logged_in_client, admin_user):
+        # First visit generates token
+        logged_in_client.get("/calendar/subscribe")
+        db.session.refresh(admin_user)
+        original_token = admin_user.calendar_token
+        # Second visit preserves it
+        logged_in_client.get("/calendar/subscribe")
+        db.session.refresh(admin_user)
+        assert admin_user.calendar_token == original_token
+
+    def test_requires_login(self, client):
+        resp = client.get("/calendar/subscribe", follow_redirects=False)
+        assert resp.status_code in (302, 303)
+        assert "/login" in resp.headers["Location"]
+
+
+# ---------------------------------------------------------------------------
+# Calendar Banner on Index Page
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarBanner:
+    """Banner shown/hidden based on calendar_token presence."""
+
+    def test_banner_shown_without_token(self, db, logged_in_client, admin_user):
+        assert admin_user.calendar_token is None
+        resp = logged_in_client.get("/")
+        assert b"Sync your race schedule" in resp.data
+
+    def test_banner_hidden_with_token(self, db, logged_in_client, admin_user):
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+        assert admin_user.calendar_token is not None
+        resp = logged_in_client.get("/")
+        assert b"Sync your race schedule" not in resp.data
+
+
+# ---------------------------------------------------------------------------
+# Profile Page Calendar Section
+# ---------------------------------------------------------------------------
+
+
+class TestProfileCalendarSection:
+    """Profile shows generate button or subscription URL."""
+
+    def test_profile_shows_generate_button_without_token(
+        self, db, logged_in_client, admin_user
+    ):
+        resp = logged_in_client.get("/profile")
+        assert b"Generate Calendar Feed" in resp.data
+
+    def test_profile_shows_ics_url_with_token(self, db, logged_in_client, admin_user):
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+        resp = logged_in_client.get("/profile")
+        assert admin_user.calendar_token.encode() in resp.data
+        assert b".ics" in resp.data
+        assert b"Copy" in resp.data


### PR DESCRIPTION
## Summary
- Replace flash+redirect calendar subscribe flow with a dedicated subscription page
- Add "Open in Calendar App" button using `webcal://` protocol for one-tap subscribe (Apple Calendar, Outlook)
- Add step-by-step setup instructions for Apple Calendar (iPhone/iPad/Mac), Google Calendar, and Outlook (web + desktop)
- Subscription URL with copy button for manual setup (Google Calendar)
- Rename navbar link from "iCal" to "Calendar"
- Add 10 new tests for the subscribe page (23 total in test_calendar.py)

## Test plan
- [x] `pytest` — all 417 tests pass
- [x] `black . && isort . && flake8` — passes
- [ ] Manual: click Calendar in navbar → lands on instructions page with URL + copy button + webcal button
- [ ] Manual: banner "Subscribe now" link → same page
- [ ] Manual: profile "Generate Calendar Feed" → same page
- [ ] Manual: test "Open in Calendar App" button on iPhone/Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)