### PR TITLE
Force Node.js 24 for transitive action dependencies (v0.57.3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   IMAGE_NAME: chris-edwards-pub/race-crew-network
 

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -12,6 +12,7 @@ permissions:
   issues: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   IMAGE_NAME: chris-edwards-pub/race-crew-network
   TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.57.3
+- Force Node.js 24 runtime for transitive action dependencies (e.g. actions/cache inside trivy-action)
+- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to deploy and vulnerability-scan workflows
+
 ## 0.57.2
 - Upgrade all GitHub Actions to Node.js 24 runtime to resolve deprecation warnings
 - actions/checkout v4 → v6, docker/login-action v3 → v4, docker/setup-buildx-action v3 → v4

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.57.2"
+__version__ = "0.57.3"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to deploy and vulnerability-scan workflows
- Eliminates remaining Node 20 deprecation warning from `actions/cache` used internally by `trivy-action`

## Test plan
- [ ] Deploy workflow completes with no Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)