### PR TITLE
Upgrade GitHub Actions to Node.js 24 runtime (v0.57.2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
 
@@ -43,17 +43,17 @@ jobs:
           echo "Detected version: $VERSION"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: table
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload scan results as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: trivy-vulnerability-report
           path: trivy-results.txt
@@ -113,7 +113,7 @@ jobs:
       - name: Run Trivy for SARIF output
         if: always()
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: sarif
@@ -125,7 +125,7 @@ jobs:
       - name: Upload SARIF to GitHub Security tab
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
 
@@ -137,7 +137,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner (table)
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: table
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (SARIF)
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: sarif
@@ -58,12 +58,12 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
 
       - name: Upload scan results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: trivy-vulnerability-report
           path: trivy-results.txt

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,12 @@
 # Version History
 
+## 0.57.2
+- Upgrade all GitHub Actions to Node.js 24 runtime to resolve deprecation warnings
+- actions/checkout v4 → v6, docker/login-action v3 → v4, docker/setup-buildx-action v3 → v4
+- docker/build-push-action v6 → v7, actions/upload-artifact v4 → v6
+- github/codeql-action v3 → v4, aws-actions/configure-aws-credentials v4 → v6
+- aquasecurity/trivy-action 0.34.2 → 0.35.0
+
 ## 0.57.1
 - Fix CVE-2025-47278: Flask session signing fallback key used in wrong order (fixed in 3.1.1)
 - Fix CVE-2026-27205: Flask missing `Vary: Cookie` header enabling cache poisoning (fixed in 3.1.3)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.57.1"
+__version__ = "0.57.2"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions in `deploy.yml` and `vulnerability-scan.yml` to Node.js 24 runtime versions, resolving deprecation warnings ahead of the June 2, 2026 enforcement date
- Updated actions: checkout v4→v6, docker/login v3→v4, setup-buildx v3→v4, build-push v6→v7, upload-artifact v4→v6, codeql-action v3→v4, configure-aws-credentials v4→v6, trivy-action 0.34.2→0.35.0

## Test plan
- [ ] Deploy workflow completes successfully (build, scan, deploy)
- [ ] No Node.js 20 deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)