### PR TITLE
Add calendar subscribe links to emails, home banner, and profile

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.56.0
+- Add calendar subscribe links to all email footers (notify crew, RSVP reminder, coming-up reminder, crew digest)
+- Add calendar subscription banner on home page for users without a subscription
+- Add calendar subscription section on profile page with URL copy or generate button
+
 ## 0.55.0
 - Replace flash+redirect calendar subscribe flow with dedicated subscription page
 - Add "Open in Calendar App" button using webcal:// protocol for one-tap subscribe (Apple Calendar, Outlook)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.55.0"
+__version__ = "0.56.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/notifications/service.py
+++ b/app/notifications/service.py
@@ -51,6 +51,7 @@ def notify_crew(
 
     schedule_url = url_for("regattas.index", _external=True)
     profile_url = url_for("auth.profile", _external=True)
+    subscribe_url = url_for("calendar.subscribe", _external=True)
     sent_count = 0
 
     for crew in crew_members:
@@ -68,6 +69,7 @@ def notify_crew(
             custom_message=message,
             schedule_url=schedule_url,
             profile_url=profile_url,
+            subscribe_url=subscribe_url,
         )
         body_text = render_template(
             "email/notify_crew.txt",
@@ -77,6 +79,7 @@ def notify_crew(
             custom_message=message,
             schedule_url=schedule_url,
             profile_url=profile_url,
+            subscribe_url=subscribe_url,
         )
 
         try:
@@ -435,6 +438,7 @@ def send_crew_digests() -> int:
 
         schedule_url = url_for("regattas.index", _external=True)
         profile_url = url_for("auth.profile", _external=True)
+        subscribe_url = url_for("calendar.subscribe", _external=True)
         subject = "Race Crew Network — Daily Update"
 
         body_html = render_template(
@@ -444,6 +448,7 @@ def send_crew_digests() -> int:
             coming_up=coming_up,
             schedule_url=schedule_url,
             profile_url=profile_url,
+            subscribe_url=subscribe_url,
         )
         body_text = render_template(
             "email/crew_digest.txt",
@@ -452,6 +457,7 @@ def send_crew_digests() -> int:
             coming_up=coming_up,
             schedule_url=schedule_url,
             profile_url=profile_url,
+            subscribe_url=subscribe_url,
         )
 
         try:
@@ -545,6 +551,7 @@ def send_rsvp_reminders(days_before: int | None = None) -> int:
 
             schedule_url = url_for("regattas.index", _external=True)
             profile_url = url_for("auth.profile", _external=True)
+            subscribe_url = url_for("calendar.subscribe", _external=True)
             skipper = regatta.creator
 
             subject = (
@@ -559,6 +566,7 @@ def send_rsvp_reminders(days_before: int | None = None) -> int:
                 skipper_name=skipper.display_name if skipper else "Your skipper",
                 schedule_url=schedule_url,
                 profile_url=profile_url,
+                subscribe_url=subscribe_url,
             )
             body_text = render_template(
                 "email/rsvp_reminder.txt",
@@ -567,6 +575,7 @@ def send_rsvp_reminders(days_before: int | None = None) -> int:
                 skipper_name=skipper.display_name if skipper else "Your skipper",
                 schedule_url=schedule_url,
                 profile_url=profile_url,
+                subscribe_url=subscribe_url,
             )
 
             try:
@@ -652,6 +661,7 @@ def send_coming_up_reminders(days_before: int | None = None) -> int:
 
             schedule_url = url_for("regattas.index", _external=True)
             profile_url = url_for("auth.profile", _external=True)
+            subscribe_url = url_for("calendar.subscribe", _external=True)
 
             subject = (
                 f"Coming Up: {regatta.name} — "
@@ -665,6 +675,7 @@ def send_coming_up_reminders(days_before: int | None = None) -> int:
                 days=days_before,
                 schedule_url=schedule_url,
                 profile_url=profile_url,
+                subscribe_url=subscribe_url,
             )
             body_text = render_template(
                 "email/coming_up_reminder.txt",
@@ -673,6 +684,7 @@ def send_coming_up_reminders(days_before: int | None = None) -> int:
                 days=days_before,
                 schedule_url=schedule_url,
                 profile_url=profile_url,
+                subscribe_url=subscribe_url,
             )
 
             try:

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -111,6 +111,7 @@ def index():
         rsvp_filters=rsvp_filters,
         pdf_url=url_for("regattas.pdf", **pdf_args),
         crew_list=crew_list,
+        show_calendar_banner=current_user.calendar_token is None,
     )
 
 

--- a/app/templates/email/coming_up_reminder.html
+++ b/app/templates/email/coming_up_reminder.html
@@ -12,4 +12,4 @@
     </tr>
 </table>
 <p><a href="{{ schedule_url }}">View your schedule</a></p>
-<p style="font-size:13px;color:#666;">Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>
+<p style="font-size:13px;color:#666;"><a href="{{ subscribe_url }}">Add races to your calendar</a> | Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>

--- a/app/templates/email/coming_up_reminder.txt
+++ b/app/templates/email/coming_up_reminder.txt
@@ -7,4 +7,5 @@ Location: {{ regatta.location }}
 
 View your schedule: {{ schedule_url }}
 
+Add races to your calendar: {{ subscribe_url }}
 Manage your notification preferences: {{ profile_url }}

--- a/app/templates/email/crew_digest.html
+++ b/app/templates/email/crew_digest.html
@@ -18,4 +18,4 @@
 </ul>
 {% endif %}
 <p><a href="{{ schedule_url }}">View your schedule</a></p>
-<p style="font-size:13px;color:#666;">Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>
+<p style="font-size:13px;color:#666;"><a href="{{ subscribe_url }}">Add races to your calendar</a> | Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>

--- a/app/templates/email/crew_digest.txt
+++ b/app/templates/email/crew_digest.txt
@@ -11,4 +11,5 @@ Here's what's happening with your schedule:
 {% endif %}
 View your schedule: {{ schedule_url }}
 
+Add races to your calendar: {{ subscribe_url }}
 Manage your notification preferences: {{ profile_url }}

--- a/app/templates/email/notify_crew.html
+++ b/app/templates/email/notify_crew.html
@@ -25,4 +25,4 @@
     </tbody>
 </table>
 <p><a href="{{ schedule_url }}">View your schedule and RSVP</a></p>
-<p style="font-size:13px;color:#666;">Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>
+<p style="font-size:13px;color:#666;"><a href="{{ subscribe_url }}">Add races to your calendar</a> | Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>

--- a/app/templates/email/notify_crew.txt
+++ b/app/templates/email/notify_crew.txt
@@ -10,4 +10,5 @@ Hi {{ crew_name }},
 
 View your schedule and RSVP: {{ schedule_url }}
 
+Add races to your calendar: {{ subscribe_url }}
 Manage your notification preferences: {{ profile_url }}

--- a/app/templates/email/rsvp_reminder.html
+++ b/app/templates/email/rsvp_reminder.html
@@ -3,4 +3,4 @@
 <p><strong>{{ regatta.name }}</strong> is coming up on {{ regatta.start_date.strftime('%b %d, %Y') }} at {{ regatta.location }}.</p>
 <p>{{ skipper_name }} would like to know if you can make it.</p>
 <p><a href="{{ schedule_url }}" style="display:inline-block;padding:10px 20px;background-color:#0d6efd;color:#fff;text-decoration:none;border-radius:4px;">RSVP Now</a></p>
-<p style="font-size:13px;color:#666;">Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>
+<p style="font-size:13px;color:#666;"><a href="{{ subscribe_url }}">Add races to your calendar</a> | Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>

--- a/app/templates/email/rsvp_reminder.txt
+++ b/app/templates/email/rsvp_reminder.txt
@@ -6,4 +6,5 @@ Hi {{ crew_name }},
 
 RSVP now: {{ schedule_url }}
 
+Add races to your calendar: {{ subscribe_url }}
 Manage your notification preferences: {{ profile_url }}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,6 +19,14 @@
     </div>
 </div>
 
+{% if show_calendar_banner %}
+<div class="alert alert-info alert-dismissible fade show mb-3" role="alert">
+    Sync your race schedule! Add your Yes/Maybe regattas to your phone or computer calendar.
+    <a href="{{ url_for('calendar.subscribe') }}" class="alert-link">Subscribe now</a>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+{% endif %}
+
 <div class="mb-3 d-flex flex-wrap gap-2 btn-bar align-items-center">
     {% if current_user.is_admin or (current_user.is_skipper and (selected_skipper == 0 or selected_skipper == current_user.id)) %}
     <a href="{{ url_for('regattas.create') }}" class="btn btn-primary btn-sm">+ Add Regatta</a>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -70,6 +70,20 @@
                 <div class="form-text">Choose whether to receive notifications immediately or batched into a daily summary.</div>
             </div>
             <hr>
+            <h5 class="mt-3">Calendar Subscription</h5>
+            {% if current_user.calendar_token %}
+            <p class="form-text">Paste this URL into your calendar app (Google Calendar, Apple Calendar, Outlook):</p>
+            <div class="input-group mb-3">
+                <input type="text" class="form-control" id="ical-url" readonly
+                       value="{{ url_for('calendar.ical_feed', token=current_user.calendar_token, _external=True) }}">
+                <button class="btn btn-outline-secondary" type="button" id="copy-ical-url"
+                        onclick="navigator.clipboard.writeText(document.getElementById('ical-url').value); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy', 2000);">Copy</button>
+            </div>
+            {% else %}
+            <p class="form-text">Add your Yes/Maybe regattas to your phone or computer calendar.</p>
+            <a href="{{ url_for('calendar.subscribe') }}" class="btn btn-outline-primary btn-sm mb-3">Generate Calendar Feed</a>
+            {% endif %}
+            <hr>
             <p class="text-muted">Leave password blank to keep your current password.</p>
             <div class="mb-3">
                 <label for="password" class="form-label">New Password</label>


### PR DESCRIPTION
## Summary
- Add "Add races to your calendar" subscribe link to all email footers (notify crew, RSVP reminder, coming-up reminder, crew digest)
- Add dismissible calendar subscription banner on home page for users who haven't subscribed yet
- Add calendar subscription section on profile page with URL + copy button (or generate button if no token)

## Test plan
- [x] `pytest` — all 417 tests pass
- [ ] Manual: home page shows banner for users without calendar token, hidden after subscribing
- [ ] Manual: profile page shows calendar URL with copy button after subscribing
- [ ] Manual: email footers include "Add races to your calendar" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)