### PR TITLE
Add daily vulnerability scan with GitHub Issue notifications (v0.57.0)

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,0 +1,153 @@
+name: Daily Vulnerability Scan
+
+on:
+  schedule:
+    - cron: "0 6 * * *"   # Daily at 6 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+  issues: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: chris-edwards-pub/race-crew-network
+  TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2
+  TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1
+
+jobs:
+  scan:
+    name: Scan Latest Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner (table)
+        uses: aquasecurity/trivy-action@0.34.2
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: table
+          exit-code: 0
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          output: trivy-results.txt
+
+      - name: Run Trivy vulnerability scanner (SARIF)
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@0.34.2
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: sarif
+          output: trivy-results.sarif
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+
+      - name: Upload SARIF to GitHub Security tab
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Upload scan results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-vulnerability-report
+          path: trivy-results.txt
+          retention-days: 30
+
+      - name: Notify via GitHub Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SCAN_DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          LABEL="security/vulnerability-scan"
+          TITLE="Trivy Scan: CRITICAL/HIGH vulnerabilities found in latest image"
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+          # Ensure the label exists
+          gh label create "$LABEL" --color "d73a4a" \
+            --description "Automated Trivy vulnerability scan findings" 2>/dev/null || true
+
+          # Check if vulnerabilities were found (Total: lines with non-zero counts)
+          HAS_VULNS=false
+          if [ -f trivy-results.txt ]; then
+            if grep -qE "Total: [1-9]" trivy-results.txt; then
+              HAS_VULNS=true
+            fi
+          fi
+
+          # Find existing open issue with our label
+          EXISTING_ISSUE=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ "$HAS_VULNS" = "true" ]; then
+            # Build issue body in a temp file to avoid heredoc indentation issues
+            BODY_FILE=$(mktemp)
+            {
+              echo "## Trivy Vulnerability Scan Results"
+              echo ""
+              echo "**Scan date:** $SCAN_DATE"
+              echo "**Image:** \`$REGISTRY/$IMAGE_NAME:latest\`"
+              echo "**Severity filter:** CRITICAL, HIGH (unfixed ignored)"
+              echo ""
+              echo '```'
+              cat trivy-results.txt
+              echo '```'
+              echo ""
+              echo "> Automated by [Daily Vulnerability Scan]($RUN_URL)"
+            } > "$BODY_FILE"
+
+            if [ -n "$EXISTING_ISSUE" ]; then
+              echo "Adding comment to existing issue #$EXISTING_ISSUE"
+              gh issue comment "$EXISTING_ISSUE" --body-file "$BODY_FILE"
+            else
+              echo "Creating new issue"
+              gh issue create --title "$TITLE" --label "$LABEL" --body-file "$BODY_FILE"
+            fi
+            rm -f "$BODY_FILE"
+          else
+            if [ -n "$EXISTING_ISSUE" ]; then
+              echo "Scan clean — commenting and closing issue #$EXISTING_ISSUE"
+              CLEAN_FILE=$(mktemp)
+              {
+                echo "## Scan Clean"
+                echo ""
+                echo "**Scan date:** $SCAN_DATE"
+                echo ""
+                echo "No CRITICAL or HIGH vulnerabilities found. Closing this issue."
+                echo ""
+                echo "> Automated by [Daily Vulnerability Scan]($RUN_URL)"
+              } > "$CLEAN_FILE"
+              gh issue comment "$EXISTING_ISSUE" --body-file "$CLEAN_FILE"
+              gh issue close "$EXISTING_ISSUE" --reason completed
+              rm -f "$CLEAN_FILE"
+            else
+              echo "No vulnerabilities found and no open issue — nothing to do."
+            fi
+          fi
+
+      - name: Write Trivy results to job summary
+        if: always()
+        run: |
+          if [ -f trivy-results.txt ]; then
+            echo "## 🔍 Trivy Vulnerability Scan Results" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat trivy-results.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## 🔍 Trivy Vulnerability Scan Results" >> "$GITHUB_STEP_SUMMARY"
+            echo "⚠️ trivy-results.txt was not found — the scan may not have produced output." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/README.md
+++ b/README.md
@@ -341,6 +341,12 @@ workflow has three stages:
 The container service handles HTTPS termination, health checks, and rolling
 deployments automatically. No SSH, nginx, or certbot required.
 
+A **daily vulnerability scan** runs at 6 AM UTC via a separate GitHub Actions
+workflow. It scans the `latest` GHCR image with Trivy and automatically creates
+or updates a GitHub Issue (labeled `security/vulnerability-scan`) when
+CRITICAL/HIGH vulnerabilities are found. Issues are auto-closed when scans come
+back clean. Run it manually with `gh workflow run vulnerability-scan.yml`.
+
 ### Container images
 
 Images are stored in GHCR at:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 0.57.0
+- Add daily vulnerability scan workflow (GitHub Actions) that scans the latest GHCR image with Trivy
+- Automatically creates/updates GitHub Issues when CRITICAL/HIGH vulnerabilities are found
+- Uploads SARIF results to GitHub Security tab
+- Auto-closes issues when scans come back clean
+
 ## 0.56.1
 - Fix CVE-2026-32274: bump black minimum version to 26.3.1 (arbitrary file writes via cache)
 - Fix CVE-2026-0861, CVE-2025-71238: add `apt-get upgrade` to Dockerfile to pick up patched glibc and kernel packages

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.56.1"
+__version__ = "0.57.0"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow scans the `latest` GHCR image daily at 6 AM UTC with Trivy for CRITICAL/HIGH vulnerabilities
- Automatically creates/updates a GitHub Issue (labeled `security/vulnerability-scan`) when vulns are found — deduplicates via label search
- Auto-closes the issue when scans come back clean
- Uploads SARIF results to GitHub Security tab and scan artifacts (30-day retention)

## Test plan
- [ ] Run manually: `gh workflow run vulnerability-scan.yml` → verify workflow completes
- [ ] If current image has vulns → verify GitHub Issue created with label and scan results
- [ ] Run again → verify it comments on existing issue (no duplicate)
- [ ] Check GitHub Security tab → SARIF results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)