### PR TITLE
Fix Flask CVEs: bump 3.1.0 to 3.1.3 (v0.57.1)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.57.1
+- Fix CVE-2025-47278: Flask session signing fallback key used in wrong order (fixed in 3.1.1)
+- Fix CVE-2026-27205: Flask missing `Vary: Cookie` header enabling cache poisoning (fixed in 3.1.3)
+- Bump Flask from 3.1.0 to 3.1.3
+
 ## 0.57.0
 - Add daily vulnerability scan workflow (GitHub Actions) that scans the latest GHCR image with Trivy
 - Automatically creates/updates GitHub Issues when CRITICAL/HIGH vulnerabilities are found

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.57.0"
+__version__ = "0.57.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -763,27 +763,43 @@ def import_schedule_extract_file():
     task_id = str(uuid.uuid4())
     user_id = current_user.id
 
+    # Read upload data eagerly — the stream may be closed before the
+    # SSE generator runs (SpooledTemporaryFile lifecycle).
+    if uploaded and uploaded.filename:
+        file_bytes = uploaded.stream.read()
+        file_name = uploaded.filename
+    else:
+        file_bytes = None
+        file_name = None
+
     def _sse(event: dict) -> str:
         return f"data: {json.dumps(event)}\n\n"
 
     def generate():
         _cleanup_stale_task_results()
-        if not uploaded or not uploaded.filename:
+        if file_bytes is None or not file_name:
             yield _sse({"type": "error", "message": "No file uploaded."})
             yield _sse({"type": "failed"})
             return
 
-        filename = uploaded.filename
+        filename = file_name
         yield _sse({"type": "progress", "message": f"Reading file: {filename}..."})
 
-        # Read raw bytes for hashing, then reset stream for text extraction
-        raw_bytes = uploaded.stream.read()
+        raw_bytes = file_bytes
         content_hash = hashlib.sha256(raw_bytes).hexdigest()
         cache_key = f"file-sha256:{content_hash}"
-        uploaded.stream.seek(0)
+
+        # Wrap bytes in a FileStorage so extract_text_from_file can read it
+        from io import BytesIO
+
+        from werkzeug.datastructures import FileStorage
+
+        file_obj = FileStorage(
+            stream=BytesIO(raw_bytes), filename=filename
+        )
 
         try:
-            content = extract_text_from_file(uploaded, filename)
+            content = extract_text_from_file(file_obj, filename)
         except ValueError as e:
             yield _sse({"type": "error", "message": str(e)})
             yield _sse({"type": "failed"})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.1.0
+Flask==3.1.3
 Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.7


### PR DESCRIPTION
## Summary
- Bump Flask from 3.1.0 to 3.1.3 to fix CVE-2025-47278 (session signing fallback key order) and CVE-2026-27205 (missing `Vary: Cookie` header)
- Fix file upload SSE endpoint to read stream eagerly before entering generator, resolving `SpooledTemporaryFile` lifecycle change in newer Werkzeug
- All 417 tests pass

## Test plan
- [x] Full test suite passes (`pytest` — 417 passed)
- [x] Previously failing `TestExtractFile` tests now pass with the stream fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)