### PR TITLE
Add 18-day training curriculum (v0.62.0)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.62.0
+- Add 18-day training curriculum covering Flask app development through the Race Crew Network codebase
+- Four phases: Foundations (Days 1-4), Core Features (Days 5-9), Communication & Integration (Days 10-13), Operations & Advanced (Days 14-18)
+- Includes course index, daily lesson plans with code walkthroughs, and quick-reference appendix
+
 ## 0.61.0
 - Add admin "Assume Identity" feature to impersonate another user for troubleshooting
 - Persistent warning banner shown while impersonating with one-click exit

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 
-__version__ = "0.61.0"
+__version__ = "0.62.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/training/00-index.md
+++ b/training/00-index.md
@@ -1,12 +1,13 @@
-# Race Crew Network - Flask Application Training: 10-Day Curriculum
+# Race Crew Network - Flask Application Training: 18-Day Curriculum
 
 ## Course Overview
 
 This training program teaches you how to build and deploy a production-ready
 Flask web application through the study of the Race Crew Network app.
-Over 10 days, you'll learn Flask fundamentals, database management with
-SQLAlchemy, authentication, file uploads, calendar integration, AI-powered
-data import, cloud storage, and containerized cloud deployment.
+Over 18 days across 4 phases, you'll learn Flask fundamentals, database
+management with SQLAlchemy, multi-user role-based access control, email
+notifications via AWS SES, AI-powered data import, calendar integration,
+responsive UI design, infrastructure as code, and containerized cloud deployment.
 
 ## Target Audience
 
@@ -19,32 +20,42 @@ IT professionals with:
 ## What You'll Build Understanding of
 
 A complete web application for managing sailing regatta events:
-- User authentication with role-based access (Admin/Crew)
-- Invite-based registration system
-- CRUD operations for regatta events
-- RSVP system with Yes/No/Maybe responses
-- Document upload and management (PDFs, external links)
-- AI-powered schedule import from URLs (Anthropic Claude API)
+- Multi-user role system: Admin, Skipper, and Crew roles
+- Invite-based registration with email invites via AWS SES
+- CRUD operations for regatta events with owner-based permissions
+- RSVP system with Yes/No/Maybe and schedule filtering
+- Document upload/management with S3/local storage abstraction
+- AI-powered schedule import from URLs and files (Anthropic Claude API)
 - Document discovery with SSE streaming progress
-- iCal calendar feed integration
+- Email notifications: manual crew notify, RSVP alerts, scheduled reminders
+- iCal calendar feed with scoped subscriptions
 - PDF schedule generation with WeasyPrint
-- S3-compatible cloud storage for file uploads
-- Production deployment with Docker on AWS Lightsail
+- Profile pictures and Multiavatar SVG avatars
+- Admin impersonation for debugging user views
+- Site settings for runtime configuration (GA, email)
+- Responsive design with Bootstrap 5
+- Terraform-managed AWS infrastructure
+- Trivy vulnerability scanning in CI/CD pipeline
+- Production deployment on AWS Lightsail Container Service
 
 ## Technical Stack You'll Master
 
-- Python 3.13 & Flask 3.1.0 web framework
-- SQLAlchemy ORM for database operations
+- Python 3.13 & Flask 3.1.3 web framework
+- SQLAlchemy ORM (8 models + association table)
 - Flask-Login for authentication
 - Flask-Migrate for database schema management
 - MySQL 8.0 database
 - Gunicorn WSGI server
 - Docker Compose orchestration (local dev)
 - AWS Lightsail Container Service (production)
+- AWS SES for transactional email
 - S3-compatible object storage (Lightsail buckets)
 - Anthropic Claude API for AI-powered imports
 - WeasyPrint for PDF generation
 - Bootstrap 5 for responsive frontend
+- Terraform for infrastructure as code
+- GitHub Actions for CI/CD
+- Trivy for container vulnerability scanning
 
 ## Prerequisites
 
@@ -67,7 +78,7 @@ Each session includes:
 
 ## Recommended Approach
 
-1. Read each session sequentially (Day 1 → Day 10)
+1. Read each session sequentially (Day 1 through Day 18)
 2. Have the code repository open while reading
 3. Follow along by examining the referenced files
 4. Take notes on concepts that are new to you
@@ -77,15 +88,17 @@ Each session includes:
 ## Time Commitment
 
 Each session: 1-2 hours of focused reading and code exploration
-Total course: ~15-20 hours spread over 10 workdays
+Total course: ~25-35 hours spread over 18 workdays
 Best pace: One session per day with hands-on exploration
 
 # Session Roadmap
 
+## Phase 1: Foundations (Days 1-4)
+
 ### Day 1: Introduction and Environment Setup
 File: 01-day1.md
 Topics:
-  - Application overview and feature tour
+  - Application overview and feature tour (3 roles, 6 blueprints)
   - Docker Compose setup (web, db containers)
   - Running the application locally
   - Creating your first admin account
@@ -97,100 +110,189 @@ Topics:
   - The create_app() factory pattern
   - Flask extensions initialization
   - Configuration management with environment variables
-  - Blueprint registration and organization
+  - Blueprint registration (6 blueprints)
+  - Context processors and template filters
   - Application context and lifecycle
 
 ### Day 3: Database Models and SQLAlchemy
 File: 03-day3.md
 Topics:
   - Object-Relational Mapping (ORM) concepts
-  - User, Regatta, Document, and RSVP models
-  - Database relationships and foreign keys
+  - 8 models + skipper_crew association table
+  - User model with roles, avatars, and notification preferences
+  - Database relationships (1:N, M:N self-referential)
   - Password hashing with bcrypt
-  - Database schema design
+  - Permission scoping with visible_regattas()
 
 ### Day 4: Authentication and User Management
 File: 04-day4.md
 Topics:
   - Flask-Login integration
   - Login/logout implementation
-  - Invite-based registration system
-  - Token generation for security
-  - User profile management
-  - Admin user administration
+  - Invite-based registration with email invites
+  - Auto-link crew to inviting skipper
+  - Avatar seed generation
+  - User profile with image uploads
+  - Admin user administration and impersonation
 
-### Day 5: Regatta Management (CRUD Operations)
+## Phase 2: Core Features (Days 5-9)
+
+### Day 5: Multi-User Role System and Permissions
 File: 05-day5.md
+Topics:
+  - Three roles: Admin, Skipper, Crew
+  - permissions.py helper functions and decorators
+  - Admin impersonation via session
+  - Role-based UI visibility in templates
+  - Permission checks in route handlers
+
+### Day 6: Event Management (CRUD Operations)
+File: 06-day6.md
 Topics:
   - RESTful route design in Flask
   - Create, Read, Update, Delete operations
-  - Form processing and validation
-  - Date handling in Python
-  - Permission checks and admin-only routes
-  - Flash messages for user feedback
+  - Owner-based permission model
+  - Bulk delete with checkbox selection
+  - Schedule filtering by skipper and RSVP status
+  - Auto-generated Google Maps links
 
-### Day 6: RSVP System and Database Relationships
-File: 06-day6.md
-Topics:
-  - Many-to-many relationships
-  - Upsert pattern (update or insert)
-  - SQLAlchemy lazy loading
-  - Custom Jinja2 template filters
-  - Status tracking and display
-
-### Day 7: Document Upload and File Handling
+### Day 7: RSVP System and Schedule View
 File: 07-day7.md
 Topics:
-  - File upload processing with Flask
-  - UUID-based secure filename generation
-  - Supporting both file uploads and external URLs
-  - S3-compatible cloud storage abstraction
-  - Presigned URLs for secure file downloads
-  - File size limits and validation
+  - Schedule switcher (My Schedule / All Schedules)
+  - RSVP with filter state preservation
+  - PDF schedule generation with WeasyPrint
+  - Notification triggers on RSVP changes
+  - Custom template filters (sort_rsvps, regatta_days)
 
-### Day 8: Calendar Integration (iCal Feeds)
+### Day 8: Document Upload and Storage
 File: 08-day8.md
 Topics:
-  - iCalendar format (RFC 5545)
-  - icalendar Python library
-  - Token-based feed authentication
-  - Generating calendar events
-  - All-day event handling
-  - Calendar subscription URLs
+  - File upload processing with Flask
+  - S3/local storage abstraction layer
+  - Profile image uploads and validation
+  - Path traversal protection
+  - Presigned URLs for secure downloads
+  - Storage blueprint for local file serving
 
-### Day 9: Docker and Containerization
+### Day 9: Skipper and Crew Management
 File: 09-day9.md
 Topics:
-  - Dockerfile structure and best practices
-  - Multi-container orchestration with docker-compose
-  - Container networking and service discovery
-  - Volume persistence for data
-  - Health checks for dependencies
-  - Gunicorn production configuration
-  - GitHub Container Registry (GHCR)
+  - My Crew page and crew listing
+  - Invite crew (new user or existing)
+  - Remove crew members
+  - Self-service schedule creation/deletion
+  - Leave skipper (crew self-service)
+  - skipper_crew association table
 
-### Day 10: Database Migrations and Deployment
+## Phase 3: Communication and Integration (Days 10-13)
+
+### Day 10: Email Service with AWS SES
 File: 10-day10.md
 Topics:
-  - Flask-Migrate and Alembic
-  - Creating and applying database migrations
-  - Automatic migration on startup
+  - AWS SES integration via boto3
+  - HMAC-SHA256 unsubscribe tokens (RFC 8058)
+  - One-click unsubscribe handling
+  - Bounce and complaint webhook processing
+  - Email opt-in/opt-out model
+  - SiteSetting-based email configuration
+
+### Day 11: Notification System
+File: 11-day11.md
+Topics:
+  - Manual crew notification (events + crew selection)
+  - RSVP-to-skipper notifications (per-RSVP and digest)
+  - Scheduled reminders (RSVP reminder, coming-up)
+  - Crew digest emails
+  - NotificationLog for deduplication
+  - Digest flush on preference switch
+
+### Day 12: Calendar Integration
+File: 12-day12.md
+Topics:
+  - iCalendar format (RFC 5545)
+  - Token-based feed authentication
+  - Subscribe page with webcal:// URLs
+  - Scoped feeds (only yes/maybe RSVPs)
+  - RSVP status in event descriptions
+  - Calendar links in notification emails
+
+### Day 13: AI-Powered Schedule Import
+File: 13-day13.md
+Topics:
+  - Claude API integration via anthropic SDK
+  - Extraction and discovery prompt engineering
+  - File import (PDF, DOCX, TXT)
+  - ImportCache and TaskResult models
+  - SSE streaming for progress updates
+  - SSRF protection for URL fetching
+  - Two-level document discovery
+
+## Phase 4: Operations and Advanced Topics (Days 14-18)
+
+### Day 14: User Interface and Responsive Design
+File: 14-day14.md
+Topics:
+  - Bootstrap 5 responsive grid and breakpoints
+  - Navbar with mobile collapse
+  - Avatar system (Multiavatar SVG + profile photos)
+  - user_icon template filter with fallback
+  - Impersonation banner
+  - Mobile-friendly layout patterns
+
+### Day 15: Site Settings and Admin Configuration
+File: 15-day15.md
+Topics:
+  - SiteSetting model (key/value store)
+  - Google Analytics settings page
+  - Email settings page (SES configuration)
+  - Runtime config vs environment variables
+  - Context processor for conditional GA injection
+
+### Day 16: Docker and Containerization
+File: 16-day16.md
+Topics:
+  - Dockerfile structure and best practices
+  - Docker Compose for local development
+  - GitHub Container Registry (GHCR) publishing
+  - Entrypoint script (migrations, admin init, Gunicorn)
+  - Gunicorn production configuration
+  - Volume management and local storage
+
+### Day 17: Database Migrations and Testing
+File: 17-day17.md
+Topics:
+  - Flask-Migrate and Alembic fundamentals
+  - Migration history (16 versioned migrations)
+  - Creating and applying migrations
+  - pytest fixtures and test configuration
+  - Test patterns (admin, skipper, crew clients)
+  - Mocking external APIs (Anthropic, SES, requests)
+
+### Day 18: CI/CD, Security and Deployment
+File: 18-day18.md
+Topics:
+  - GitHub Actions workflows (deploy, scan, terraform)
+  - Trivy vulnerability scanning (deploy gate + daily)
+  - Terraform infrastructure (Lightsail, SES, CloudFront, Route53)
   - AWS Lightsail Container Service deployment
-  - GitHub Actions CI/CD pipeline
-  - Environment variables in production
-  - Managed database and automated backups
+  - Security practices (CSRF, SSRF, path traversal, HMAC)
 
 ### Appendix: Quick Reference
 File: 99-appendix.md
 Topics:
+  - Model reference table (all 8 models + skipper_crew)
+  - Permission patterns reference
+  - Notification types and triggers
+  - SiteSetting keys reference
+  - Template filters reference
+  - Email templates listing
   - Flask routing patterns
   - SQLAlchemy query examples
-  - Jinja2 template syntax
   - Docker Compose commands
-  - Flask CLI commands
+  - Terraform and Trivy commands
   - Troubleshooting guide
   - Security best practices
-  - Further reading resources
 
 # Navigating the Materials
 
@@ -200,16 +302,16 @@ Topics:
 01-day1.md        Day 1 session
 02-day2.md        Day 2 session
 ...
-10-day10.md       Day 10 session
+18-day18.md       Day 18 session
 99-appendix.md    Reference materials and cheat sheets
 
 ## Reading the Code References
 
 Throughout the materials, you'll see references like:
 
-  File: app/models.py:15-20
+  File: app/models.py:24-60
 
-This means "open the file app/models.py and look at lines 15 through 20."
+This means "open the file app/models.py and look at lines 24 through 60."
 All file paths are relative to the race-crew-network/ directory.
 
 ## Architecture Diagrams
@@ -253,8 +355,9 @@ Explanation follows the code, connecting it to broader concepts.
    docker compose up --build
 
 2. Wait for all services to be healthy
-3. Open a new terminal and create an admin account:
-   docker compose exec web flask create-admin
+3. The entrypoint script automatically:
+   - Runs database migrations
+   - Creates the admin account from INIT_ADMIN_EMAIL/INIT_ADMIN_PASSWORD
 
 4. Access the app at http://localhost
 
@@ -264,48 +367,63 @@ Open 01-day1.md and start your learning journey!
 
 # Learning Objectives
 
-By the end of this 10-day program, you will understand:
+By the end of this 18-day program, you will understand:
 
 ### Flask Fundamentals
 - Application factory pattern
-- Blueprint organization
+- Blueprint organization (6 blueprints)
 - Route handlers and HTTP methods
 - Template rendering with Jinja2
-- Form processing
-- Flash messages
+- Form processing and flash messages
+- Context processors and template filters
 - Configuration management
 
 ### Database and ORM
-- SQLAlchemy models and relationships
+- SQLAlchemy models and relationships (8 models)
+- Self-referential many-to-many relationships
 - Database migrations with Alembic
 - Query patterns and filtering
-- Foreign keys and constraints
-- Transaction management
+- Permission scoping on queries
 
 ### Authentication and Security
 - Flask-Login integration
 - Password hashing with bcrypt
 - Token-based authentication
 - CSRF protection
-- Role-based access control
-- Secure file handling
+- Role-based access control (Admin/Skipper/Crew)
+- Admin impersonation
+- HMAC token verification
+- SSRF and path traversal protection
+
+### Email and Notifications
+- AWS SES email integration
+- RSVP notifications (per-event and digest)
+- Scheduled reminders
+- Bounce and complaint handling
+- One-click unsubscribe (RFC 8058)
+
+### AI Integration
+- Claude API for data extraction
+- Prompt engineering for structured output
+- File parsing (PDF, DOCX, TXT)
+- SSE streaming for long-running tasks
 
 ### Docker and Deployment
 - Multi-container applications
-- Container networking
-- Volume management
+- Container networking and volumes
 - Production server configuration
 - Cloud deployment with AWS Lightsail
 - CI/CD with GitHub Actions
+- Terraform infrastructure as code
+- Trivy vulnerability scanning
 
 ### Advanced Features
-- File upload handling with S3 storage
+- S3/local storage abstraction
 - iCalendar feed generation
-- AI-powered data import (Anthropic API)
 - PDF generation with WeasyPrint
-- Custom CLI commands
-- Database relationship patterns
-- Template filters
+- Responsive design with Bootstrap 5
+- Avatar system (SVG + photo)
+- Runtime configuration via SiteSetting
 
 # Support and Tips
 
@@ -351,11 +469,10 @@ Happy coding!
 
 # Course Information
 
-Application: Race Crew Network
-Version: 0.34.2
+Application: Race Crew Network v0.61.0
 Python: 3.13+
-Flask: 3.1.0
-Training Version: 2.0
+Flask: 3.1.3
+Training Version: 3.0
 Last Updated: 2026-03
 
 Repository: race-crew-network/

--- a/training/01-day1.md
+++ b/training/01-day1.md
@@ -3,6 +3,7 @@
 ## Learning Objectives
 By the end of this session, you will understand:
 - What the Race Crew Network application does and who uses it
+- The three user roles: Admin, Skipper, and Crew
 - The 2-container Docker architecture (web, db)
 - How to run the application locally with Docker Compose
 - Basic Flask concepts: routes, templates, and blueprints
@@ -15,6 +16,7 @@ By the end of this session, you will understand:
 - MVC (Model-View-Controller) pattern
 - RESTful routing
 - Flask CLI commands
+- Role-based access control overview
 
 ## File Focus
 For this session, examine these files:
@@ -28,23 +30,39 @@ For this session, examine these files:
 ## What Is Race Crew Network?
 Race Crew Network is a specialized event management system for sailboat
 racing. It solves a common problem for sailing clubs: coordinating crew
-attendance across multiple regatta events.
+attendance across multiple regatta events throughout the season.
 
 **Key Features:**
+- Multi-user role system: Admin, Skipper, and Crew
 - Centralized schedule of all regatta dates and locations
+- Schedule filtering by skipper and RSVP status
 - RSVP system (Yes/No/Maybe) to track crew availability
 - Document management for NOR (Notice of Race) and SI (Sailing Instructions)
-- AI-powered schedule import from regatta websites (Anthropic Claude API)
+- AI-powered schedule import from URLs and files (Anthropic Claude API)
 - Automatic document discovery from regatta event pages
-- iCal calendar feed integration for personal calendars
+- Email notifications via AWS SES (crew notify, RSVP alerts, reminders)
+- iCal calendar feed integration with scoped subscriptions
 - PDF schedule generation with WeasyPrint
+- Profile pictures and generated SVG avatars
 - Invite-based user registration (no public sign-ups)
-- Role-based access (Admin vs Crew)
+- Site settings for runtime configuration
+- Admin impersonation for debugging user views
 
 **User Roles:**
-- **Admin**: Create/edit/delete regattas, upload documents, invite crew,
-  import schedules via AI, discover documents
-- **Crew**: View schedule, download documents, set RSVP status
+- **Admin**: Full access — manage all events, users, settings, AI import,
+  impersonate users. Admins are also skippers by default.
+- **Skipper**: Create/edit/delete their own events, manage their crew,
+  send notifications, view RSVP responses.
+- **Crew**: View their skipper's schedule, RSVP to events, download
+  documents, manage their profile.
+
+**Application Blueprints (6 modules):**
+1. **admin** — AI-powered schedule import, document discovery, settings
+2. **auth** — Login, registration, profiles, user management, crew management
+3. **regattas** — Event CRUD, RSVP, document upload, notifications
+4. **calendar** — iCal feed generation, subscribe page
+5. **email** — Unsubscribe handling, SES webhooks
+6. **storage** — Local file serving (development)
 
 ## Who Uses It?
 This app is designed for small to medium sailing clubs (5-50 members) that
@@ -52,11 +70,14 @@ compete in multiple regattas per season. It replaces email chains and
 spreadsheets with a single source of truth.
 
 Example workflow:
-1. Admin creates a new regatta entry with date, location, and links
-2. Admin uploads the NOR and SI PDF documents
-3. Crew members visit the site and set their RSVP
-4. Admin can see at a glance who's attending each event
-5. Crew members subscribe to the calendar feed in their preferred app
+1. Admin invites a skipper with an email invite
+2. Skipper creates regatta events for the season
+3. Skipper invites crew members to their crew
+4. Skipper notifies crew about upcoming events via email
+5. Crew members visit the site and set their RSVP
+6. Skipper receives RSVP notifications as crew responds
+7. Automated reminders go out 14 days and 3 days before events
+8. Crew subscribes to iCal feed for calendar integration
 
 # Part 2: Docker Architecture
 
@@ -68,7 +89,7 @@ two containers:
 2. **db** - MySQL 8 database for persistent data storage
 
 In production, the app runs on AWS Lightsail Container Service with a
-managed MySQL database and S3-compatible object storage (see Day 10).
+managed MySQL database and S3-compatible object storage (see Day 16-18).
 
 ## Architecture Diagram
 
@@ -202,11 +223,11 @@ What happens:
 3. Docker creates the mysql_data and uploads volumes
 4. MySQL starts and runs its health check
 5. Once MySQL is healthy, the web container starts
-6. The web container runs database migrations automatically (via entrypoint.sh)
-7. The entrypoint creates the initial admin account (if configured)
+6. The entrypoint script runs database migrations (via `flask db upgrade`)
+7. The entrypoint creates the initial admin account (via `flask init-admin`)
 8. Gunicorn starts and listens on port 8000 (mapped to host port 80)
 
-You'll see logs from both services. Watch for:
+Watch the logs for:
 - "Running database migrations..." from web
 - "Initializing admin account if needed..." from web
 - "Starting Gunicorn..." from web
@@ -224,39 +245,34 @@ docker compose exec web flask create-admin
 
 This runs the Flask CLI command inside the running web container.
 
-You'll be prompted for:
-- Email address (used for login)
-- Password (at least 8 characters)
-- Display name (shown in the app)
-- Initials (2-3 characters, displayed on RSVP badges)
-
 ## Step 4: Access the Application
 Open your browser and navigate to http://localhost
 
-You should see the login page. Log in with the email and password you just
-created.
+You should see the login page. Log in with the email and password you configured.
 
 After login, you'll see:
-- The main regatta schedule (empty initially)
-- Navbar with "Home", "iCal", "Crew", and "Import" links
-- A "+ New Regatta" button (admin only)
+- The main schedule page (empty initially)
+- Navbar with Home, Calendar, My Crew, and Admin links
+- A "+ New Event" button (admin/skipper only)
+- Schedule filter dropdown for switching between skippers
+- A "Notify Crew" button for sending email notifications
 
 ## Step 5: Explore the Interface
-Try creating your first regatta:
+Try creating your first event:
 
-1. Click "+ New Regatta" button
+1. Click "+ New Event" button
 2. Fill in:
    - Name: "Mid-Winters Championship"
+   - Boat Class: "Thistle"
    - Date: Pick a future date
-   - Location: "San Francisco, CA"
-   - Google Maps URL: (optional)
-   - Website URL: (optional)
+   - Location: "San Francisco YC"
 3. Click "Save"
 
 You'll be redirected to the main schedule. Notice:
-- The regatta appears in the table
+- The event appears in the table
 - Your RSVP dropdown shows "-" (not responded yet)
-- Edit and Delete buttons appear (admin only)
+- Edit and Delete buttons appear (you're the admin/owner)
+- A Google Maps link is auto-generated from the location
 
 Try setting your RSVP:
 - Change the dropdown from "-" to "Yes"
@@ -291,7 +307,7 @@ Flask is "micro" because it provides the essentials and lets you add what you
 need via extensions (like SQLAlchemy for databases, Flask-Login for auth).
 
 ## The Application Factory Pattern
-File: race-crew-network/app/__init__.py:17-53
+File: race-crew-network/app/__init__.py:33-165
 
 Flask apps can be created in two ways:
 1. Direct instantiation: `app = Flask(__name__)` at module level
@@ -300,9 +316,11 @@ Flask apps can be created in two ways:
 This application uses the factory pattern:
 
 ```python
-def create_app():
+def create_app(test_config=None):
     app = Flask(__name__)
     app.config.from_object("app.config.Config")
+    if test_config:
+        app.config.update(test_config)
 
     # Initialize extensions
     db.init_app(app)
@@ -310,15 +328,14 @@ def create_app():
     login_manager.init_app(app)
     csrf.init_app(app)
 
-    # Register blueprints
+    # Register 6 blueprints
     from app.admin import bp as admin_bp
     from app.auth import bp as auth_bp
     from app.calendar import bp as calendar_bp
+    from app.email import bp as email_bp
     from app.regattas import bp as regattas_bp
-    app.register_blueprint(admin_bp)
-    app.register_blueprint(auth_bp)
-    app.register_blueprint(calendar_bp)
-    app.register_blueprint(regattas_bp)
+    from app.storage_routes import bp as storage_bp
+    # ... register each blueprint
 
     return app
 ```
@@ -326,32 +343,26 @@ def create_app():
 **Why use a factory?**
 - Can create multiple app instances (useful for testing)
 - Extensions are initialized with the app context
-- Configuration can vary per instance (dev vs production)
+- Configuration can vary per instance (dev vs production vs test)
 
 ## Blueprints: Modular Routing
-Blueprints organize routes into logical groups. This app has four:
+Blueprints organize routes into logical groups. This app has six:
 
-1. **admin** - AI-powered schedule import, document discovery
-2. **auth** - Login, logout, registration, user management
-3. **regattas** - Regatta CRUD, RSVP, document handling
-4. **calendar** - iCal feed generation
+1. **admin** — AI-powered schedule import, document discovery, site settings
+2. **auth** — Login, logout, registration, user management, crew management
+3. **regattas** — Event CRUD, RSVP, document handling, crew notifications
+4. **calendar** — iCal feed generation, subscribe page
+5. **email** — Unsubscribe handling, SES bounce/complaint webhooks
+6. **storage** — Local file serving for development
 
-Example: The auth blueprint (race-crew-network/app/auth/routes.py)
-defines routes like:
-- /login
-- /logout
-- /register/<token>
-- /profile
-- /admin/users
-
-When registered, these become available as full routes. Flask automatically
-combines the blueprint's routes with the main app.
+When registered, their routes become available as full routes. Flask
+automatically combines each blueprint's routes with the main app.
 
 ## Routes: Mapping URLs to Functions
 A route connects a URL to a Python function:
 
 ```python
-@app.route('/login', methods=['GET', 'POST'])
+@bp.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
         # Process login form
@@ -361,7 +372,7 @@ def login():
 ```
 
 Key concepts:
-- **@app.route()**: Decorator that registers the function as a route handler
+- **@bp.route()**: Decorator that registers the function as a route handler
 - **methods**: List of HTTP methods the route accepts (GET, POST, etc.)
 - **request**: Global object containing form data, query params, headers
 - **render_template()**: Renders a Jinja2 template with context data
@@ -376,8 +387,8 @@ for inserting Python expressions and control flow:
 {% block content %}
 <h1>Welcome, {{ current_user.display_name }}!</h1>
 <ul>
-{% for regatta in regattas %}
-    <li>{{ regatta.name }} - {{ regatta.date }}</li>
+{% for regatta in upcoming %}
+    <li>{{ regatta.name }} - {{ regatta.start_date }}</li>
 {% endfor %}
 </ul>
 {% endblock %}
@@ -394,7 +405,7 @@ Flask extensions add features. This app uses:
 
 - **Flask-SQLAlchemy**: ORM for database operations (Day 3)
 - **Flask-Login**: User session management (Day 4)
-- **Flask-Migrate**: Database schema migrations (Day 10)
+- **Flask-Migrate**: Database schema migrations (Day 17)
 - **Flask-WTF**: CSRF protection (Day 4)
 
 Extensions are initialized at the module level, then attached to the app in
@@ -419,33 +430,29 @@ This two-step process is required for the factory pattern to work.
 2. **The application factory pattern** (`create_app()`) creates a configured
    Flask instance. This enables testing and multiple configurations.
 
-3. **Blueprints organize routes** into logical modules. This keeps code
-   organized as the application grows.
+3. **Six blueprints organize routes** into logical modules: admin, auth,
+   regattas, calendar, email, and storage.
 
-4. **Flask handles the HTTP request/response cycle**. Routes map URLs to
-   Python functions. Templates render HTML with dynamic data.
+4. **Three user roles** (Admin, Skipper, Crew) provide layered access control.
+   Each role sees different features and can perform different actions.
 
 5. **Docker volumes persist data** across container restarts. The mysql_data
    volume stores the database, and uploads stores user files locally.
    In production, file uploads use S3-compatible object storage.
 
-6. **Flask CLI commands** (like `flask create-admin`) extend the framework
+6. **Flask CLI commands** (like `flask init-admin`) extend the framework
    with custom administrative tasks.
 
 ## What's Next?
 In Day 2, we'll dive deep into the application factory pattern and understand
 how Flask extensions are initialized. We'll explore configuration management
-with environment variables and see how the app bootstraps itself on startup.
-
-You now have a running Flask application! Before moving on, try:
-- Creating a few more regattas
-- Changing your RSVP status
-- Exploring the Crew page (invite management)
-- Viewing the application logs in the terminal
+with environment variables, the six blueprint registrations, and the context
+processors and template filters that power the UI.
 
 Questions to ponder:
 - How does Flask know which function to call for a given URL?
 - Where is the HTML for the login page stored?
 - How does the web container know when MySQL is ready?
+- What's the difference between a Skipper and a Crew member?
 
 See you in Day 2!

--- a/training/02-day2.md
+++ b/training/02-day2.md
@@ -5,16 +5,20 @@ By the end of this session, you will understand:
 - The application factory pattern and why it's used
 - How Flask extensions are initialized and attached to the app
 - Configuration management with environment variables
-- Blueprint registration and organization
-- The application lifecycle from startup to serving requests
+- Blueprint registration for all six application modules
+- Context processors that inject data into every template render
+- Template filters that transform data inside Jinja2 templates
+- Error handling at the application level
 
 ## Concepts Covered
 - Application factory pattern
 - Flask extensions (SQLAlchemy, Flask-Login, Flask-Migrate, CSRF)
 - Configuration classes and environment variables
-- Blueprint registration
+- Blueprint registration (6 blueprints)
 - WSGI (Web Server Gateway Interface)
-- Context processors and template filters
+- Context processors (version, profile image, site settings)
+- Template filters (avatar_svg, user_icon, sort_rsvps, regatta_days)
+- Custom error handlers (RequestEntityTooLarge)
 
 ## File Focus
 For this session, examine these files:
@@ -24,7 +28,7 @@ For this session, examine these files:
 - race-crew-network/entrypoint.sh - Container startup script
 - race-crew-network/.env.example - Environment variable template
 
-# Part 1: the Application Factory
+# Part 1: The Application Factory
 
 ## What Is the Factory Pattern?
 The factory pattern is a design pattern where a function creates and returns a
@@ -59,8 +63,42 @@ def create_app():
 4. **Deferred Configuration**: Load config based on environment at runtime
 5. **Circular Imports**: Avoid import issues when models need db and db needs app
 
+## Module-Level Setup
+File: race-crew-network/app/__init__.py:1-17
+
+Before the factory function, the module sets up imports and extension objects:
+
+```python
+from flask import Flask, flash, has_request_context, redirect, request, url_for
+from flask_login import LoginManager
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf.csrf import CSRFProtect
+from markupsafe import Markup, escape
+from sqlalchemy.exc import SQLAlchemyError
+from werkzeug.exceptions import RequestEntityTooLarge
+
+__version__ = "0.61.0"
+
+db = SQLAlchemy()
+migrate = Migrate()
+login_manager = LoginManager()
+login_manager.login_view = "auth.login"
+login_manager.login_message = None
+csrf = CSRFProtect()
+```
+
+Notice `__version__` is defined here. This is the single source of truth for
+the application version, used in the footer of every page via a context
+processor (covered below). The extensions are created as empty instances --
+they get connected to the Flask app inside create_app().
+
+Setting `login_manager.login_message = None` suppresses the default
+"Please log in to access this page" flash message that Flask-Login shows
+when redirecting unauthenticated users to the login page.
+
 ## The create_app Function
-File: race-crew-network/app/__init__.py:17-53
+File: race-crew-network/app/__init__.py:33-165
 
 ```python
 def create_app(test_config=None):
@@ -77,24 +115,21 @@ def create_app(test_config=None):
     from app.admin import bp as admin_bp
     from app.auth import bp as auth_bp
     from app.calendar import bp as calendar_bp
+    from app.email import bp as email_bp
     from app.regattas import bp as regattas_bp
+    from app.storage_routes import bp as storage_bp
 
     app.register_blueprint(admin_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(calendar_bp)
+    app.register_blueprint(email_bp)
     app.register_blueprint(regattas_bp)
+    app.register_blueprint(storage_bp)
 
     from app.commands import register_commands
     register_commands(app)
 
-    @app.context_processor
-    def inject_version():
-        return {"app_version": __version__}
-
-    @app.template_filter("sort_rsvps")
-    def sort_rsvps(rsvps):
-        order = {"yes": 0, "no": 1, "maybe": 2}
-        return sorted(rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name))
+    # ... context processors, template filters, error handlers ...
 
     return app
 ```
@@ -111,9 +146,12 @@ and static files relative to this module.
 **Step 2: Load configuration**
 ```python
 app.config.from_object("app.config.Config")
+if test_config:
+    app.config.update(test_config)
 ```
 Loads all UPPERCASE attributes from the Config class as configuration values.
-This is Flask's recommended way to manage settings.
+The test_config parameter allows tests to override settings like the database
+URI (switching to SQLite in-memory) and disabling CSRF.
 
 **Step 3: Initialize extensions**
 ```python
@@ -122,45 +160,32 @@ migrate.init_app(app, db)
 login_manager.init_app(app)
 csrf.init_app(app)
 ```
-Each extension was created at module level (lines 9-14), but they need to be
+Each extension was created at module level (lines 12-17), but they need to be
 attached to the app instance. This two-step initialization is required for
 the factory pattern.
 
-**Step 4: Register blueprints**
+**Step 4: Register six blueprints**
 ```python
 app.register_blueprint(admin_bp)
 app.register_blueprint(auth_bp)
 app.register_blueprint(calendar_bp)
+app.register_blueprint(email_bp)
 app.register_blueprint(regattas_bp)
+app.register_blueprint(storage_bp)
 ```
-Imports and registers all four route blueprints. This makes their routes
-available in the application.
+Imports are done inside the function to avoid circular imports. All six route
+modules become available once registered.
 
 **Step 5: Register CLI commands**
 ```python
 register_commands(app)
 ```
-Adds custom Flask CLI commands like `flask create-admin`.
+Adds custom Flask CLI commands like `flask init-admin` and `flask create-admin`.
 
-**Step 6: Add context processors**
-```python
-@app.context_processor
-def inject_version():
-    return {"app_version": __version__}
-```
-Context processors add variables to every template render. This makes
-app_version available in all templates without passing it explicitly.
+**Step 6: Add context processors, template filters, and error handlers**
+(Covered in Parts 3-5 below.)
 
-**Step 7: Add template filters**
-```python
-@app.template_filter("sort_rsvps")
-def sort_rsvps(rsvps):
-    # ... sorting logic
-```
-Template filters transform data in templates. This custom filter sorts RSVPs
-by status (yes, no, maybe) and then by user name.
-
-**Step 8: Return the configured app**
+**Step 7: Return the configured app**
 ```python
 return app
 ```
@@ -169,7 +194,7 @@ The fully configured app is returned and ready to handle requests.
 # Part 2: Configuration Management
 
 ## The Config Class
-File: race-crew-network/app/config.py
+File: race-crew-network/app/config.py:1-18
 
 ```python
 import os
@@ -182,9 +207,12 @@ class Config:
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB max upload
+    PROFILE_IMAGE_MAX_BYTES = 10 * 1024 * 1024
     UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "uploads")
     BUCKET_NAME = os.environ.get("BUCKET_NAME", "")
     AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+    SES_ACCESS_KEY_ID = os.environ.get("SES_ACCESS_KEY_ID", "")
+    SES_SECRET_ACCESS_KEY = os.environ.get("SES_SECRET_ACCESS_KEY", "")
     ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 ```
 
@@ -201,64 +229,232 @@ This reads from environment variables with fallback defaults. Benefits:
 
 ## Key Configuration Values
 
-**SECRET_KEY**:
-Used for cryptographic signing of session cookies, CSRF tokens, and other
-security features. Must be random and secret. Generate with:
+**SECRET_KEY**: Used for cryptographic signing of session cookies, CSRF
+tokens, and other security features. Must be random and secret in production.
+
+**SQLALCHEMY_DATABASE_URI**: Database connection string. Format:
+`mysql+pymysql://username:password@host:port/database`
+
+**MAX_CONTENT_LENGTH**: Flask's built-in limit for HTTP request body size
+(10 MB). Werkzeug raises RequestEntityTooLarge if exceeded.
+
+**PROFILE_IMAGE_MAX_BYTES**: Application-level limit for profile image
+uploads (also 10 MB). This is checked explicitly in the upload handler for
+a more user-friendly error message.
+
+**BUCKET_NAME**: S3-compatible bucket for file uploads in production
+(Lightsail Object Storage). Empty string for local development.
+
+**SES_ACCESS_KEY_ID / SES_SECRET_ACCESS_KEY**: Credentials for Amazon SES
+email sending. Separate from the main AWS credentials to support scoped
+IAM policies.
+
+**ANTHROPIC_API_KEY**: API key for the Anthropic Claude API, used for
+AI-powered schedule import and document discovery (Day 13).
+
+**SQLALCHEMY_TRACK_MODIFICATIONS**: Set to False to disable SQLAlchemy's
+event system. This reduces memory overhead and is recommended.
+
+# Part 3: Context Processors
+
+Context processors are functions that inject variables into every template
+render. They run before each template is rendered, making their return values
+available without explicitly passing them from route handlers.
+
+## inject_version
+File: race-crew-network/app/__init__.py:62-64
+
 ```python
-python3 -c "import secrets; print(secrets.token_hex(32))"
+@app.context_processor
+def inject_version():
+    return {"app_version": __version__}
 ```
 
-**SQLALCHEMY_DATABASE_URI**:
-Database connection string format:
-```
-mysql+pymysql://username:password@host:port/database
-```
-- mysql+pymysql: SQLAlchemy dialect + driver
-- racecrew:racecrew: username and password
-- @db:3306: host (Docker service name) and port
-- /racecrew: database name
+Makes `app_version` available in all templates. The base template uses this
+to display "v0.61.0" in the page footer.
 
-**BUCKET_NAME**:
-S3-compatible bucket for file uploads in production (Lightsail Object Storage).
-Empty string for local development (uses local file system).
+## inject_profile_image
+File: race-crew-network/app/__init__.py:66-78
 
-**ANTHROPIC_API_KEY**:
-API key for the Anthropic Claude API, used for AI-powered schedule import
-and document discovery features.
+```python
+@app.context_processor
+def inject_profile_image():
+    from flask_login import current_user as cu
 
-**SQLALCHEMY_TRACK_MODIFICATIONS**:
-Set to False to disable SQLAlchemy's event system that tracks object changes.
-This reduces memory overhead and is recommended unless you need it.
-
-**MAX_CONTENT_LENGTH**:
-Limits HTTP request body size to 10MB. Prevents users from uploading huge
-files that could fill disk space or cause memory issues.
-
-**UPLOAD_FOLDER**:
-Directory path where uploaded files are stored. Must be writable by the app.
-
-## Environment Variables
-File: race-crew-network/.env.example
-
-```
-SECRET_KEY=change-me-to-a-random-string
-DATABASE_URL=mysql+pymysql://racecrew:racecrew@db:3306/racecrew
-UPLOAD_FOLDER=/app/uploads
-MYSQL_ROOT_PASSWORD=rootpassword
-MYSQL_DATABASE=racecrew
-MYSQL_USER=racecrew
-MYSQL_PASSWORD=racecrew
-INIT_ADMIN_EMAIL=admin@example.com
-INIT_ADMIN_PASSWORD=changeme123
+    url = None
+    if cu.is_authenticated and cu.profile_image_key:
+        try:
+            from app import storage
+            url = storage.get_file_url(cu.profile_image_key)
+        except Exception:
+            pass
+    return {"current_user_profile_image_url": url}
 ```
 
-The .env file is loaded by Docker Compose (via env_file: .env). These
-variables are available to both the web and db containers.
+This processor resolves the current user's profile image URL on every request.
+The navbar uses `current_user_profile_image_url` to display the user's photo
+next to their name. If the user has no profile image or URL generation fails,
+it returns None and the template falls back to an avatar.
 
-**Important**: .env is in .gitignore and never committed. Each environment
-(dev, staging, production) has its own .env file.
+## inject_site_settings
+File: race-crew-network/app/__init__.py:80-104
 
-# Part 3: Flask Extensions
+```python
+@app.context_processor
+def inject_site_settings():
+    from app.models import SiteSetting
+
+    ga_measurement_id = ""
+    try:
+        ga_setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
+        if ga_setting and ga_setting.value:
+            ga_measurement_id = ga_setting.value.strip()
+    except SQLAlchemyError as exc:
+        app.logger.warning("Unable to load GA setting from database: %s", exc)
+        ga_measurement_id = ""
+
+    is_local_host = False
+    if has_request_context():
+        host = (request.host or "").split(":", 1)[0].lower()
+        is_local_host = host in {"localhost", "127.0.0.1"}
+
+    is_dev_or_test = bool(app.config.get("TESTING")) or is_local_host
+
+    return {
+        "ga_measurement_id": ga_measurement_id,
+        "is_dev_or_test": is_dev_or_test,
+    }
+```
+
+This processor loads runtime settings from the database (specifically Google
+Analytics tracking). It also detects whether the app is running locally or
+in test mode, so the base template can conditionally skip the GA script.
+The SiteSetting model is covered in Day 15.
+
+# Part 4: Template Filters
+
+Template filters transform data inside Jinja2 templates using the pipe
+syntax: `{{ value | filter_name }}`. Flask lets you register custom filters.
+
+## avatar_svg
+File: race-crew-network/app/__init__.py:20-30, 106-109
+
+```python
+def _avatar_svg_markup(user, size=20):
+    """Render a Multiavatar inline SVG for a user-like object."""
+    from multiavatar.multiavatar import multiavatar
+
+    key = user.avatar_key if hasattr(user, "avatar_key") else str(user)
+    svg = multiavatar(key, None, None)
+    return Markup(
+        f'<span class="avatar-icon" style="display:inline-block;'
+        f"width:{size}px;height:{size}px;vertical-align:middle;"
+        f'">{svg}</span>'
+    )
+
+@app.template_filter("avatar_svg")
+def avatar_svg_filter(user, size=20):
+    return _avatar_svg_markup(user, size)
+```
+
+Generates an inline SVG avatar using the Multiavatar library. Each user has
+an `avatar_key` property (based on their `avatar_seed` or email) that
+produces a unique, deterministic avatar. Usage in templates:
+`{{ user | avatar_svg }}` or `{{ user | avatar_svg(32) }}` for a custom size.
+
+The helper `_avatar_svg_markup` is extracted as a standalone function so both
+the filter and the `user_icon` filter can reuse it.
+
+## user_icon
+File: race-crew-network/app/__init__.py:111-132
+
+```python
+@app.template_filter("user_icon")
+def user_icon_filter(user, size=20):
+    """Render profile picture when present; otherwise render avatar fallback."""
+    if user and getattr(user, "profile_image_key", None):
+        try:
+            from app import storage
+            image_url = escape(storage.get_file_url(user.profile_image_key))
+            display_name = escape(getattr(user, "display_name", "User"))
+            return Markup(
+                f'<span class="avatar-icon" style="display:inline-block;'
+                f"width:{size}px;height:{size}px;vertical-align:middle;"
+                '">'
+                f'<img class="avatar-photo" src="{image_url}" alt="{display_name}" '
+                f'style="width:100%;height:100%;border-radius:50%;object-fit:cover;">'
+                "</span>"
+            )
+        except Exception:
+            pass
+    return _avatar_svg_markup(user, size)
+```
+
+This is the primary filter used throughout the application. It implements a
+two-tier fallback: if the user has a profile photo, render it as a circular
+`<img>` tag; otherwise, fall back to the SVG avatar. The `escape()` calls
+prevent XSS from user-provided display names or storage URLs.
+
+## sort_rsvps
+File: race-crew-network/app/__init__.py:134-139
+
+```python
+@app.template_filter("sort_rsvps")
+def sort_rsvps(rsvps):
+    order = {"yes": 0, "no": 1, "maybe": 2}
+    return sorted(
+        rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name)
+    )
+```
+
+Sorts RSVP lists for display: Yes responses first, then No, then Maybe,
+with alphabetical sorting within each group. Used on the regatta detail page
+and the schedule view.
+
+## regatta_days
+File: race-crew-network/app/__init__.py:141-153
+
+```python
+@app.template_filter("regatta_days")
+def regatta_days(start_date, end_date=None):
+    if not start_date:
+        return ""
+    if not end_date or end_date <= start_date:
+        return start_date.strftime("%a")
+    day_span = (end_date - start_date).days
+    if day_span == 1:
+        return f"{start_date.strftime('%a')} & {end_date.strftime('%a')}"
+    return f"{start_date.strftime('%a')} thru {end_date.strftime('%a')}"
+```
+
+Formats regatta date ranges into human-readable day strings. A single-day
+event shows "Sat"; a two-day event shows "Sat & Sun"; longer events show
+"Sat thru Mon". Used in the schedule table and calendar feeds.
+
+# Part 5: Error Handling
+
+## RequestEntityTooLarge Handler
+File: race-crew-network/app/__init__.py:155-163
+
+```python
+@app.errorhandler(RequestEntityTooLarge)
+def handle_request_entity_too_large(_exc):
+    max_mb = int(app.config.get("PROFILE_IMAGE_MAX_BYTES", 10 * 1024 * 1024)) // (
+        1024 * 1024
+    )
+    flash(f"Profile picture must be {max_mb} MB or smaller.", "error")
+    if request.path == url_for("auth.profile"):
+        return redirect(url_for("auth.profile"))
+    return redirect(request.referrer or url_for("regattas.index"))
+```
+
+When a user uploads a file larger than MAX_CONTENT_LENGTH, Werkzeug raises
+RequestEntityTooLarge before the route handler even runs. This global error
+handler catches it and shows a friendly flash message instead of a raw 413
+error page. If the upload came from the profile page, it redirects back
+there; otherwise it redirects to the referrer or home page.
+
+# Part 6: Flask Extensions
 
 ## What Are Extensions?
 Flask extensions add functionality to the core framework. This app uses four:
@@ -269,24 +465,12 @@ Flask extensions add functionality to the core framework. This app uses four:
 4. **Flask-WTF**: CSRF protection and form handling
 
 ## Two-Step Initialization
-File: race-crew-network/app/__init__.py:9-14
-
-```python
-db = SQLAlchemy()
-migrate = Migrate()
-login_manager = LoginManager()
-login_manager.login_view = "auth.login"
-csrf = CSRFProtect()
-```
-
 Extensions are created at module level without an app instance. They're
 initialized later in create_app():
 
 ```python
-db.init_app(app)
-migrate.init_app(app, db)
-login_manager.init_app(app)
-csrf.init_app(app)
+db = SQLAlchemy()          # Step 1: Create (module level)
+db.init_app(app)           # Step 2: Attach (inside factory)
 ```
 
 This pattern allows the extensions to be imported anywhere while ensuring they
@@ -295,62 +479,27 @@ work with the correct app context.
 ## Flask-SQLAlchemy (db)
 Provides a clean API for database operations:
 ```python
-# Query
 user = db.session.query(User).filter_by(email='test@example.com').first()
-
-# Create
-new_regatta = Regatta(name="Mid-Winters", date=date(2024, 1, 15))
+new_regatta = Regatta(name="Mid-Winters", start_date=date(2024, 1, 15))
 db.session.add(new_regatta)
 db.session.commit()
-
-# Update
-regatta.name = "Mid-Winters Championship"
-db.session.commit()
-
-# Delete
-db.session.delete(regatta)
-db.session.commit()
 ```
-
-We'll explore this deeply in Day 3 (Database Models).
+Explored deeply in Day 3 (Database Models).
 
 ## Flask-Login (login_manager)
-Manages user sessions:
-- Stores user ID in encrypted session cookie
-- Provides @login_required decorator for protected routes
-- Makes current_user available in routes and templates
-- Handles login/logout
-
-Configuration:
-```python
-login_manager.login_view = "auth.login"
-```
-Sets the route to redirect to when @login_required fails. "auth.login" refers
-to the login function in the auth blueprint.
-
-We'll explore this in Day 4 (Authentication).
+Manages user sessions. `login_manager.login_view = "auth.login"` sets the
+route to redirect to when @login_required fails. Covered in Day 4.
 
 ## Flask-Migrate (migrate)
-Manages database schema changes:
-```bash
-flask db migrate -m "Add calendar_token to users"
-flask db upgrade
-```
-
-Generates migration scripts when models change, and applies them to the
-database. We'll cover this in Day 10 (Migrations & Deployment).
+Manages database schema changes via Alembic migration scripts. Covered in
+Day 17.
 
 ## Flask-WTF (csrf)
-Protects against Cross-Site Request Forgery attacks by:
-- Generating unique tokens for each session
-- Validating tokens on POST/PUT/DELETE requests
-- Automatically rejecting requests with invalid tokens
+Protects against Cross-Site Request Forgery attacks by generating unique
+tokens per session and validating them on form submissions. Templates must
+include `{{ csrf_token() }}` in forms.
 
-Templates must include {{ csrf_token() }} in forms for this to work.
-
-# Part 4: Application Lifecycle
-
-## From Container Start to Handling Requests
+# Part 7: Application Lifecycle
 
 ## Startup Sequence Diagram
 
@@ -361,6 +510,8 @@ Templates must include {{ csrf_token() }} in forms for this to work.
   [entrypoint.sh executes]
            |
            +---> flask db upgrade (apply migrations)
+           |
+           +---> flask init-admin (create admin if needed)
            |
            +---> gunicorn -c gunicorn.conf.py wsgi:app
                        |
@@ -374,10 +525,13 @@ Templates must include {{ csrf_token() }} in forms for this to work.
                        v
               [create_app() runs]
                        |
-                       +---> Load config
-                       +---> Initialize extensions
-                       +---> Register blueprints
-                       +---> Add context processors
+                       +---> Load Config
+                       +---> Initialize 4 extensions
+                       +---> Register 6 blueprints
+                       +---> Register CLI commands
+                       +---> Add 3 context processors
+                       +---> Add 4 template filters
+                       +---> Add error handler
                        |
                        v
               [Gunicorn workers start]
@@ -385,31 +539,6 @@ Templates must include {{ csrf_token() }} in forms for this to work.
                        v
               [App ready for requests]
 ```
-
-## Entrypoint Script
-File: race-crew-network/entrypoint.sh
-
-```bash
-#!/bin/sh
-set -e
-
-echo "Running database migrations..."
-flask db upgrade
-
-echo "Initializing admin account if needed..."
-flask init-admin
-
-echo "Starting Gunicorn..."
-exec gunicorn -c gunicorn.conf.py wsgi:app
-```
-
-**set -e**: Exit immediately if any command fails
-**flask db upgrade**: Apply pending database migrations
-**flask init-admin**: Creates admin user from INIT_ADMIN_EMAIL/PASSWORD env vars
-**exec**: Replace shell with Gunicorn (proper signal handling)
-
-This ensures the database schema is current and admin user exists before the
-app starts.
 
 ## WSGI Entry Point
 File: race-crew-network/wsgi.py
@@ -421,53 +550,36 @@ app = create_app()
 ```
 
 WSGI (Web Server Gateway Interface) is Python's standard for web servers
-(Gunicorn) to communicate with web apps (Flask).
-
-Gunicorn imports wsgi.py and calls the app object for each request.
+(Gunicorn) to communicate with web apps (Flask). Gunicorn imports wsgi.py
+and calls the app object for each request.
 
 ## Request Handling Flow
 
-1. **Client sends HTTP request** → host port 80
-2. **Docker maps port 80** → web container port 8000
-3. **Gunicorn receives request** → picks a worker process
-4. **Worker calls Flask app** → WSGI interface (wsgi:app)
-5. **Flask routes request** → matches URL to blueprint route
-6. **Route function executes** → accesses database, renders template
-7. **Response returned** → Gunicorn → client
+1. **Client sends HTTP request** to host port 80
+2. **Docker maps port 80** to web container port 8000
+3. **Gunicorn receives request** and picks a worker process
+4. **Worker calls Flask app** via WSGI interface
+5. **Flask runs context processors** (inject_version, inject_profile_image,
+   inject_site_settings)
+6. **Flask routes request** by matching URL to a blueprint route
+7. **Route function executes**: accesses database, renders template
+8. **Template filters** (user_icon, sort_rsvps, etc.) transform data
+9. **Response returned** through Gunicorn to client
 
 ## Blueprints in Depth
-Blueprints organize routes into modules. This app has four:
+Blueprints organize routes into modules. This app has six:
 
-**admin** (race-crew-network/app/admin/__init__.py):
-```python
-from flask import Blueprint
+| Blueprint   | Module                    | Key Routes                                   |
+|-------------|---------------------------|----------------------------------------------|
+| admin       | app/admin/__init__.py     | /admin/import-schedule, /admin/settings       |
+| auth        | app/auth/__init__.py      | /login, /register, /profile, /admin/users     |
+| regattas    | app/regattas/__init__.py  | /, /regattas/new, /regattas/<id>/rsvp         |
+| calendar    | app/calendar/__init__.py  | /calendar/feed, /calendar/subscribe           |
+| email       | app/email/__init__.py     | /unsubscribe, /ses/webhook                    |
+| storage     | app/storage_routes.py     | /uploads/<path:filename>                      |
 
-bp = Blueprint("admin", __name__)
-
-from app.admin import routes
-```
-Routes: /admin/import-schedule, /admin/import-single, /admin/regattas/discover
-
-**auth** (race-crew-network/app/auth/__init__.py):
-```python
-from flask import Blueprint
-
-bp = Blueprint("auth", __name__)
-
-from app.auth import routes  # Import after to avoid circular imports
-```
-Routes: /login, /logout, /register/<token>, /profile, /admin/users
-
-**Registration in create_app()**:
-```python
-from app.admin import bp as admin_bp
-from app.auth import bp as auth_bp
-app.register_blueprint(admin_bp)
-app.register_blueprint(auth_bp)
-```
-
-This makes all blueprint routes available. Flask automatically combines
-blueprint route prefixes with route paths.
+The storage blueprint is unique: it only serves files in local development.
+In production, files are served directly from S3-compatible object storage.
 
 # Key Takeaways
 
@@ -475,32 +587,41 @@ blueprint route prefixes with route paths.
    configured Flask instance. This enables testing, multiple configs, and
    proper extension initialization.
 
-2. **Configuration is loaded from environment variables** via a Config class.
-   This keeps secrets out of source code and allows per-environment settings.
+2. **Configuration is loaded from environment variables** via a Config class
+   with 11 settings. This keeps secrets out of source code and allows
+   per-environment settings. SES and Anthropic credentials are separate
+   from core Flask config.
 
 3. **Flask extensions are initialized in two steps**: Create at module level,
    then attach to app in create_app() with init_app(). This supports the
-   factory pattern.
+   factory pattern and avoids circular imports.
 
-4. **Blueprints organize routes** into logical modules (admin, auth, regattas,
-   calendar). They keep code organized and promote reusability.
+4. **Six blueprints organize routes** into logical modules: admin, auth,
+   regattas, calendar, email, and storage. They keep the codebase modular
+   and maintainable.
 
-5. **The application lifecycle** starts with entrypoint.sh running migrations,
-   then Gunicorn loading wsgi.py which calls create_app(). The configured app
-   then handles requests via WSGI.
+5. **Three context processors** inject data into every template render:
+   the app version, the current user's profile image URL, and site settings
+   (Google Analytics). This avoids repetitive code in route handlers.
 
-6. **Context processors and template filters** customize template rendering.
-   Context processors add variables to all templates. Filters transform data.
+6. **Four template filters** transform data in templates: avatar_svg and
+   user_icon for user avatars/photos, sort_rsvps for ordered RSVP lists,
+   and regatta_days for human-readable date ranges.
+
+7. **The RequestEntityTooLarge error handler** provides a friendly message
+   when file uploads exceed the configured limit, instead of showing a raw
+   HTTP 413 error.
 
 ## What's Next?
-In Day 3, we'll explore the database layer with SQLAlchemy. You'll learn how
-Python classes (models) map to database tables, and how to define
-relationships between data. We'll examine all five models in this application:
-User, Regatta, Document, RSVP, and ImportCache.
+In Day 3, we'll explore the database layer with SQLAlchemy. The application
+has grown to 8 models plus a self-referential many-to-many association table.
+You'll learn how the User model handles roles, avatars, notification
+preferences, and permission scoping with visible_regattas().
 
 Questions to ponder:
 - Why does Flask use a two-step initialization for extensions?
 - What would happen if SECRET_KEY changed between server restarts?
-- How does Flask know which blueprint a route belongs to?
+- How does the user_icon filter decide between a photo and an SVG avatar?
+- Why does inject_site_settings check for localhost separately from TESTING?
 
 See you in Day 3!

--- a/training/04-day4.md
+++ b/training/04-day4.md
@@ -2,26 +2,30 @@
 
 ## Learning Objectives
 By the end of this session, you will understand:
-- Flask-Login integration and how user sessions work
+- How Flask-Login manages user sessions
 - Login and logout implementation
-- The invite-based registration system with tokens
-- User profile management
-- Admin user administration features
-- Authorization patterns (@login_required, role checks)
+- The invite-based registration system with auto-link and avatar generation
+- User profile management with image uploads and notification preferences
+- Admin user administration: invite, edit, delete, impersonate
+- Email invitations for new users
 
 ## Concepts Covered
-- Flask-Login and session management
-- User authentication flow
+- Flask-Login and UserMixin
+- Session management with encrypted cookies
 - Token-based invite system
-- Form validation and flash messages
-- Authorization vs authentication
-- Admin-only routes
-- Password change functionality
+- Auto-link crew to inviting skipper on registration
+- Avatar seed generation
+- Profile image upload with validation
+- Notification preference management
+- Admin impersonation via session
+- Email invite with fallback to link copy
 
 ## File Focus
 For this session, examine:
-- race-crew-network/app/auth/routes.py - All authentication routes
-- race-crew-network/app/models.py:9-44 - User model and user_loader
+- race-crew-network/app/auth/routes.py:85-164 — Login, logout, register
+- race-crew-network/app/auth/routes.py:167-273 — Profile management
+- race-crew-network/app/auth/routes.py:295-524 — Admin user management
+- race-crew-network/app/models.py:24-44 — User model with user_loader
 
 # Part 1: Flask-Login Overview
 
@@ -39,10 +43,10 @@ login_manager = LoginManager()
 login_manager.login_view = "auth.login"
 ```
 
-login_view sets the route to redirect to when authentication is required.
+`login_view` sets the route to redirect to when authentication is required.
 
 ## User Loader Function
-File: race-crew-network/app/models.py:42-44 (current line numbers)
+File: race-crew-network/app/models.py:24-26
 
 ```python
 @login_manager.user_loader
@@ -54,24 +58,10 @@ Flask-Login calls this on every request to load the user from the session
 cookie. The user_id is stored in the cookie; this function retrieves the full
 User object from the database.
 
-## current_user Object
-Flask-Login provides current_user, a proxy to the logged-in user:
-
-```python
-from flask_login import current_user
-
-if current_user.is_authenticated:
-    print(f"Logged in as {current_user.display_name}")
-else:
-    print("Not logged in")
-```
-
-Available everywhere after login_manager is initialized.
-
 # Part 2: Login and Logout
 
 ## Login Route
-File: race-crew-network/app/auth/routes.py:9-26 (current line numbers)
+File: race-crew-network/app/auth/routes.py:85-102
 
 ```python
 @bp.route("/login", methods=["GET", "POST"])
@@ -94,65 +84,18 @@ def login():
     return render_template("login.html")
 ```
 
-## Step-by-Step Login Flow
+The login validates three things:
+1. **User exists**: `User.query.filter_by(email=email).first()`
+2. **Registration complete**: `user.invite_token is None` — users with
+   pending invitations can't log in
+3. **Password matches**: `user.check_password(password)` — bcrypt comparison
 
-1. **Check if already logged in**:
-   ```python
-   if current_user.is_authenticated:
-       return redirect(url_for("regattas.index"))
-   ```
-   If already authenticated, send to main page.
-
-2. **Handle POST request** (form submission):
-   ```python
-   if request.method == "POST":
-   ```
-   GET shows the form, POST processes it.
-
-3. **Extract form data**:
-   ```python
-   email = request.form.get("email", "").strip().lower()
-   password = request.form.get("password", "")
-   ```
-   Normalize email to lowercase for case-insensitive matching.
-
-4. **Find user by email**:
-   ```python
-   user = User.query.filter_by(email=email).first()
-   ```
-   Returns User object or None.
-
-5. **Validate credentials**:
-   ```python
-   if user and user.invite_token is None and user.check_password(password):
-   ```
-   Three checks:
-   - user exists
-   - invite_token is None (registration complete)
-   - password matches
-
-6. **Log in the user**:
-   ```python
-   login_user(user)
-   ```
-   Creates session cookie with encrypted user ID.
-
-7. **Redirect to next page**:
-   ```python
-   next_page = request.args.get("next")
-   return redirect(next_page or url_for("regattas.index"))
-   ```
-   If user was redirected to login from a protected page, return them there.
-   Otherwise go to main page.
-
-8. **Show error on failure**:
-   ```python
-   flash("Invalid email or password.", "error")
-   ```
-   Flash message appears on next page render.
+The `next` parameter handles the common case where a user visits a protected
+page while logged out — after login, they're redirected back to the page
+they originally wanted.
 
 ## Logout Route
-File: race-crew-network/app/auth/routes.py:29-33 (current line numbers)
+File: race-crew-network/app/auth/routes.py:105-109
 
 ```python
 @bp.route("/logout")
@@ -162,24 +105,143 @@ def logout():
     return redirect(url_for("auth.login"))
 ```
 
-@login_required ensures only authenticated users can logout. logout_user()
-clears the session cookie.
+`logout_user()` clears the session cookie.
 
 # Part 3: Invite-Based Registration
 
-## Why Invite-Based?
-This app doesn't have public registration. Admins must invite users by email.
-This prevents spam accounts and keeps the app private.
+## Registration with Auto-Link and Avatar
 
-## Invite Flow
-1. Admin enters email on /admin/users page
-2. System creates User with invite_token set
-3. Admin copies invite link and sends to person
-4. Person visits link, sets name/initials/password
-5. invite_token is cleared, marking registration complete
+File: race-crew-network/app/auth/routes.py:112-164
 
-## Creating an Invite
-File: race-crew-network/app/auth/routes.py:122-153 (current line numbers)
+```python
+@bp.route("/register/<token>", methods=["GET", "POST"])
+def register(token: str):
+    user = User.query.filter_by(invite_token=token).first_or_404()
+
+    if request.method == "POST":
+        # ... validation ...
+        user.display_name = display_name
+        user.initials = initials
+        user.set_password(password)
+        user.invite_token = None  # Mark registration complete
+        if not user.avatar_seed:
+            user.avatar_seed = User.generate_avatar_seed()
+
+        # Auto-link to inviting skipper's crew
+        inviter = None
+        if user.invited_by:
+            inviter = db.session.get(User, user.invited_by)
+            if inviter and inviter.is_skipper:
+                if user not in inviter.crew_members.all():
+                    inviter.crew_members.append(user)
+
+        db.session.commit()
+
+        # Notify the skipper that crew member joined
+        if inviter and inviter.is_skipper:
+            notify_crew_joined(user, inviter)
+
+        login_user(user)
+        flash("Welcome aboard!", "success")
+        return redirect(url_for("regattas.index"))
+```
+
+Three things happen beyond basic registration:
+
+1. **Avatar seed generation**: `User.generate_avatar_seed()` creates a random
+   seed for the Multiavatar SVG library (Day 14). This gives every user a
+   unique avatar from the moment they register.
+
+2. **Auto-link to skipper**: If the user was invited by a skipper (via
+   `invited_by` foreign key), they're automatically added to that skipper's
+   crew. The `crew_members.append(user)` manipulates the skipper_crew
+   association table (Day 9).
+
+3. **Crew joined notification**: The inviting skipper receives an email that
+   their crew member has completed registration (Day 11).
+
+# Part 4: User Profile Management
+
+## Profile with Image Upload and Preferences
+
+File: race-crew-network/app/auth/routes.py:167-273
+
+The profile route handles multiple concerns:
+
+```python
+@bp.route("/profile", methods=["GET", "POST"])
+@login_required
+def profile():
+    if request.method == "POST":
+        # Basic info: display_name, initials, email, phone
+        # Password change (optional)
+        # Profile image upload/remove
+        # Email opt-in
+        # Notification preferences (rsvp_notification, rsvp_delivery)
+        # Digest flush on mode switch
+```
+
+### Profile Image Upload
+
+```python
+profile_image = request.files.get("profile_image")
+remove_profile_image = request.form.get("remove_profile_image") == "on"
+
+if profile_image and profile_image.filename:
+    new_image_key = _upload_profile_image(profile_image)
+    current_user.profile_image_key = new_image_key
+elif remove_profile_image:
+    current_user.profile_image_key = None
+```
+
+The `_upload_profile_image()` helper (lines 47-64) validates the file:
+- Extension must be jpg, jpeg, png, gif, or webp
+- Size must be under the configured limit (default 10 MB)
+- Stored with a UUID filename under `profile-images/` to prevent conflicts
+
+Old images are cleaned up after a successful commit:
+
+```python
+if old_image_key and old_image_key != current_user.profile_image_key:
+    storage.delete_file(old_image_key)
+```
+
+### Notification Preferences
+
+```python
+prefs["rsvp_notification"] = request.form.get("rsvp_notification") == "on"
+rsvp_delivery = request.form.get("rsvp_delivery", "per_rsvp")
+if rsvp_delivery in ("per_rsvp", "digest"):
+    prefs["rsvp_delivery"] = rsvp_delivery
+current_user.notification_prefs = json.dumps(prefs)
+```
+
+The profile page lets users configure:
+- **rsvp_notification**: Whether to receive RSVP alerts (skippers only)
+- **rsvp_delivery**: Per-RSVP (instant) or digest (daily batch) mode
+- **email_opt_in**: Global email opt-in/out
+
+### Digest Flush on Mode Switch
+
+```python
+switching_to_instant = (
+    old_prefs.get("rsvp_delivery") == "digest"
+    and prefs.get("rsvp_delivery") == "per_rsvp"
+)
+# ... after commit ...
+if switching_to_instant:
+    flush_skipper_digest(current_user)
+    flush_crew_digest(current_user)
+```
+
+When switching from digest to instant mode, any pending digest items are
+sent immediately so they're not lost (Day 11).
+
+# Part 5: Admin User Management
+
+## Inviting Users
+
+File: race-crew-network/app/auth/routes.py:310-355
 
 ```python
 @bp.route("/admin/users/invite", methods=["POST"])
@@ -189,17 +251,7 @@ def invite_user():
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
-    import secrets
-
-    email = request.form.get("email", "").strip().lower()
-    if not email:
-        flash("Email is required.", "error")
-        return redirect(url_for("auth.admin_users"))
-
-    if User.query.filter_by(email=email).first():
-        flash("A user with that email already exists.", "error")
-        return redirect(url_for("auth.admin_users"))
-
+    is_skipper = request.form.get("is_skipper") == "on"
     token = secrets.token_urlsafe(32)
     user = User(
         email=email,
@@ -207,234 +259,84 @@ def invite_user():
         display_name=email,
         initials="??",
         invite_token=token,
+        is_skipper=is_skipper,
+        invited_by=current_user.id,
+        avatar_seed=User.generate_avatar_seed(),
     )
     db.session.add(user)
     db.session.commit()
 
-    invite_url = url_for("auth.register", token=token, _external=True)
-    flash(f"Invite link: {invite_url}", "success")
-    return redirect(url_for("auth.admin_users"))
+    send_email_invite = request.form.get("send_email_invite") == "on"
+    if send_email_invite and is_email_configured():
+        _send_invite_email(email, invite_url, current_user.display_name)
+    else:
+        flash(f"Invite link: {invite_url}", "success")
 ```
 
-KEY POINTS:
-- **Admin check**: Only admins can invite
-- **Token generation**: secrets.token_urlsafe(32) creates a random 32-byte token
-- **Placeholder data**: User created with temporary values
-- **_external=True**: Generates full URL with domain
-
-## Completing Registration
-File: race-crew-network/app/auth/routes.py:36-64 (current line numbers)
-
-```python
-@bp.route("/register/<token>", methods=["GET", "POST"])
-def register(token: str):
-    user = User.query.filter_by(invite_token=token).first_or_404()
-
-    if request.method == "POST":
-        display_name = request.form.get("display_name", "").strip()
-        initials = request.form.get("initials", "").strip().upper()
-        password = request.form.get("password", "")
-        password2 = request.form.get("password2", "")
-
-        if not display_name or not initials:
-            flash("Name and initials are required.", "error")
-        elif len(initials) < 2 or len(initials) > 3:
-            flash("Initials must be 2-3 characters.", "error")
-        elif len(password) < 6:
-            flash("Password must be at least 6 characters.", "error")
-        elif password != password2:
-            flash("Passwords do not match.", "error")
-        else:
-            user.display_name = display_name
-            user.initials = initials
-            user.set_password(password)
-            user.invite_token = None  # Mark registration complete
-            db.session.commit()
-            login_user(user)
-            flash("Welcome aboard!", "success")
-            return redirect(url_for("regattas.index"))
-
-    return render_template("register.html", user=user)
-```
-
-VALIDATION CHAIN:
-1. Find user by token (404 if not found)
-2. Validate all required fields present
-3. Validate initials length (2-3 characters)
-4. Validate password length (minimum 6)
-5. Validate passwords match
-6. Update user and clear invite_token
-7. Log user in automatically
-8. Redirect to main page
-
-# Part 4: User Profile Management
-
-## Profile Editing
-File: race-crew-network/app/auth/routes.py:67-98 (current line numbers)
-
-Users can edit their own profile. Key features:
-- Change display name, initials, email
-- Optional password change
-- Optional phone number
-- Email uniqueness validation
-
-```python
-@bp.route("/profile", methods=["GET", "POST"])
-@login_required
-def profile():
-    if request.method == "POST":
-        # ... validation ...
-
-        current_user.display_name = display_name
-        current_user.initials = initials
-        current_user.email = email
-        current_user.phone = request.form.get("phone", "").strip() or None
-
-        if password:
-            current_user.set_password(password)
-
-        db.session.commit()
-        flash("Profile updated.", "success")
-        return redirect(url_for("auth.profile"))
-
-    return render_template("profile.html")
-```
-
-OPTIONAL PASSWORD CHANGE:
-```python
-if password:
-    current_user.set_password(password)
-```
-Password only updated if provided. Allows users to change other fields without
-changing password.
-
-EMAIL UNIQUENESS CHECK:
-```python
-elif email != current_user.email and User.query.filter_by(email=email).first():
-    flash("That email is already in use.", "error")
-```
-Only check if email changed. Allows user to submit form without changing email.
-
-# Part 5: Admin User Management
-
-## Admin-Only Routes
-All admin routes start with the same authorization check:
-
-```python
-if not current_user.is_admin:
-    flash("Access denied.", "error")
-    return redirect(url_for("regattas.index"))
-```
-
-This is manual authorization checking. Some frameworks have decorators for
-this, but explicit checks work fine for small apps.
-
-## User Listing
-File: race-crew-network/app/auth/routes.py:111-119 (current line numbers)
-
-```python
-@bp.route("/admin/users")
-@login_required
-def admin_users():
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
-
-    users = User.query.order_by(User.display_name).all()
-    return render_template("admin_users.html", users=users)
-```
-
-Shows all users sorted by name. Includes pending invites (invite_token set).
-
-## Editing Other Users
-File: race-crew-network/app/auth/routes.py:156-195 (current line numbers)
-
-Admins can:
-- Change any user's name, initials, email
-- Toggle admin status
-- Reset passwords
-- Cannot delete themselves
-
-```python
-user.is_admin = is_admin
-```
-This allows admins to promote/demote users.
+Admin invites are richer than crew invites (Day 9):
+- **is_skipper flag**: Admin can mark invitees as skippers
+- **Email invite option**: If email is configured, send the invite via SES
+- **Fallback**: If email fails or isn't configured, show the invite link
 
 ## Deleting Users
-File: race-crew-network/app/auth/routes.py:198-215 (current line numbers)
+
+File: race-crew-network/app/auth/routes.py:450-484
+
+User deletion includes comprehensive cascade cleanup:
 
 ```python
-@bp.route("/admin/users/<int:user_id>/delete", methods=["POST"])
+# Delete profile image from storage
+if user.profile_image_key:
+    storage.delete_file(user.profile_image_key)
+
+# Delete regattas created by this user (cascades their docs & RSVPs)
+for regatta in Regatta.query.filter_by(created_by=user.id).all():
+    db.session.delete(regatta)
+
+# Delete user's own RSVPs and uploaded documents
+RSVP.query.filter_by(user_id=user.id).delete()
+Document.query.filter_by(uploaded_by=user.id).delete()
+
+# Clean up skipper_crew associations (both directions)
+db.session.execute(
+    skipper_crew.delete().where(
+        (skipper_crew.c.skipper_id == user.id)
+        | (skipper_crew.c.crew_id == user.id)
+    )
+)
+db.session.delete(user)
+```
+
+The cascade cleans up everything: storage files, regattas (which cascade
+their own documents and RSVPs), the user's own RSVPs, documents, and all
+crew associations in both directions.
+
+## Impersonation
+
+File: race-crew-network/app/auth/routes.py:487-524
+
+```python
+@bp.route("/admin/users/<int:user_id>/impersonate", methods=["POST"])
 @login_required
-def delete_user(user_id: int):
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
+def impersonate(user_id: int):
+    session["impersonating_admin_id"] = current_user.id
+    login_user(target)
+    flash(f"You are now viewing as {target.display_name}.", "info")
+    return redirect(url_for("regattas.index"))
 
-    user = db.session.get(User, user_id)
-    if not user:
-        flash("User not found.", "error")
-    elif user.id == current_user.id:
-        flash("You cannot delete yourself.", "error")
-    else:
-        db.session.delete(user)
-        db.session.commit()
-        flash(f"User {user.display_name} deleted.", "success")
-
-    return redirect(url_for("auth.admin_users"))
-```
-
-SAFETY CHECK:
-```python
-elif user.id == current_user.id:
-    flash("You cannot delete yourself.", "error")
-```
-Prevents admins from accidentally locking themselves out.
-
-# Part 6: Authentication vs Authorization
-
-## Authentication
-**Who are you?** Proving identity via login credentials.
-
-In this app:
-- Flask-Login manages sessions
-- login_user() creates session
-- current_user provides identity
-- @login_required ensures authentication
-
-## Authorization
-**What can you do?** Determining permissions based on identity.
-
-In this app:
-- is_admin boolean on User model
-- Manual checks: `if not current_user.is_admin`
-- Two roles: Admin (full access) and Crew (view + RSVP)
-
-## Protection Patterns
-
-**Require login**:
-```python
+@bp.route("/admin/stop-impersonation", methods=["POST"])
 @login_required
-def some_route():
-    # Only authenticated users
+def stop_impersonation():
+    admin_id = session.pop("impersonating_admin_id", None)
+    admin_user = db.session.get(User, admin_id)
+    login_user(admin_user)
+    flash("Returned to your account.", "success")
 ```
 
-**Require admin**:
-```python
-@login_required
-def admin_route():
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
-    # Only admins past this point
-```
-
-**Owner-only access**:
-```python
-if resource.owner_id != current_user.id:
-    flash("Access denied.", "error")
-    return redirect(...)
-```
+Impersonation stores the real admin's ID in the session, then logs in as the
+target user. The base template shows a yellow warning banner when
+`impersonating_admin_id` is in the session (Day 14). Stopping impersonation
+pops the admin ID and re-logs in as the admin.
 
 # Key Takeaways
 
@@ -444,19 +346,20 @@ if resource.owner_id != current_user.id:
 2. **Login validates three things**: user exists, registration is complete
    (invite_token is None), and password matches.
 
-3. **Invite-based registration** uses random tokens to prevent public sign-ups.
-   Admins create User with token, invitee completes registration via link.
+3. **Registration auto-links to the inviting skipper** and generates a unique
+   avatar seed. The `notify_crew_joined` notification tells the skipper their
+   crew member registered.
 
-4. **Flash messages provide feedback** to users. They persist across one
-   redirect and then disappear.
+4. **Profile management** handles image uploads with validation, notification
+   preferences with JSON storage, and digest flush on delivery mode switches.
 
-5. **Authorization is separate from authentication**. @login_required handles
-   authentication, manual checks handle authorization.
-
-6. **Password changes are optional** in profile editing. Only update password
-   if provided.
+5. **Admin user management** includes email invites with fallback, skipper
+   flag on invite, comprehensive cascade delete, and session-based
+   impersonation for debugging user views.
 
 ## What's Next?
-In Day 5, we'll explore regatta management with full CRUD operations. You'll
-see how to create, read, update, and delete regattas, with form processing
-and date handling.
+In Day 5, we'll explore the multi-user role system in depth — Admin, Skipper,
+and Crew roles, the permissions.py helper functions and decorators, admin
+impersonation flow, and role-based UI visibility in templates.
+
+See you in Day 5!

--- a/training/05-day5.md
+++ b/training/05-day5.md
@@ -1,323 +1,599 @@
-# Day 5: Regatta Management (CRUD Operations)
+# Day 5: Multi-User Role System & Permissions
 
 ## Learning Objectives
-
 By the end of this session, you will understand:
-- RESTful route design in Flask
-- Create, Read, Update, Delete (CRUD) operations
-- Form processing with request.form
-- Date handling in Python
-- Permission checks for admin-only routes
-- Flash messages for user feedback
+- The three user roles (Admin, Skipper, Crew) and how they are stored in the database
+- How permission decorators gate access to routes
+- How helper functions check fine-grained permissions for individual resources
+- How `visible_regattas()` scopes data so users only see relevant events
+- How admin impersonation works and why it is useful for debugging
+- How role-based UI in templates shows and hides navigation elements
 
 ## Concepts Covered
-
-- CRUD pattern
-- RESTful routing
-- Form validation
-- Date parsing with fromisoformat()
-- Conditional logic in save operations
-- URL generation with url_for()
+- Role-based access control (RBAC)
+- Python decorator pattern for route protection
+- Data scoping: restricting query results by role
+- Session-based impersonation with safe restore
+- Conditional template rendering with Jinja2
 
 ## File Focus
+For this session, examine these files:
+- app/permissions.py — Decorators and helper functions for role checks
+- app/models.py — User model with role flags and visibility scoping
+- app/auth/routes.py — Impersonation routes (lines 487-524)
+- app/templates/base.html — Role-based navbar and impersonation banner
 
-For this session, examine:
-- race-crew-network/app/regattas/routes.py - CRUD operations
+# Part 1: The Three Roles
 
-# Part 1: RESTful Routing
+## Role Definitions
 
-## CRUD Operations
+Race Crew Network has three distinct user roles. Each role is determined
+by fields on the `User` model, not by a separate roles table. This keeps
+the permission model simple and query-friendly.
 
-**Create**: Add new regatta
-**Read**: View regatta list
-**Update**: Edit existing regatta
-**Delete**: Remove regatta
-
-## Routes in This App
-
-| Operation    | HTTP Method | Route                    | Function      |
-|--------------|-------------|--------------------------|---------------|
-| Read         | GET         | /                        | index()       |
-| PDF          | GET         | /schedule.pdf            | pdf()         |
-| Create       | GET         | /regattas/new            | create()      |
-| Create       | POST        | /regattas/new            | create()      |
-| Update       | GET         | /regattas/<id>/edit      | edit()        |
-| Update       | POST        | /regattas/<id>/edit      | edit()        |
-| Delete       | POST        | /regattas/<id>/delete    | delete()      |
-| Bulk Delete  | POST        | /regattas/bulk-delete    | bulk_delete() |
-
-GET shows forms, POST processes them.
-
-# Part 2: Read (Index)
-
-## Index Route
-
-File: race-crew-network/app/regattas/routes.py:16-35
+File: app/models.py:24-33
 
 ```python
-@bp.route("/")
-def index():
-    if not current_user.is_authenticated:
-        return render_template("login.html")
+class User(UserMixin, db.Model):
+    __tablename__ = "users"
 
-    today = date.today()
-    upcoming = (
-        Regatta.query.filter(Regatta.start_date >= today)
-        .order_by(Regatta.start_date)
-        .all()
-    )
-    past = (
-        Regatta.query.filter(Regatta.start_date < today)
-        .order_by(Regatta.start_date.desc())
-        .all()
-    )
-    users = User.query.filter(User.invite_token.is_(None)).order_by(User.display_name).all()
-    return render_template("index.html", upcoming=upcoming, past=past, users=users)
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    is_admin = db.Column(db.Boolean, default=False, nullable=False)
+    is_skipper = db.Column(db.Boolean, default=False, nullable=False)
 ```
 
-NOTE: The index route serves the login page for anonymous users instead of
-redirecting. This avoids an ugly /login?next=%2F URL and provides a cleaner
-user experience.
+The three roles are:
 
-QUERYING PATTERNS:
-- **filter()**: WHERE clause conditions
-- **order_by()**: Sort results
-- **.desc()**: Descending order
-- **.all()**: Execute and return list
+1. **Admin** (`is_admin=True`): Full access to everything. Admins are
+   implicitly skippers too -- they can create events, manage crew, and
+   access all administrative functions.
 
-SPLITTING UPCOMING AND PAST:
+2. **Skipper** (`is_skipper=True`): Can create and manage their own events,
+   invite and manage their own crew, and send notifications. Cannot access
+   admin features like user management or site settings.
+
+3. **Crew**: A user who is not a skipper and not an admin. Crew members
+   are linked to one or more skippers through the `skipper_crew`
+   association table. They can view their skipper's schedule, RSVP to
+   events, and manage their own profile.
+
+## The Crew Relationship
+
+Crew membership is a self-referential many-to-many relationship on the
+`User` model. A skipper has crew members, and a crew member can belong
+to multiple skippers.
+
+File: app/models.py:10-21
+
 ```python
-today = date.today()
-upcoming = Regatta.query.filter(Regatta.start_date >= today)...
-past = Regatta.query.filter(Regatta.start_date < today)...
+skipper_crew = db.Table(
+    "skipper_crew",
+    db.Column("skipper_id", db.Integer, db.ForeignKey("users.id"),
+              primary_key=True),
+    db.Column("crew_id", db.Integer, db.ForeignKey("users.id"),
+              primary_key=True),
+    db.Column("created_at", db.DateTime,
+              default=lambda: datetime.now(timezone.utc), nullable=False),
+)
 ```
 
-Past regattas show most recent first (.desc()), upcoming show nearest first.
+The relationship is defined on the `User` model with a `backref` so it
+works in both directions:
 
-# Part 3: Create
-
-## Create Route
-
-File: race-crew-network/app/regattas/routes.py:65-75
+File: app/models.py:52-60
 
 ```python
-@bp.route("/regattas/new", methods=["GET", "POST"])
+crew_members = db.relationship(
+    "User",
+    secondary=skipper_crew,
+    primaryjoin=id == skipper_crew.c.skipper_id,
+    secondaryjoin=id == skipper_crew.c.crew_id,
+    backref="skippers",
+    lazy="dynamic",
+)
+```
+
+This gives us two properties per user:
+- `user.crew_members` -- the crew this skipper manages (dynamic query)
+- `user.skippers` -- the skippers this crew member belongs to (list)
+
+The `is_crew` property uses the backref to determine if a user is crew
+for at least one skipper:
+
+File: app/models.py:86-88
+
+```python
+@property
+def is_crew(self) -> bool:
+    """True if this user is crew for at least one skipper."""
+    return len(self.skippers) > 0
+```
+
+## Role Hierarchy Diagram
+
+```
++-------------------------------------------------------+
+|                       ADMIN                            |
+|   is_admin = True                                      |
+|   - All skipper abilities (implicitly a skipper)       |
+|   - User management, site settings, AI import          |
+|   - Impersonate any user                               |
+|   - Can manage ALL events (any owner)                  |
++-------------------------------------------------------+
+        |
+        v
++-------------------------------------------------------+
+|                      SKIPPER                           |
+|   is_skipper = True                                    |
+|   - Create / edit / delete OWN events                  |
+|   - Invite and manage crew                             |
+|   - Send notifications to crew                         |
+|   - View RSVP responses                                |
++-------------------------------------------------------+
+        |
+        v (skipper_crew association)
++-------------------------------------------------------+
+|                       CREW                             |
+|   on a skipper's crew_members list                     |
+|   - View skipper's schedule                            |
+|   - RSVP to skipper's events                           |
+|   - Download documents                                 |
+|   - Manage own profile                                 |
++-------------------------------------------------------+
+```
+
+# Part 2: Permission Decorators
+
+## require_admin
+
+The `require_admin` decorator is the simplest gate. It blocks any
+non-admin user and redirects them to the schedule page with an error
+flash message.
+
+File: app/permissions.py:9-19
+
+```python
+def require_admin(f):
+    """Decorator: deny access unless current_user is admin."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not current_user.is_admin:
+            flash("Access denied.", "error")
+            return redirect(url_for("regattas.index"))
+        return f(*args, **kwargs)
+
+    return decorated
+```
+
+Usage in a route is straightforward -- stack it below `@login_required`:
+
+```python
+@bp.route("/admin/users")
 @login_required
-def create():
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
-
-    if request.method == "POST":
-        return _save_regatta(None)
-
-    return render_template("regatta_form.html", regatta=None)
+@require_admin
+def admin_users():
+    ...
 ```
 
-PATTERN:
-- GET: Show empty form (regatta=None)
-- POST: Process form via _save_regatta()
-- Admin check at top
+The decorator order matters. `@login_required` runs first (outermost),
+ensuring the user is authenticated. Then `@require_admin` checks the
+role. If either check fails, the request is redirected before the view
+function runs.
 
-## Save Function
+## require_skipper
 
-File: race-crew-network/app/regattas/routes.py:250-293
+The `require_skipper` decorator is slightly broader. It allows both
+admins and skippers through, since admins are implicitly skippers.
+
+File: app/permissions.py:22-32
 
 ```python
-def _save_regatta(regatta: Regatta | None):
-    name = request.form.get("name", "").strip()
-    boat_class = request.form.get("boat_class", "").strip() or "TBD"
-    location = request.form.get("location", "").strip()
-    location_url = request.form.get("location_url", "").strip()
-    start_date_str = request.form.get("start_date", "")
-    end_date_str = request.form.get("end_date", "")
-    notes = request.form.get("notes", "").strip()
-    source_url = request.form.get("source_url", "").strip()
+def require_skipper(f):
+    """Decorator: deny access unless current_user is skipper or admin."""
 
-    if not name or not location or not start_date_str:
-        flash("Name, location, and start date are required.", "error")
-        return render_template("regatta_form.html", regatta=regatta)
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not (current_user.is_admin or current_user.is_skipper):
+            flash("Access denied.", "error")
+            return redirect(url_for("regattas.index"))
+        return f(*args, **kwargs)
 
-    try:
-        start_date = date.fromisoformat(start_date_str)
-        end_date = date.fromisoformat(end_date_str) if end_date_str else None
-    except ValueError:
-        flash("Invalid date format.", "error")
-        return render_template("regatta_form.html", regatta=regatta)
-
-    if regatta is None:
-        regatta = Regatta(created_by=current_user.id)
-        db.session.add(regatta)
-
-    regatta.name = name
-    regatta.boat_class = boat_class
-    regatta.location = location
-    if location_url:
-        regatta.location_url = location_url
-    else:
-        regatta.location_url = f"https://www.google.com/maps/search/{quote_plus(location)}"
-    regatta.start_date = start_date
-    regatta.end_date = end_date
-    regatta.notes = notes or None
-    regatta.source_url = source_url or None
-
-    db.session.commit()
-    flash(f"Regatta '{name}' saved.", "success")
-    return redirect(url_for("regattas.index"))
+    return decorated
 ```
 
-FORM EXTRACTION:
+Notice the `or` condition: `current_user.is_admin or current_user.is_skipper`.
+This is the convention throughout the codebase -- admin always passes
+skipper-level checks.
+
+## When Decorators Are Not Enough
+
+Decorators answer a binary question: "Can this user access this route at
+all?" But sometimes we need a finer-grained check: "Can this user modify
+*this specific* regatta?" That requires inspecting the resource, which
+is where helper functions come in.
+
+# Part 3: Permission Helper Functions
+
+## can_manage_regatta
+
+This function checks if a user can edit or delete a specific regatta.
+Admins can manage any event. Skippers can only manage events they created.
+
+File: app/permissions.py:35-39
+
 ```python
-name = request.form.get("name", "").strip()
+def can_manage_regatta(user, regatta) -> bool:
+    """True if user can edit/delete this regatta (owner or admin)."""
+    if user.is_admin:
+        return True
+    return user.is_skipper and regatta.created_by == user.id
 ```
-request.form is a dict-like object with form data. .get() with default avoids KeyError.
 
-DATE PARSING:
-```python
-start_date = date.fromisoformat(start_date_str)
-```
-Converts "2024-01-15" to date object. Raises ValueError if invalid.
+The edit route demonstrates the inline pattern -- fetch the resource,
+then call the helper:
 
-CREATE VS UPDATE:
-```python
-if regatta is None:
-    regatta = Regatta(created_by=current_user.id)
-    db.session.add(regatta)
-```
-If None, create new. Otherwise update existing.
-
-AUTO-GENERATED GOOGLE MAPS:
-```python
-if location_url:
-    regatta.location_url = location_url
-else:
-    regatta.location_url = f"https://www.google.com/maps/search/{quote_plus(location)}"
-```
-If no URL provided, generate Google Maps search link.
-
-# Part 4: Update
-
-## Edit Route
-
-File: race-crew-network/app/regattas/routes.py:78-93
+File: app/regattas/routes.py:160-170
 
 ```python
 @bp.route("/regattas/<int:regatta_id>/edit", methods=["GET", "POST"])
 @login_required
 def edit(regatta_id: int):
-    if not current_user.is_admin:
-        flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
-
     regatta = db.session.get(Regatta, regatta_id)
     if not regatta:
-        flash("Regatta not found.", "error")
+        flash("Event not found.", "error")
         return redirect(url_for("regattas.index"))
 
-    if request.method == "POST":
-        return _save_regatta(regatta)
-
-    return render_template("regatta_form.html", regatta=regatta)
+    if not can_manage_regatta(current_user, regatta):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
 ```
 
-KEY DIFFERENCE FROM CREATE:
-- Loads existing regatta: `db.session.get(Regatta, regatta_id)`
-- Passes to _save_regatta(regatta) instead of None
-- Same form template handles both create and edit
+This pattern repeats across the delete, bulk delete, upload document,
+and delete document routes. The decorator guards the door; the helper
+function guards the specific resource.
 
-# Part 5: Delete
+## can_rsvp_to_regatta
 
-## Delete Route
+RSVP permissions are more nuanced. A user can RSVP if they are:
+- An admin (always allowed)
+- The regatta owner (the skipper who created it)
+- A crew member of the regatta's creator
 
-File: race-crew-network/app/regattas/routes.py:96-108
+File: app/permissions.py:42-55
 
 ```python
-@bp.route("/regattas/<int:regatta_id>/delete", methods=["POST"])
+def can_rsvp_to_regatta(user, regatta) -> bool:
+    """True if user can RSVP to this regatta."""
+    if user.is_admin:
+        return True
+    if regatta.created_by == user.id:
+        return True
+    # Check if user is crew of the regatta creator
+    creator = regatta.creator
+    if creator and user in creator.crew_members.all():
+        return True
+    return False
+```
+
+This traverses the `creator` relationship on the regatta to find
+the skipper, then checks if the user is in that skipper's crew list.
+This ensures crew members can only RSVP to events from their own
+skipper, not events from unrelated skippers.
+
+## Permission Check Flow
+
+```
+Request arrives at a protected route
+           |
+           v
+  @login_required  -----> Not logged in? Redirect to login
+           |
+           v
+  @require_admin   -----> Not admin? Flash "Access denied"
+  (or @require_skipper)
+           |
+           v
+  Fetch resource (regatta, document, etc.)
+           |
+           v
+  can_manage_regatta()  --> Not owner/admin? Flash "Access denied"
+  (or can_rsvp_to_regatta())
+           |
+           v
+  Execute view logic
+```
+
+# Part 4: Data Scoping with visible_regattas
+
+## The Problem
+
+Without data scoping, every user would see every regatta in the system.
+Crew member Alice should only see events from her skipper Bob, not events
+from unrelated skipper Carol.
+
+## The Solution
+
+The `visible_regattas()` method on the `User` model builds a query
+filtered by ownership. It collects all skipper IDs that are relevant
+to this user and filters the Regatta table accordingly.
+
+File: app/models.py:105-122
+
+```python
+def visible_regattas(self):
+    """Return a query of regattas this user can see."""
+    owner_ids = set()
+    if self.is_skipper:
+        owner_ids.add(self.id)
+    for skipper in self.skippers:
+        owner_ids.add(skipper.id)
+
+    if not owner_ids:
+        return Regatta.query.filter(Regatta.id < 0)
+
+    return Regatta.query.filter(Regatta.created_by.in_(owner_ids))
+```
+
+How `owner_ids` gets built for each role:
+
+- **Admin who is also a skipper**: Contains the admin's own ID. Since
+  admins see all events through the UI's "All Schedules" option, the
+  index route handles admin differently (see Day 6).
+- **Skipper**: Contains the skipper's own ID.
+- **Crew member of one skipper**: Contains that skipper's ID.
+- **Crew member of multiple skippers**: Contains all their skippers' IDs.
+- **User with no role**: Returns an empty query (`Regatta.id < 0` matches nothing).
+
+The companion method `visible_regattas_split()` divides the results into
+upcoming and past events, sorted appropriately:
+
+File: app/models.py:124-136
+
+```python
+def visible_regattas_split(self):
+    """Return (upcoming, past) tuples of visible regattas."""
+    today = date.today()
+    base = self.visible_regattas()
+    upcoming = (
+        base.filter(Regatta.start_date >= today)
+            .order_by(Regatta.start_date).all()
+    )
+    past = (
+        base.filter(Regatta.start_date < today)
+            .order_by(Regatta.start_date.desc()).all()
+    )
+    return upcoming, past
+```
+
+This split is used directly in the index route and PDF generation route.
+
+# Part 5: Admin Impersonation
+
+## Why Impersonation?
+
+When a crew member reports a problem, the admin needs to see exactly what
+they see. Impersonation lets the admin temporarily log in as another user
+without knowing their password.
+
+## Starting Impersonation
+
+File: app/auth/routes.py:487-506
+
+```python
+@bp.route("/admin/users/<int:user_id>/impersonate", methods=["POST"])
 @login_required
-def delete(regatta_id: int):
+def impersonate(user_id: int):
     if not current_user.is_admin:
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
-    regatta = db.session.get(Regatta, regatta_id)
-    if regatta:
-        db.session.delete(regatta)
-        db.session.commit()
-        flash(f"Regatta '{regatta.name}' deleted.", "success")
+    if user_id == current_user.id:
+        flash("You cannot impersonate yourself.", "error")
+        return redirect(url_for("auth.admin_users"))
+
+    target = db.session.get(User, user_id)
+    if not target:
+        flash("User not found.", "error")
+        return redirect(url_for("auth.admin_users"))
+
+    session["impersonating_admin_id"] = current_user.id
+    login_user(target)
+    flash(f"You are now viewing as {target.display_name}.", "info")
     return redirect(url_for("regattas.index"))
 ```
 
-DELETE CASCADE:
-Remember from Day 3, Regatta has:
+The key line is `session["impersonating_admin_id"] = current_user.id`.
+Before switching users, the admin's own user ID is saved in the session.
+Then `login_user(target)` switches Flask-Login's `current_user` to the
+target user. From this point on, the app behaves exactly as if the
+target user had logged in.
+
+Safety checks prevent:
+- Non-admins from impersonating (manual `is_admin` check)
+- Admins from impersonating themselves (would create a broken session)
+- Impersonating nonexistent users
+
+## Stopping Impersonation
+
+File: app/auth/routes.py:509-524
+
 ```python
-documents = db.relationship(..., cascade="all, delete-orphan")
-rsvps = db.relationship(..., cascade="all, delete-orphan")
-```
-Deleting a regatta automatically deletes its documents and RSVPs.
-
-# Part 6: PDF Generation and Bulk Delete
-
-## PDF Schedule
-
-File: race-crew-network/app/regattas/routes.py:38-62
-
-```python
-@bp.route("/schedule.pdf")
+@bp.route("/admin/stop-impersonation", methods=["POST"])
 @login_required
-def pdf():
-    today = date.today()
-    upcoming = Regatta.query.filter(Regatta.start_date >= today)...
-    past = Regatta.query.filter(Regatta.start_date < today)...
-    html_str = render_template("pdf_schedule.html", upcoming=upcoming, past=past, ...)
-    pdf_bytes = HTML(string=html_str).write_pdf()
-    response = make_response(pdf_bytes)
-    response.headers["Content-Type"] = "application/pdf"
-    return response
+def stop_impersonation():
+    admin_id = session.pop("impersonating_admin_id", None)
+    if not admin_id:
+        flash("You are not impersonating anyone.", "warning")
+        return redirect(url_for("regattas.index"))
+
+    admin_user = db.session.get(User, admin_id)
+    if not admin_user:
+        flash("Original admin account not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    login_user(admin_user)
+    flash("Returned to your account.", "success")
+    return redirect(url_for("regattas.index"))
 ```
 
-This uses WeasyPrint to render an HTML template to PDF. The same query logic
-as the index route provides upcoming/past regattas for the PDF layout.
+`session.pop()` retrieves and removes the saved admin ID in one
+operation. The admin is then logged back in with `login_user(admin_user)`.
 
-## Bulk Delete
+## Impersonation Session Flow
 
-File: race-crew-network/app/regattas/routes.py:111-136
-
-Admins can select multiple regattas via checkboxes and delete them at once:
-
-```python
-@bp.route("/regattas/bulk-delete", methods=["POST"])
-@login_required
-def bulk_delete():
-    selected = request.form.getlist("selected")
-    ...
-    for regatta_id in selected:
-        regatta = db.session.get(Regatta, int(regatta_id))
-        if regatta:
-            db.session.delete(regatta)
-            count += 1
-    db.session.commit()
+```
+Admin clicks "Impersonate" on user management page
+    |
+    v
+session["impersonating_admin_id"] = admin.id
+login_user(target_user)
+    |
+    v
+current_user is now target_user
+Warning banner visible in all pages
+    |
+    v
+Admin clicks "Exit" on warning banner
+    |
+    v
+admin_id = session.pop("impersonating_admin_id")
+login_user(admin_user)
+    |
+    v
+current_user is admin again, banner disappears
 ```
 
-request.form.getlist() returns all values for checkboxes with the same name
-attribute, enabling multi-select operations.
+# Part 6: Role-Based UI in Templates
+
+## Navbar Visibility
+
+The base template uses Jinja2 conditionals to show different navigation
+items based on the current user's role.
+
+File: app/templates/base.html:37-49
+
+```html
+{% if current_user.is_admin or current_user.is_skipper %}
+<a class="nav-link nav-pill-link"
+   href="{{ url_for('auth.my_crew') }}">My Crew</a>
+{% endif %}
+{% if current_user.is_admin %}
+<li class="nav-item dropdown">
+    <a class="nav-link nav-pill-link dropdown-toggle" href="#"
+       role="button" data-bs-toggle="dropdown">Admin</a>
+    <ul class="dropdown-menu">
+        <li><a class="dropdown-item"
+               href="{{ url_for('auth.admin_users') }}">Users</a></li>
+        ...
+    </ul>
+</li>
+{% endif %}
+```
+
+What each role sees in the navbar:
+
+| Element          | Admin | Skipper | Crew |
+|------------------|-------|---------|------|
+| Home             | Yes   | Yes     | Yes  |
+| Calendar         | Yes   | Yes     | Yes  |
+| My Crew          | Yes   | Yes     | No   |
+| Admin dropdown   | Yes   | No      | No   |
+| Create Schedule  | No    | No      | Yes  |
+
+## Create My Schedule
+
+Crew-only users see a "Create My Schedule" option in their profile
+dropdown. This promotes them to skipper status so they can create their
+own events.
+
+File: app/templates/base.html:54-61
+
+```html
+{% if not current_user.is_skipper and not current_user.is_admin %}
+<li>
+    <form method="POST"
+          action="{{ url_for('auth.create_schedule') }}">
+        <input type="hidden" name="csrf_token"
+               value="{{ csrf_token() }}">
+        <button type="submit" class="dropdown-item">
+            Create My Schedule</button>
+    </form>
+</li>
+{% endif %}
+```
+
+This is a POST form (not a link) because it modifies server state -- it
+sets `is_skipper=True` on the user record.
+
+## Impersonation Banner
+
+When an admin is impersonating another user, a warning banner appears
+between the navbar and the page content.
+
+File: app/templates/base.html:72-80
+
+```html
+{% if session.get('impersonating_admin_id') %}
+<div class="alert alert-warning text-center mb-0 rounded-0 py-2">
+    <strong>Viewing as {{ current_user.display_name }}</strong> —
+    <form method="POST"
+          action="{{ url_for('auth.stop_impersonation') }}"
+          class="d-inline">
+        <input type="hidden" name="csrf_token"
+               value="{{ csrf_token() }}">
+        <button type="submit"
+                class="btn btn-sm btn-warning">Exit</button>
+    </form>
+</div>
+{% endif %}
+```
+
+This banner is always visible during impersonation because it checks the
+session directly, not the user's role. It provides a clear escape hatch
+with the "Exit" button that POSTs to the `stop_impersonation` route.
 
 # Key Takeaways
 
-1. **CRUD operations follow consistent patterns**: GET shows forms, POST
-   processes them. Shared logic in helper functions.
+1. **Roles are stored as boolean flags** (`is_admin`, `is_skipper`) on
+   the `User` model. Crew membership is a many-to-many relationship
+   through the `skipper_crew` table.
 
-2. **Form data comes from request.form**, a dict-like object. Always provide
-   defaults with .get() to handle missing fields.
+2. **Two decorator patterns** gate route access: `require_admin` for
+   admin-only routes, `require_skipper` for routes open to both admins
+   and skippers.
 
-3. **Date parsing with fromisoformat()** converts ISO format strings
-   ("2024-01-15") to date objects. Wrap in try/except for validation.
+3. **Two helper functions** check resource-level permissions:
+   `can_manage_regatta()` for edit/delete operations and
+   `can_rsvp_to_regatta()` for RSVP eligibility.
 
-4. **Flash messages provide feedback** to users after operations. They persist
-   across one redirect.
+4. **Data scoping via `visible_regattas()`** ensures users only see
+   events they should see -- their own events (as skipper) plus their
+   skippers' events (as crew).
 
-5. **Admin checks protect routes**. Manual checks work well for small apps.
+5. **Admin impersonation** saves the admin's ID in the session, switches
+   to the target user, and restores the admin when done. A persistent
+   warning banner ensures the admin knows they are impersonating.
+
+6. **Template conditionals** hide or show navbar items, dropdowns, and
+   action buttons based on role. This is defense-in-depth: even if a
+   user found the URL, the server-side permission checks would block
+   them.
 
 ## What's Next?
+In Day 6, we will explore how permissions apply in practice through
+the event management CRUD operations. You will see how `_save_regatta()`
+processes form data, how the index route builds filtered schedule views,
+and how bulk delete iterates with per-item permission checks.
 
-In Day 6, we'll explore the RSVP system and many-to-many relationships through
-the join table pattern.
+Questions to ponder:
+- Why does `can_rsvp_to_regatta()` check the regatta creator's crew list
+  instead of a global permission?
+- What would happen if `session["impersonating_admin_id"]` was not saved
+  before calling `login_user(target)`?
+- Why is `visible_regattas()` a method on the User model rather than a
+  standalone function in `permissions.py`?
+- How would you add a fourth role (e.g., "Race Committee") to this system?
+
+See you in Day 6!

--- a/training/06-day6.md
+++ b/training/06-day6.md
@@ -1,167 +1,501 @@
-# Day 6: RSVP System and Database Relationships
+# Day 6: Event Management (CRUD Operations)
 
 ## Learning Objectives
 By the end of this session, you will understand:
-- Many-to-many relationships via join tables
-- Upsert pattern (update or insert)
-- SQLAlchemy lazy loading strategies
-- Custom Jinja2 template filters
-- Status tracking and display logic
+- How the index route builds a filtered schedule view with skipper and RSVP filters
+- How create, edit, and delete routes enforce permissions at the resource level
+- How the `_save_regatta()` helper processes form data and auto-generates map links
+- How bulk delete iterates selected items with per-item permission checks
+- How flash messages provide user feedback throughout the CRUD lifecycle
+- How the permission model from Day 5 applies to real route handlers
 
 ## Concepts Covered
-- Many-to-many relationships
-- Join table pattern
-- Upsert operations
-- Template filters
-- Query optimization
+- CRUD (Create, Read, Update, Delete) pattern in Flask
+- Shared helper functions for form processing
+- Query-string filters for server-side list refinement
+- Bulk operations with per-item authorization
+- Flash messages for user feedback
+- Auto-generation of derived fields (Google Maps URLs)
 
 ## File Focus
-- race-crew-network/app/regattas/routes.py:139-159 - RSVP route
-- race-crew-network/app/models.py:96-112 - RSVP model
-- race-crew-network/app/__init__.py:46-51 - sort_rsvps filter
+For this session, examine these files:
+- app/regattas/routes.py — All CRUD routes, index, and helper functions
+- app/permissions.py — can_manage_regatta (from Day 5)
+- app/models.py — Regatta model and User.visible_regattas_split
 
-# Part 1: Many-to-Many Relationships
+# Part 1: The Index Route (Read)
 
-## The Relationship
-Users and Regattas have a many-to-many relationship:
-- One user can RSVP to many regattas
-- One regatta can have RSVPs from many users
+## Building the Schedule View
 
-This requires a join table: RSVP.
+The index route is the main landing page. It combines data scoping (from
+Day 5) with query-string filters to build a personalized schedule view.
 
-## RSVP Model Review
-File: race-crew-network/app/models.py:96-112
+File: app/regattas/routes.py:52-106
 
 ```python
-class RSVP(db.Model):
-    __tablename__ = "rsvps"
+@bp.route("/")
+def index():
+    if not current_user.is_authenticated:
+        return render_template("login.html")
 
-    id = db.Column(db.Integer, primary_key=True)
-    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"))
-    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
-    status = db.Column(db.String(10), nullable=False)  # yes, no, maybe
-    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
-
-    __table_args__ = (
-        db.UniqueConstraint("regatta_id", "user_id"),
+    upcoming, past = current_user.visible_regattas_split()
+    upcoming, past, skipper_id, rsvp_filters = _apply_schedule_filters(
+        upcoming, past, current_user
     )
 ```
 
-### Two Foreign Keys
-- regatta_id → links to Regatta
-- user_id → links to User
+The first call to `visible_regattas_split()` scopes the data by role (as
+covered in Day 5). Then `_apply_schedule_filters()` applies additional
+query-string filters on top of that scoped data.
 
-### Unique Constraint
-Ensures one user can only have one RSVP per regatta.
+## Schedule Filters
 
-# Part 2: RSVP Route (Upsert Pattern)
+The `_apply_schedule_filters()` function handles two filter types: skipper
+selection and RSVP status.
 
-## RSVP Route
-File: race-crew-network/app/regattas/routes.py:139-159
+File: app/regattas/routes.py:22-49
 
 ```python
-@bp.route("/regattas/<int:regatta_id>/rsvp", methods=["POST"])
+def _apply_schedule_filters(upcoming, past, user):
+    """Apply skipper and RSVP query-string filters."""
+    skipper_id = request.args.get("skipper", type=int)
+    if skipper_id is None and user.is_skipper:
+        skipper_id = user.id
+    if skipper_id:
+        upcoming = [r for r in upcoming if r.created_by == skipper_id]
+        past = [r for r in past if r.created_by == skipper_id]
+
+    rsvp_filters = [
+        v.lower()
+        for v in request.args.getlist("rsvp")
+        if v.lower() in ("yes", "no", "maybe")
+    ]
+    if rsvp_filters and set(rsvp_filters) != {"yes", "no", "maybe"}:
+        visible_ids = {r.id for r in upcoming + past}
+        rsvp_regatta_ids = {
+            r.regatta_id
+            for r in RSVP.query.filter(
+                RSVP.regatta_id.in_(visible_ids),
+                RSVP.status.in_(rsvp_filters),
+            ).all()
+        }
+        upcoming = [r for r in upcoming if r.id in rsvp_regatta_ids]
+        past = [r for r in past if r.id in rsvp_regatta_ids]
+
+    return upcoming, past, skipper_id, rsvp_filters
+```
+
+Key behaviors:
+- **Default skipper filter**: If no `?skipper=` param is in the URL and
+  the user is a skipper, default to showing their own events. This means
+  skippers land on their own schedule by default.
+- **skipper_id == 0**: Means "All Schedules" -- the user explicitly chose
+  to see all visible events. The `if skipper_id:` check is falsy for 0,
+  so no skipper filter is applied.
+- **RSVP filter**: Only applied if the filter is a proper subset of all
+  statuses. If the user selects all three (yes, no, maybe), it is the
+  same as no filter, so it is skipped for efficiency.
+
+## Building the Template Context
+
+The rest of the index route assembles context data for the template:
+
+File: app/regattas/routes.py:67-106
+
+```python
+    schedules = []
+    if current_user.is_skipper:
+        schedules.append(current_user)
+    for skipper in current_user.skippers:
+        if skipper.id != current_user.id:
+            schedules.append(skipper)
+
+    if current_user.is_skipper:
+        can_manage_any = skipper_id in (0, current_user.id) or not skipper_id
+    else:
+        can_manage_any = False
+
+    crew_list = []
+    if current_user.is_skipper:
+        crew_list = get_eligible_crew(current_user)
+
+    return render_template(
+        "index.html",
+        upcoming=upcoming,
+        past=past,
+        schedules=schedules,
+        selected_skipper=skipper_id,
+        can_manage_any=can_manage_any,
+        crew_list=crew_list,
+        show_calendar_banner=current_user.calendar_token is None,
+    )
+```
+
+The `schedules` list powers the schedule dropdown. It includes the user
+themselves (if skipper) plus all skippers they are crew for. The
+`can_manage_any` flag tells the template whether to show edit/delete
+controls -- a skipper can only manage events when viewing their own
+schedule (or "All Schedules"), not when viewing another skipper's events.
+
+## Index Route Data Flow
+
+```
+Browser requests GET /
+        |
+        v
+current_user.visible_regattas_split()
+  --> Scoped by role (Day 5)
+  --> Returns (upcoming, past)
+        |
+        v
+_apply_schedule_filters(upcoming, past, user)
+  --> ?skipper=N  --> Filter by creator
+  --> ?rsvp=yes   --> Filter by RSVP status
+  --> Returns filtered (upcoming, past, skipper_id, rsvp_filters)
+        |
+        v
+Build template context:
+  - schedules[]     --> For schedule dropdown
+  - can_manage_any  --> Show/hide edit controls
+  - crew_list[]     --> For "Notify Crew" modal
+  - pdf_url         --> PDF download link with current filters
+        |
+        v
+render_template("index.html", ...)
+```
+
+# Part 2: Create Route
+
+## Route Handler
+
+Creating an event requires the user to be an admin or a skipper. The
+route uses an inline check rather than the `require_skipper` decorator
+because the pattern is simple and the rest of the flow depends on it.
+
+File: app/regattas/routes.py:147-157
+
+```python
+@bp.route("/regattas/new", methods=["GET", "POST"])
 @login_required
-def rsvp(regatta_id: int):
-    status = request.form.get("status", "").lower()
-    if status not in ("yes", "no", "maybe"):
-        flash("Invalid RSVP status.", "error")
+def create():
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
-    existing = RSVP.query.filter_by(
-        regatta_id=regatta_id, user_id=current_user.id
-    ).first()
+    if request.method == "POST":
+        return _save_regatta(None)
 
-    if existing:
-        existing.status = status
+    return render_template("regatta_form.html", regatta=None)
+```
+
+On GET, the form is rendered with `regatta=None`, which tells the
+template to show empty fields. On POST, `_save_regatta(None)` is called
+with `None` to signal creation rather than update.
+
+# Part 3: Edit Route
+
+## Permission Check Pattern
+
+The edit route demonstrates the two-step authorization pattern: first
+check that the resource exists, then check that the user can manage it.
+
+File: app/regattas/routes.py:160-175
+
+```python
+@bp.route("/regattas/<int:regatta_id>/edit", methods=["GET", "POST"])
+@login_required
+def edit(regatta_id: int):
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta:
+        flash("Event not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if not can_manage_regatta(current_user, regatta):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if request.method == "POST":
+        return _save_regatta(regatta)
+
+    return render_template("regatta_form.html", regatta=regatta)
+```
+
+Notice that `_save_regatta(regatta)` receives the existing regatta object
+this time. The helper knows the difference between create and update by
+checking whether its argument is `None`.
+
+# Part 4: The _save_regatta Helper
+
+## Shared Form Processing
+
+The `_save_regatta()` helper is used by both create and edit routes. It
+handles form validation, date parsing, and auto-generation of the Google
+Maps link.
+
+File: app/regattas/routes.py:413-455
+
+```python
+def _save_regatta(regatta: Regatta | None):
+    name = request.form.get("name", "").strip()
+    boat_class = request.form.get("boat_class", "").strip()
+    location = request.form.get("location", "").strip()
+    location_url = request.form.get("location_url", "").strip()
+    start_date_str = request.form.get("start_date", "")
+    end_date_str = request.form.get("end_date", "")
+    notes = request.form.get("notes", "").strip()
+    source_url = request.form.get("source_url", "").strip()
+
+    if not name or not location or not start_date_str:
+        flash("Name, location, and start date are required.", "error")
+        return render_template("regatta_form.html", regatta=regatta)
+
+    try:
+        start_date = date.fromisoformat(start_date_str)
+        end_date = date.fromisoformat(end_date_str) if end_date_str else None
+    except ValueError:
+        flash("Invalid date format.", "error")
+        return render_template("regatta_form.html", regatta=regatta)
+
+    if regatta is None:
+        regatta = Regatta(created_by=current_user.id)
+        db.session.add(regatta)
+
+    regatta.name = name
+    regatta.boat_class = boat_class
+    regatta.location = location
+    if location_url:
+        regatta.location_url = location_url
     else:
-        db.session.add(
-            RSVP(regatta_id=regatta_id, user_id=current_user.id, status=status)
+        regatta.location_url = (
+            f"https://www.google.com/maps/search/{quote_plus(location)}"
         )
+    regatta.start_date = start_date
+    regatta.end_date = end_date
+    regatta.notes = notes or None
+    regatta.source_url = source_url or None
 
     db.session.commit()
+    flash(f"Event '{name}' saved.", "success")
     return redirect(url_for("regattas.index"))
 ```
 
-### Upsert Pattern
+Key design decisions:
+
+1. **Create vs Update**: When `regatta is None`, a new `Regatta` is
+   created and added to the session. When an existing regatta is passed,
+   its fields are updated in place.
+
+2. **Google Maps auto-generation**: If the user does not provide a
+   `location_url`, one is automatically generated using the location text.
+   `quote_plus()` URL-encodes the location string for the Google Maps
+   search URL.
+
+3. **Validation with re-render**: If required fields are missing or dates
+   are invalid, the form is re-rendered (not redirected) so the user's
+   input is preserved. The `regatta` object is passed back to the template
+   to repopulate fields.
+
+4. **created_by assignment**: On create, `created_by` is set to
+   `current_user.id`. This establishes ownership, which is used by
+   `can_manage_regatta()` for all future permission checks.
+
+## Create vs Update Flow
+
+```
+_save_regatta(regatta)
+        |
+        v
+  Parse form fields, validate
+        |
+  Missing required? --> Re-render form with error flash
+        |
+  Invalid date? ------> Re-render form with error flash
+        |
+        v
+  regatta is None?
+    YES --> Regatta(created_by=current_user.id)
+            db.session.add(regatta)
+    NO  --> Update existing fields in place
+        |
+        v
+  Set location_url:
+    Provided? --> Use it
+    Empty?    --> Auto-generate Google Maps link
+        |
+        v
+  db.session.commit()
+  flash("Event saved.", "success")
+  redirect to index
+```
+
+# Part 5: Delete Route
+
+## Single Delete
+
+The delete route follows the same fetch-then-check pattern as edit.
+
+File: app/regattas/routes.py:178-193
+
 ```python
-existing = RSVP.query.filter_by(...).first()
+@bp.route("/regattas/<int:regatta_id>/delete", methods=["POST"])
+@login_required
+def delete(regatta_id: int):
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta:
+        return redirect(url_for("regattas.index"))
 
-if existing:
-    existing.status = status      # UPDATE
-else:
-    db.session.add(RSVP(...))    # INSERT
+    if not can_manage_regatta(current_user, regatta):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if regatta:
+        db.session.delete(regatta)
+        db.session.commit()
+        flash(f"Event '{regatta.name}' deleted.", "success")
+    return redirect(url_for("regattas.index"))
 ```
 
-This is "upsert": update if exists, insert if not.
+The route is POST-only (`methods=["POST"]`) because delete operations
+should never be triggered by a GET request. This prevents accidental
+deletion from browser prefetch or link crawlers.
 
-### Why Upsert?
-The unique constraint prevents duplicate RSVPs. Upsert allows users to change
-their status without creating duplicate entries.
+Because the Regatta model defines `cascade="all, delete-orphan"` on its
+`documents` and `rsvps` relationships (see Day 3), deleting a regatta
+automatically removes its documents and RSVPs.
 
-# Part 3: Template Filter
+## Bulk Delete
 
-## sort_rsvps Filter
-File: race-crew-network/app/__init__.py:46-51
+Bulk delete allows skippers to select multiple events and delete them
+in one action. Each selected event is checked individually.
+
+File: app/regattas/routes.py:196-221
 
 ```python
-@app.template_filter("sort_rsvps")
-def sort_rsvps(rsvps):
-    order = {"yes": 0, "no": 1, "maybe": 2}
-    return sorted(rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name))
+@bp.route("/regattas/bulk-delete", methods=["POST"])
+@login_required
+def bulk_delete():
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    selected = request.form.getlist("selected")
+    if not selected:
+        flash("No events selected.", "warning")
+        return redirect(url_for("regattas.index"))
+
+    count = 0
+    for regatta_id in selected:
+        try:
+            rid = int(regatta_id)
+        except (ValueError, TypeError):
+            continue
+        regatta = db.session.get(Regatta, rid)
+        if regatta and can_manage_regatta(current_user, regatta):
+            db.session.delete(regatta)
+            count += 1
+
+    db.session.commit()
+    flash(f"Deleted {count} event(s).", "success")
+    return redirect(url_for("regattas.index"))
 ```
 
-### Usage in Templates
-```html
-{% for rsvp in regatta.rsvps|sort_rsvps %}
-    <span>{{ rsvp.user.initials }}</span>
-{% endfor %}
+Key details:
+
+1. **Per-item permission check**: Even though the user passed the
+   initial skipper/admin gate, each regatta is checked individually with
+   `can_manage_regatta()`. A skipper cannot delete another skipper's
+   events by manipulating form data.
+
+2. **Defensive int parsing**: The `try/except` around `int(regatta_id)`
+   guards against tampered form data where non-numeric values are
+   submitted.
+
+3. **Single commit**: All deletions are batched and committed once at the
+   end, not per-item. This is more efficient and ensures atomicity -- if
+   the commit fails, no events are deleted.
+
+4. **Count feedback**: The flash message reports how many events were
+   actually deleted. If a user selected 5 events but only had permission
+   to delete 3, the message says "Deleted 3 event(s)."
+
+# Part 6: Permission Model Summary
+
+The CRUD routes use a layered permission model. Here is how each
+operation is protected:
+
+```
++----------------+-------------------+---------------------------+
+| Operation      | Gate              | Resource Check            |
++----------------+-------------------+---------------------------+
+| Index (read)   | is_authenticated  | visible_regattas() scope  |
+| Create         | admin or skipper  | N/A (new resource)        |
+| Edit           | login_required    | can_manage_regatta()      |
+| Delete         | login_required    | can_manage_regatta()      |
+| Bulk Delete    | admin or skipper  | can_manage_regatta() each |
++----------------+-------------------+---------------------------+
 ```
 
-### Sorting Logic
-1. Primary sort: status (yes=0, no=1, maybe=2)
-2. Secondary sort: user display_name alphabetically
+The pattern is consistent: broad gates for route access, narrow checks
+for resource-level operations. This is defense-in-depth -- even if the UI
+hides the edit button, the server enforces the rule.
 
-Result: "Yes" responses first, then "No", then "Maybe", each group
-alphabetically.
+# Part 7: Flash Messages
 
-# Part 4: Lazy Loading
+Flash messages provide immediate feedback after every action. The pattern
+used throughout the CRUD routes follows a consistent convention:
 
-## Relationship Loading
-From Regatta model:
-```python
-rsvps = db.relationship("RSVP", backref="regatta", lazy="dynamic")
-```
+| Category    | Usage                                    | Bootstrap class    |
+|-------------|------------------------------------------|--------------------|
+| `"success"` | Successful create, edit, delete          | `alert-success`    |
+| `"error"`   | Permission denied, validation failures   | `alert-danger`     |
+| `"warning"` | Empty selection, no-op situations        | `alert-warning`    |
+| `"info"`    | Informational (e.g., impersonation)      | `alert-info`       |
 
-lazy="dynamic" returns a query object instead of loading all RSVPs immediately.
-
-### Lazy Loading Options
-- **select** (default): Load when accessed (N+1 query problem)
-- **dynamic**: Return query object (can filter further)
-- **joined**: Load with JOIN (single query)
-- **subquery**: Load with subquery
-
-### Dynamic Example
-```python
-regatta.rsvps                    # Returns query object
-regatta.rsvps.count()            # SELECT COUNT(*)
-regatta.rsvps.filter_by(status='yes').all()  # Can add filters
-```
+Flash messages are consumed by the base template (see Day 5) and displayed
+once. They do not persist across additional page loads.
 
 # Key Takeaways
 
-1. **Many-to-many relationships** require a join table with two foreign keys.
-   RSVP connects Users and Regattas.
+1. **The index route combines data scoping with query-string filters**
+   to build a personalized, filterable schedule view.
+   `visible_regattas_split()` scopes by role; `_apply_schedule_filters()`
+   refines by skipper and RSVP status.
 
-2. **Upsert pattern** (update or insert) is common for unique relationships.
-   Check if exists, update if yes, insert if no.
+2. **Create and edit share `_save_regatta()`**, a helper that handles
+   form parsing, validation, Google Maps link auto-generation, and the
+   create-vs-update distinction based on whether `regatta` is `None`.
 
-3. **Template filters** transform data in templates. Register with
-   @app.template_filter() decorator.
+3. **Permission checks are layered**: decorators and inline checks gate
+   route access, then `can_manage_regatta()` verifies resource-level
+   authorization. This prevents users from accessing resources by
+   manipulating URLs or form data.
 
-4. **Lazy loading strategies** control when related objects are loaded.
-   lazy="dynamic" provides maximum flexibility.
+4. **Bulk delete checks each item individually** with
+   `can_manage_regatta()`, not just the initial role gate. A single
+   commit at the end ensures efficiency and atomicity.
+
+5. **Flash messages follow a consistent category convention** (`success`,
+   `error`, `warning`, `info`) that maps directly to Bootstrap alert
+   classes in the base template.
+
+6. **All mutating operations use POST** (never GET), preventing accidental
+   triggers from browser prefetch or link crawlers.
 
 ## What's Next?
-In Day 7, we'll explore document uploads and file handling with secure UUID
-filenames and Docker volume management.
+In Day 7, we will explore the RSVP system and schedule view features.
+You will see how the RSVP upsert pattern works, how filter state is
+preserved across form submissions, how PDF generation adapts to the
+current view, and how the crew notification flow validates ownership
+before sending emails.
+
+Questions to ponder:
+- Why does `_apply_schedule_filters()` default skippers to their own
+  schedule but not crew members?
+- What happens if a user submits a bulk delete form with regatta IDs
+  they do not own?
+- Why does `_save_regatta()` re-render the form instead of redirecting
+  on validation failure?
+- How would you add a "duplicate event" feature using the existing
+  `_save_regatta()` helper?
+
+See you in Day 7!

--- a/training/07-day7.md
+++ b/training/07-day7.md
@@ -1,289 +1,591 @@
-# Day 7: Document Upload and File Handling
+# Day 7: RSVP System & Schedule View
 
 ## Learning Objectives
-
 By the end of this session, you will understand:
-- File upload processing in Flask
-- UUID-based secure filename generation
-- Supporting both file uploads and external URLs
-- S3-compatible cloud storage abstraction
-- Presigned URLs for secure file downloads
-- File deletion and cleanup
+- How the RSVP route uses an upsert pattern to create or update responses
+- How filter state is preserved across RSVP form submissions via hidden fields
+- How RSVP submissions trigger email notifications to the regatta's skipper
+- How PDF generation adapts its title and columns based on the current filter
+- How the "Notify Crew" action validates ownership before sending emails
+- How template filters format RSVP and date data for display
 
 ## Concepts Covered
-
-- File uploads with request.files
-- UUID for unique filenames
-- Storage abstraction layer (local vs S3)
-- Presigned URLs for secure downloads
-- boto3 S3 client
-- File size limits
+- Upsert pattern (insert or update)
+- Filter state preservation across POST/redirect cycles
+- Notification triggering with preference-aware delivery
+- PDF generation with WeasyPrint
+- Template filters for sorting and formatting
+- Ownership validation in bulk actions
 
 ## File Focus
+For this session, examine these files:
+- app/regattas/routes.py — rsvp, pdf, notify_crew_action routes
+- app/permissions.py — can_rsvp_to_regatta (from Day 5)
+- app/notifications/service.py — notify_rsvp_to_skipper, notify_crew
+- app/__init__.py — sort_rsvps and regatta_days template filters
 
-- race-crew-network/app/regattas/routes.py:162-247 - Upload/download
-- race-crew-network/app/storage.py - S3 storage abstraction
-- race-crew-network/app/models.py:81-93 - Document model
-- race-crew-network/app/config.py - MAX_CONTENT_LENGTH, BUCKET_NAME
+# Part 1: The RSVP Route
 
-# Part 1: Document Model
+## Upsert Pattern
 
-## Dual-Mode Documents
+When a crew member sets their RSVP, the system needs to either create a
+new RSVP record or update an existing one. This is the classic "upsert"
+pattern.
 
-File: race-crew-network/app/models.py:81-93
-
-```python
-class Document(db.Model):
-    __tablename__ = "documents"
-
-    id = db.Column(db.Integer, primary_key=True)
-    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"))
-    doc_type = db.Column(db.String(20), nullable=False)  # NOR, SI, WWW
-    original_filename = db.Column(db.String(255), nullable=True)
-    stored_filename = db.Column(db.String(255), nullable=True)
-    url = db.Column(db.String(500), nullable=True)
-    uploaded_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
-    uploaded_by = db.Column(db.Integer, db.ForeignKey("users.id"))
-```
-
-### Two Modes:
-
-- **File upload**: stored_filename set, url is None
-- **External link**: url set, stored_filename is None
-
-# Part 2: File Upload
-
-## Upload Route
-
-File: race-crew-network/app/regattas/routes.py:176-223
+File: app/regattas/routes.py:282-321
 
 ```python
-@bp.route("/regattas/<int:regatta_id>/upload", methods=["POST"])
+@bp.route("/regattas/<int:regatta_id>/rsvp", methods=["POST"])
 @login_required
-def upload_doc(regatta_id: int):
-    if not current_user.is_admin:
+def rsvp(regatta_id: int):
+    status = request.form.get("status", "").lower()
+    if status not in ("yes", "no", "maybe"):
+        flash("Invalid RSVP status.", "error")
+        return redirect(url_for("regattas.index"))
+
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta or not can_rsvp_to_regatta(current_user, regatta):
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
-    doc_type = request.form.get("doc_type", "Other")
-    doc_url = request.form.get("doc_url", "").strip()
-    file = request.files.get("file")
+    existing = RSVP.query.filter_by(
+        regatta_id=regatta_id, user_id=current_user.id
+    ).first()
 
-    if doc_url:
-        # URL-based document
-        doc = Document(
-            regatta_id=regatta_id,
-            doc_type=doc_type,
-            url=doc_url,
-            uploaded_by=current_user.id,
-        )
-        db.session.add(doc)
-        db.session.commit()
-        flash(f"{doc_type} link added.", "success")
-    elif file and file.filename:
-        # File-based document
-        ext = os.path.splitext(file.filename)[1].lower()
-        stored_filename = f"{uuid.uuid4().hex}{ext}"
-
-        storage.upload_file(file, stored_filename)
-
-        doc = Document(
-            regatta_id=regatta_id,
-            doc_type=doc_type,
-            original_filename=file.filename,
-            stored_filename=stored_filename,
-            uploaded_by=current_user.id,
-        )
-        db.session.add(doc)
-        db.session.commit()
-        flash(f"{doc_type} uploaded.", "success")
+    if existing:
+        existing.status = status
+        rsvp_obj = existing
     else:
-        flash("Provide either a URL or a file.", "error")
+        rsvp_obj = RSVP(
+            regatta_id=regatta_id,
+            user_id=current_user.id,
+            status=status,
+        )
+        db.session.add(rsvp_obj)
 
-    return redirect(url_for("regattas.edit", regatta_id=regatta_id))
+    db.session.commit()
 ```
 
-### File Extraction:
+The upsert works in three steps:
+1. Query for an existing RSVP with the same `(regatta_id, user_id)` pair
+2. If found, update the `status` field on the existing record
+3. If not found, create a new `RSVP` object and add it to the session
+
+The RSVP model enforces uniqueness at the database level with a
+`UniqueConstraint` (see `app/models.py:207-209`), so even if the
+application logic had a race condition, the database would reject a
+duplicate.
+
+## Permission Check
+
+Before creating or updating the RSVP, the route checks
+`can_rsvp_to_regatta()` (covered in Day 5). This ensures the user is
+either the admin, the regatta's owner, or a crew member of the owner.
 
 ```python
-file = request.files.get("file")
-```
-request.files contains uploaded files as FileStorage objects.
-
-### UUID Filename:
-
-```python
-ext = os.path.splitext(file.filename)[1].lower()
-stored_filename = f"{uuid.uuid4().hex}{ext}"
-```
-
-Why UUID?
-- Prevents filename collisions
-- Prevents path traversal attacks (../../../etc/passwd)
-- Keeps original filename separate for display
-
-### Storage Abstraction:
-
-```python
-storage.upload_file(file, stored_filename)
-```
-
-Instead of saving directly to disk, the app uses a storage module that
-uploads to S3-compatible object storage (Lightsail bucket in production).
-See the Storage Module section below for details.
-
-# Part 3: File Download
-
-## Download Route
-
-File: race-crew-network/app/regattas/routes.py:162-173
-
-```python
-@bp.route("/docs/<int:doc_id>")
-@login_required
-def download_doc(doc_id: int):
-    doc = db.session.get(Document, doc_id)
-    if not doc:
-        flash("Document not found.", "error")
-        return redirect(url_for("regattas.index"))
-
-    if doc.url:
-        return redirect(doc.url)
-
-    return redirect(storage.get_file_url(doc.stored_filename))
-```
-
-### Presigned URL:
-
-```python
-return redirect(storage.get_file_url(doc.stored_filename))
-```
-Instead of serving files directly from the Flask process, the storage module
-generates a time-limited presigned URL. The browser is redirected to download
-directly from S3, which offloads bandwidth from the application server.
-
-### URL vs File:
-
-```python
-if doc.url:
-    return redirect(doc.url)
-```
-If URL-based, redirect to external site.
-
-# Part 4: File Deletion
-
-## Delete Route
-
-File: race-crew-network/app/regattas/routes.py:226-247
-
-```python
-@bp.route("/docs/<int:doc_id>/delete", methods=["POST"])
-@login_required
-def delete_doc(doc_id: int):
-    if not current_user.is_admin:
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta or not can_rsvp_to_regatta(current_user, regatta):
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
-
-    doc = db.session.get(Document, doc_id)
-    if not doc:
-        flash("Document not found.", "error")
-        return redirect(url_for("regattas.index"))
-
-    regatta_id = doc.regatta_id
-
-    # Delete file from S3 if it's a file-based document
-    if doc.stored_filename:
-        storage.delete_file(doc.stored_filename)
-
-    db.session.delete(doc)
-    db.session.commit()
-    flash("Document removed.", "success")
-    return redirect(url_for("regattas.edit", regatta_id=regatta_id))
 ```
 
-### Cleanup Pattern:
+Notice that the regatta existence check and permission check are combined
+in one `if` statement. If the regatta does not exist, Python's short-circuit
+evaluation prevents `can_rsvp_to_regatta()` from being called with `None`.
 
-1. If file-based, delete from S3 storage
-2. Delete database record
-3. storage.delete_file() silently ignores missing files (no error)
+## RSVP Notification
 
-# Part 5: Storage Module
+After committing the RSVP, the route triggers a notification to the
+skipper who created the regatta.
 
-## S3-Compatible Storage
-
-File: race-crew-network/app/storage.py
-
-In production, file uploads go to Lightsail Object Storage (S3-compatible).
-The storage module abstracts this behind three simple functions:
+File: app/regattas/routes.py:308-311
 
 ```python
-import boto3
+    try:
+        notify_rsvp_to_skipper(rsvp_obj)
+    except Exception:
+        logger.exception(
+            "Failed to send RSVP notification for regatta %s", regatta.id
+        )
+```
 
-def upload_file(file, stored_filename: str) -> None:
-    """Upload a file-like object to the S3 bucket."""
-    bucket = current_app.config["BUCKET_NAME"]
-    client = _get_client()
-    client.upload_fileobj(file, bucket, stored_filename)
+The notification is wrapped in a try/except so that email delivery
+failures do not break the RSVP flow. The RSVP is already committed
+at this point, so even if the notification fails, the user's response
+is saved.
 
-def get_file_url(stored_filename: str) -> str:
-    """Return a presigned URL (valid 1 hour) for downloading a file."""
-    bucket = current_app.config["BUCKET_NAME"]
-    client = _get_client()
-    return client.generate_presigned_url(
-        "get_object",
-        Params={"Bucket": bucket, "Key": stored_filename},
-        ExpiresIn=3600,
+## Preserving Filter State
+
+The schedule page has filters (skipper dropdown, RSVP status checkboxes).
+When a user changes their RSVP, the page reloads. Without special
+handling, the filters would reset to defaults.
+
+File: app/regattas/routes.py:313-321
+
+```python
+    redirect_args = {}
+    redirect_skipper = request.form.get("redirect_skipper")
+    if redirect_skipper is not None and redirect_skipper != "":
+        redirect_args["skipper"] = redirect_skipper
+    redirect_rsvp = request.form.getlist("redirect_rsvp")
+    if redirect_rsvp:
+        redirect_args["rsvp"] = redirect_rsvp
+    return redirect(url_for("regattas.index", **redirect_args))
+```
+
+The RSVP form in the template includes hidden fields that carry the
+current filter state. When the form is submitted, these values come
+along as form data. The route reads them and passes them as query-string
+arguments to the redirect.
+
+## Filter Preservation Flow
+
+```
+Schedule page: ?skipper=5&rsvp=yes
+        |
+        v
+RSVP form includes hidden fields:
+  <input type="hidden" name="redirect_skipper" value="5">
+  <input type="hidden" name="redirect_rsvp" value="yes">
+        |
+        v
+POST /regattas/42/rsvp
+  Form data: status=yes, redirect_skipper=5, redirect_rsvp=yes
+        |
+        v
+Route reads redirect_skipper and redirect_rsvp
+        |
+        v
+redirect to /?skipper=5&rsvp=yes
+        |
+        v
+User sees same filtered view with updated RSVP
+```
+
+This is a common pattern in server-rendered apps where forms need to
+preserve page state across POST/redirect/GET cycles.
+
+# Part 2: RSVP Notification to Skipper
+
+## Notification Logic
+
+When a crew member RSVPs, the skipper who created the regatta receives
+an email notification. This notification respects the skipper's
+preferences.
+
+File: app/notifications/service.py:112-175
+
+```python
+def notify_rsvp_to_skipper(rsvp) -> None:
+    """Send RSVP notification to the regatta's skipper."""
+    if not is_email_configured():
+        return
+
+    skipper = rsvp.regatta.creator
+    if not skipper:
+        return
+
+    if not skipper.email_opt_in:
+        return
+
+    prefs = skipper.notification_preferences
+    if not prefs.get("rsvp_notification", True):
+        return
+
+    # Phase 2: digest mode
+    if prefs.get("rsvp_delivery") == "digest":
+        return
+```
+
+The function applies a series of guard clauses before sending:
+
+1. **Email configured?** Checks if AWS SES credentials are set up.
+   In local development without SES, notifications silently skip.
+2. **Skipper exists?** Defensive check against orphaned regattas.
+3. **Opted in?** Respects the skipper's global `email_opt_in` flag.
+4. **RSVP notifications enabled?** Checks `notification_preferences`.
+5. **Digest mode?** If the skipper prefers daily digests, the notification
+   is deferred (see Day 11 for the digest system).
+
+After passing all guards, the function renders email templates and sends
+via AWS SES, then logs the notification to prevent duplicates.
+
+## Notification Decision Tree
+
+```
+notify_rsvp_to_skipper(rsvp)
+        |
+        v
+  Email configured? --NO--> return (silent skip)
+        |YES
+        v
+  Skipper exists? ----NO--> return
+        |YES
+        v
+  email_opt_in? ------NO--> return
+        |YES
+        v
+  rsvp_notification? -NO--> return
+        |YES
+        v
+  delivery == "digest"? -YES-> return (handled by daily digest job)
+        |NO
+        v
+  Render email templates (HTML + text)
+  send_email() via AWS SES
+  Log to NotificationLog table
+```
+
+# Part 3: Schedule PDF Generation
+
+## The PDF Route
+
+The PDF route generates a downloadable schedule using WeasyPrint, a
+library that converts HTML to PDF.
+
+File: app/regattas/routes.py:109-144
+
+```python
+@bp.route("/schedule.pdf")
+@login_required
+def pdf():
+    upcoming, past = current_user.visible_regattas_split()
+    upcoming, past, skipper_id, _rsvp_filters = _apply_schedule_filters(
+        upcoming, past, current_user
     )
 
-def delete_file(stored_filename: str) -> None:
-    """Delete a file from the S3 bucket. Silently ignores missing files."""
-    bucket = current_app.config["BUCKET_NAME"]
-    client = _get_client()
-    client.delete_object(Bucket=bucket, Key=stored_filename)
+    show_skipper = skipper_id == 0 or (
+        skipper_id is None and not current_user.is_skipper
+    )
+    if skipper_id and skipper_id != 0:
+        skipper = db.session.get(User, skipper_id)
+        pdf_title = (
+            f"{skipper.display_name}'s Race Schedule"
+            if skipper else "Race Schedule"
+        )
+    elif show_skipper:
+        pdf_title = "Combined Race Schedules"
+    else:
+        pdf_title = f"{current_user.display_name}'s Race Schedule"
 ```
 
-KEY DESIGN PATTERNS:
-- **Abstraction**: Routes call storage.upload_file() instead of S3 directly
-- **Presigned URLs**: Downloads bypass Flask entirely — browser fetches from S3
-- **Time-limited access**: Presigned URLs expire after 1 hour (security)
-- **Silent delete**: Missing files don't cause errors (idempotent)
-- **boto3**: AWS SDK for Python, works with any S3-compatible service
+The PDF reuses the same data scoping and filtering as the index route.
+This means the PDF always matches what the user is currently viewing on
+screen.
 
-### Local Development:
+## Dynamic Title and Columns
 
-For local development, the BUCKET_NAME config is empty. Files are stored in
-a Docker volume (uploads:/app/uploads) using the same interface.
+The PDF adapts based on context:
 
-# Part 6: File Size Limits
+| Scenario                     | Title                          | Show Skipper Column |
+|------------------------------|--------------------------------|---------------------|
+| Viewing a specific skipper   | "Bob's Race Schedule"          | No                  |
+| Viewing "All Schedules"      | "Combined Race Schedules"      | Yes                 |
+| Crew viewing (no filter)     | "Combined Race Schedules"      | Yes                 |
+| Skipper viewing own schedule | "Alice's Race Schedule"        | No                  |
 
-## MAX_CONTENT_LENGTH
+The `show_skipper` flag controls whether a "Skipper" column appears in
+the PDF table. When viewing a single skipper's events, the column is
+redundant and is hidden.
 
-File: race-crew-network/app/config.py
+## WeasyPrint Rendering
+
+File: app/regattas/routes.py:132-144
 
 ```python
-MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB
+    html_str = render_template(
+        "pdf_schedule.html",
+        upcoming=upcoming,
+        past=past,
+        generated_date=date.today().strftime("%B %d, %Y"),
+        show_skipper=show_skipper,
+        pdf_title=pdf_title,
+    )
+    pdf_bytes = HTML(string=html_str).write_pdf()
+    response = make_response(pdf_bytes)
+    response.headers["Content-Type"] = "application/pdf"
+    response.headers["Content-Disposition"] = (
+        "inline; filename=race-crew-schedule.pdf"
+    )
+    return response
 ```
 
-Flask automatically rejects requests larger than this. In production, the
-Lightsail Container Service also enforces request size limits.
+The flow is: render an HTML template, pass it to WeasyPrint to convert
+to PDF bytes, then return those bytes as an HTTP response with the
+correct content type. The `Content-Disposition: inline` header tells the
+browser to display the PDF in-browser rather than downloading it.
+
+# Part 4: Notify Crew Action
+
+## Ownership Validation
+
+The "Notify Crew" feature allows a skipper to email selected crew members
+about selected events. Both the events and the crew must be validated
+before sending.
+
+File: app/regattas/routes.py:224-279
+
+```python
+@bp.route("/regattas/notify-crew", methods=["POST"])
+@login_required
+def notify_crew_action():
+    if not current_user.is_skipper:
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    selected_ids = request.form.getlist("selected[]")
+    crew_ids = request.form.getlist("crew[]")
+    message = request.form.get("message", "").strip() or None
+```
+
+The route starts by checking that the current user is a skipper. Then it
+reads three pieces of form data: selected regatta IDs, selected crew
+member IDs, and an optional custom message.
+
+## Regatta Validation
+
+File: app/regattas/routes.py:244-255
+
+```python
+    regattas = []
+    for rid in selected_ids:
+        try:
+            regatta = db.session.get(Regatta, int(rid))
+        except (ValueError, TypeError):
+            continue
+        if regatta and regatta.created_by == current_user.id:
+            regattas.append(regatta)
+
+    if not regattas:
+        flash("No valid events selected.", "warning")
+        return redirect(url_for("regattas.index"))
+```
+
+Each selected regatta is verified: it must exist and must be owned by
+the current user (`created_by == current_user.id`). A skipper cannot
+notify crew about another skipper's events by tampering with form IDs.
+
+## Crew Validation
+
+File: app/regattas/routes.py:257-272
+
+```python
+    crew_members = []
+    valid_crew_ids = {c.id for c in current_user.crew_members.all()}
+    for cid in crew_ids:
+        try:
+            uid = int(cid)
+        except (ValueError, TypeError):
+            continue
+        if uid in valid_crew_ids:
+            user = db.session.get(User, uid)
+            if user:
+                crew_members.append(user)
+
+    if not crew_members:
+        flash("No valid crew members selected.", "warning")
+        return redirect(url_for("regattas.index"))
+```
+
+The crew validation builds a set of valid crew IDs from the skipper's
+actual crew list, then checks each submitted ID against that set. This
+prevents a skipper from emailing users who are not on their crew by
+manipulating form data.
+
+## Sending Notifications
+
+File: app/regattas/routes.py:274-279
+
+```python
+    sent = notify_crew(regattas, crew_members, message, current_user)
+    flash(
+        f"Notified {sent} crew member(s) about {len(regattas)} event(s).",
+        "success",
+    )
+    return redirect(url_for("regattas.index"))
+```
+
+After validation, the `notify_crew()` service function handles the actual
+email sending. It returns the count of successful sends, which is
+reported back to the user.
+
+## Notify Crew Validation Flow
+
+```
+POST /regattas/notify-crew
+  Form data: selected[]=[1,2,3], crew[]=[10,11], message="See you!"
+        |
+        v
+  User is skipper? --NO--> "Access denied."
+        |YES
+        v
+  Validate regattas:
+    - Regatta 1 exists, created_by == current_user? YES -> keep
+    - Regatta 2 exists, created_by == current_user? YES -> keep
+    - Regatta 3 exists, created_by == other_user?   NO  -> skip
+        |
+        v
+  Validate crew:
+    - User 10 in current_user.crew_members? YES -> keep
+    - User 11 in current_user.crew_members? YES -> keep
+        |
+        v
+  notify_crew(regattas=[1,2], crew=[10,11], message, skipper)
+        |
+        v
+  "Notified 2 crew member(s) about 2 event(s)."
+```
+
+# Part 5: Template Filters
+
+## sort_rsvps
+
+The `sort_rsvps` filter sorts RSVP responses for display in the schedule
+table. It orders by status priority (yes first, no second, maybe third),
+then alphabetically by display name within each group.
+
+File: app/__init__.py:134-139
+
+```python
+@app.template_filter("sort_rsvps")
+def sort_rsvps(rsvps):
+    order = {"yes": 0, "no": 1, "maybe": 2}
+    return sorted(
+        rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name)
+    )
+```
+
+In templates, the filter is used with the pipe syntax:
+
+```html
+{% for rsvp in regatta.rsvps.all()|sort_rsvps %}
+    <span class="badge {{ rsvp.status }}">{{ rsvp.user.initials }}</span>
+{% endfor %}
+```
+
+The tuple key `(order.get(r.status, 3), r.user.display_name)` uses
+Python's tuple sorting: first by status priority number, then by name
+for items with the same status. Unknown statuses sort last with priority 3.
+
+## regatta_days
+
+The `regatta_days` filter formats a date range as abbreviated day names,
+which is useful for at-a-glance schedule reading.
+
+File: app/__init__.py:141-153
+
+```python
+@app.template_filter("regatta_days")
+def regatta_days(start_date, end_date=None):
+    if not start_date:
+        return ""
+
+    if not end_date or end_date <= start_date:
+        return start_date.strftime("%a")
+
+    day_span = (end_date - start_date).days
+    if day_span == 1:
+        return f"{start_date.strftime('%a')} & {end_date.strftime('%a')}"
+
+    return f"{start_date.strftime('%a')} thru {end_date.strftime('%a')}"
+```
+
+Output examples:
+
+| Start Date   | End Date     | Output          |
+|--------------|--------------|-----------------|
+| 2026-03-21   | None         | "Sat"           |
+| 2026-03-21   | 2026-03-21   | "Sat"           |
+| 2026-03-21   | 2026-03-22   | "Sat & Sun"     |
+| 2026-03-21   | 2026-03-23   | "Sat thru Mon"  |
+
+The filter handles three cases: single day, two-day event (with "&"),
+and multi-day event (with "thru"). The `end_date <= start_date` check
+treats same-day events the same as no end date.
+
+# Part 6: Eligible Crew for Notify Modal
+
+## get_eligible_crew
+
+The schedule page includes a "Notify Crew" modal that shows which crew
+members can receive emails. The `get_eligible_crew()` function builds
+this list with eligibility information.
+
+File: app/notifications/service.py:15-32
+
+```python
+def get_eligible_crew(skipper: User) -> list[dict]:
+    """Return crew members with eligibility info for the notify modal."""
+    result = []
+    for crew in skipper.crew_members.all():
+        if crew.invite_token is not None:
+            result.append(
+                {"user": crew, "eligible": False,
+                 "reason": "Registration pending"})
+        elif not crew.email_opt_in:
+            result.append(
+                {"user": crew, "eligible": False,
+                 "reason": "Opted out of emails"})
+        else:
+            result.append(
+                {"user": crew, "eligible": True, "reason": None})
+    return result
+```
+
+Each crew member gets an eligibility status:
+- **Registration pending** (`invite_token is not None`): The user was
+  invited but has not completed registration yet. They cannot receive
+  notifications.
+- **Opted out** (`email_opt_in is False`): The user turned off email
+  notifications in their profile. Their preference is respected.
+- **Eligible**: The crew member can receive emails.
+
+The template uses this to show disabled checkboxes with explanatory
+tooltips for ineligible crew members, while eligible members get
+active checkboxes.
 
 # Key Takeaways
 
-1. **UUID filenames** prevent collisions and security issues. Store original
-   filename separately for display.
+1. **The RSVP route uses an upsert pattern**: query for an existing
+   record, update if found, create if not. The database's
+   `UniqueConstraint` provides a safety net against duplicates.
 
-2. **Presigned URLs** let the browser download directly from S3, offloading
-   bandwidth from the application server. They expire after a set time.
+2. **Filter state is preserved via hidden form fields**
+   (`redirect_skipper`, `redirect_rsvp`) that carry the current
+   query-string parameters through POST/redirect/GET cycles.
 
-3. **Storage abstraction** (app/storage.py) hides S3 details behind simple
-   functions. Routes call storage.upload_file() without knowing about boto3.
+3. **RSVP notifications respect preferences**: the `notify_rsvp_to_skipper`
+   function checks email configuration, opt-in status, notification
+   preferences, and delivery mode before sending. Failures are caught
+   and logged without breaking the RSVP flow.
 
-4. **Two-mode documents** (file or URL) provide flexibility without separate
-   models or tables.
+4. **PDF generation reuses the same data pipeline** as the index route
+   (scoping + filters), adapting the title and column visibility based
+   on the current filter context.
 
-5. **File cleanup** requires deleting both database record and S3 object.
+5. **The notify crew action validates both regattas and crew members**
+   against the current user's ownership. Regattas must be owned by the
+   skipper, and crew must be on the skipper's crew list. This prevents
+   form data tampering.
+
+6. **Template filters** (`sort_rsvps`, `regatta_days`) encapsulate
+   display logic so templates stay clean. They are registered on the
+   app via `@app.template_filter()` and used with Jinja2's pipe syntax.
 
 ## What's Next?
+In Day 8, we will explore document management -- how files and URLs are
+attached to regattas, how storage works in development vs. production,
+and how the upload/download routes handle both local files and
+S3-compatible object storage. We will also look at the AI-powered
+document discovery feature.
 
-In Day 8, we'll explore calendar integration with iCal format and the
-icalendar library for generating .ics feeds.
+Questions to ponder:
+- Why is the RSVP notification wrapped in try/except instead of letting
+  the error propagate?
+- What would happen if the `redirect_skipper` hidden field was missing
+  from the RSVP form?
+- Why does `notify_crew_action` check `regatta.created_by == current_user.id`
+  instead of using `can_manage_regatta()`?
+- How would you add an "undo" feature for RSVPs using the existing model?
+
+See you in Day 8!

--- a/training/08-day8.md
+++ b/training/08-day8.md
@@ -1,274 +1,536 @@
-# Day 8: Calendar Integration (iCal Feeds)
+# Day 8: Document Upload & Storage
 
 ## Learning Objectives
 By the end of this session, you will understand:
-- iCalendar format and RFC 5545 standard
-- Using the icalendar Python library
-- Token-based feed authentication
-- Generating calendar events
-- All-day event handling
-- Calendar subscription URLs
+- How the storage abstraction layer switches between S3 and local filesystem
+- The upload, download, and delete lifecycle for documents
+- Path traversal protection and why it matters
+- UUID-based filename generation to avoid collisions
+- Profile image upload with extension and size validation
+- How presigned URLs work for secure S3 file access
+- Document types in the sailing domain (NOR, SI, WWW)
 
 ## Concepts Covered
-- iCal (.ics) format
-- Calendar feed generation
-- Token authentication for public feeds
-- All-day events vs timed events
-- MIME types and Content-Disposition headers
+- Dual-mode storage abstraction (S3 vs local)
+- AWS S3 presigned URLs
+- Path traversal attacks and prevention
+- UUID-based file naming
+- File extension validation (allowlist pattern)
+- File size validation (stream seek technique)
+- MIME types and file serving
+- Flask Blueprints for static file serving
 
 ## File Focus
-- race-crew-network/app/calendar/routes.py - Calendar feed generation
+For this session, examine these files:
+- app/storage.py - Storage abstraction layer (S3 and local)
+- app/regattas/routes.py - Document upload/download/delete routes
+- app/auth/routes.py (lines 19-64) - Profile image upload logic
+- app/storage_routes.py - Local file serving blueprint
+- app/models.py (Document model) - Database schema for documents
 
-# Part 1: iCalendar Format
+# Part 1: The Storage Abstraction Layer
 
-## What Is iCal?
-iCalendar (.ics) is a standard format for calendar data (RFC 5545). It's
-supported by:
-- Google Calendar
-- Apple Calendar
-- Outlook
-- Most calendar applications
+## Why an Abstraction?
 
-SUBSCRIPTION VS IMPORT:
-- **Import**: One-time copy (no updates)
-- **Subscribe**: Live feed (updates automatically)
+Race Crew Network runs in two environments with different file storage:
 
-This app provides subscription feeds.
+- **Local development**: Files are saved to the `uploads/` directory inside
+  the Docker volume. No cloud credentials needed.
+- **Production (AWS Lightsail)**: Files are stored in an S3-compatible object
+  storage bucket. Files are never written to the container filesystem.
 
-# Part 2: Token Authentication
+Rather than scattering `if production: ... else: ...` checks across every
+route that handles files, the application centralizes this decision in a
+single module: `app/storage.py`. Every part of the app calls the same three
+functions -- `upload_file`, `get_file_url`, and `delete_file` -- and the
+storage module figures out where the bytes go.
 
-## Calendar Token
-From User model:
-```python
-calendar_token = db.Column(db.String(64), unique=True, nullable=True)
+```
+                        app code
+                           |
+            +--------------+--------------+
+            |        storage.py           |
+            |   upload_file()             |
+            |   get_file_url()            |
+            |   delete_file()             |
+            +---------+--------+----------+
+                      |        |
+           +----------+        +----------+
+           |                              |
+    +------+------+              +--------+-------+
+    |  S3 bucket  |              |  local uploads |
+    |  (prod)     |              |  (dev)         |
+    +-------------+              +----------------+
 ```
 
-Each user gets a unique token for their calendar feed. Token is generated on
-first subscription request.
+## The Mode Switch: _use_s3()
 
-## Subscribe Route
-File: race-crew-network/app/calendar/routes.py:14-31
+The entire dual-mode behavior hinges on a single configuration value:
+
+File: app/storage.py:8-10
 
 ```python
-@bp.route("/calendar/subscribe")
+def _use_s3() -> bool:
+    """Return True when S3 storage is configured (BUCKET_NAME is set)."""
+    return bool(current_app.config.get("BUCKET_NAME"))
+```
+
+If `BUCKET_NAME` is set in the environment (production), every storage
+operation goes through S3. If it is absent (local development), files are
+read and written on the local filesystem. This is a clean example of the
+Strategy pattern -- the caller never knows which backend is active.
+
+## The S3 Client
+
+When running in S3 mode, storage.py creates a boto3 client pointed at the
+configured AWS region:
+
+File: app/storage.py:13-20
+
+```python
+def _get_client():
+    """Return a boto3 S3 client configured for Lightsail Object Storage."""
+    region = current_app.config["AWS_REGION"]
+    return boto3.client(
+        "s3",
+        region_name=region,
+        endpoint_url=f"https://s3.{region}.amazonaws.com",
+    )
+```
+
+The explicit `endpoint_url` is needed because Lightsail Object Storage is
+S3-compatible but lives at a specific regional endpoint. A new client is
+created per request rather than cached, which avoids stale credential issues
+when running under Gunicorn with multiple workers.
+
+# Part 2: Core Storage Operations
+
+## upload_file()
+
+File: app/storage.py:39-48
+
+```python
+def upload_file(file, stored_filename: str) -> None:
+    """Upload a file-like object to S3 or the local filesystem."""
+    if _use_s3():
+        bucket = current_app.config["BUCKET_NAME"]
+        client = _get_client()
+        client.upload_fileobj(file, bucket, stored_filename)
+    else:
+        full_path = _get_upload_path(stored_filename)
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        file.save(full_path)
+```
+
+Two important details:
+
+1. **S3 path**: `upload_fileobj` streams the file directly from the request
+   to S3 without writing a temp file. The `stored_filename` becomes the S3
+   object key (e.g., `a1b2c3d4.pdf` or `profile-images/e5f6g7h8.jpg`).
+
+2. **Local path**: `mkdir(parents=True, exist_ok=True)` ensures the
+   subdirectory exists (important for `profile-images/` subfolder), then
+   calls Werkzeug's `file.save()` to write the bytes.
+
+## get_file_url()
+
+File: app/storage.py:51-65
+
+```python
+def get_file_url(stored_filename: str) -> str:
+    if _use_s3():
+        bucket = current_app.config["BUCKET_NAME"]
+        client = _get_client()
+        return client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": stored_filename},
+            ExpiresIn=3600,
+        )
+    return url_for("storage_bp.serve_file", filename=stored_filename)
+```
+
+**S3 mode** returns a presigned URL -- a time-limited, cryptographically
+signed URL that grants temporary read access to a private object. The URL
+expires after 3600 seconds (one hour). This means the S3 bucket can remain
+fully private (no public access) while still allowing users to download
+files through their browser.
+
+**Local mode** returns a Flask route URL like `/uploads/a1b2c3d4.pdf`,
+served by the storage blueprint (see Part 5).
+
+## delete_file()
+
+File: app/storage.py:68-79
+
+```python
+def delete_file(stored_filename: str) -> None:
+    if _use_s3():
+        bucket = current_app.config["BUCKET_NAME"]
+        client = _get_client()
+        try:
+            client.delete_object(Bucket=bucket, Key=stored_filename)
+        except ClientError:
+            pass
+    else:
+        full_path = _get_upload_path(stored_filename)
+        full_path.unlink(missing_ok=True)
+```
+
+Both paths silently ignore missing files. S3's `delete_object` wraps in a
+try/except that catches `ClientError`, and Python's `Path.unlink` uses
+`missing_ok=True`. This is intentional -- when cleaning up after a failed
+operation or deleting an already-removed file, crashing would be worse than
+silently succeeding.
+
+# Part 3: Path Traversal Protection
+
+## The Attack
+
+A path traversal attack occurs when a malicious filename like
+`../../etc/passwd` tricks the server into reading or writing files outside
+the intended upload directory. If an attacker can control the `key`
+parameter passed to local storage functions, they could potentially
+overwrite application code or read sensitive files.
+
+## The Defense
+
+File: app/storage.py:23-36
+
+```python
+def _get_upload_path(key: str) -> Path:
+    upload_folder = current_app.config.get("UPLOAD_FOLDER", "uploads")
+    base = Path(upload_folder)
+    if not base.is_absolute():
+        base = Path(current_app.root_path).parent / upload_folder
+    full_path = (base / key).resolve()
+    if not str(full_path).startswith(str(base.resolve())):
+        raise ValueError("Invalid file path")
+    return full_path
+```
+
+The protection works in three steps:
+
+1. **Resolve the base**: Convert the upload folder to an absolute path.
+2. **Resolve the candidate**: Join the key onto the base and call
+   `.resolve()`, which follows symlinks and normalizes `..` segments into
+   their actual filesystem location.
+3. **Check containment**: Verify the resolved path starts with the resolved
+   base. If someone passes `../../etc/passwd`, the resolved path would be
+   `/etc/passwd`, which does not start with `/app/uploads`, so a
+   `ValueError` is raised.
+
+This function is called by both `upload_file` and `delete_file` in local
+mode, ensuring every filesystem operation is confined to the uploads
+directory.
+
+# Part 4: Document Upload & Download Routes
+
+## Document Types
+
+In the sailing world, regattas distribute several standard documents:
+
+- **NOR** (Notice of Race): The official announcement with eligibility,
+  schedule, and entry requirements
+- **SI** (Sailing Instructions): Detailed racing rules, course layouts,
+  signal flags, and protest procedures
+- **WWW** (Website): A link to the regatta's external website
+
+Documents can be either uploaded files or external URLs. The `Document`
+model supports both:
+
+File: app/models.py:178-191
+
+```python
+class Document(db.Model):
+    __tablename__ = "documents"
+
+    id = db.Column(db.Integer, primary_key=True)
+    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"))
+    doc_type = db.Column(db.String(20), nullable=False)  # NOR, SI, WWW
+    original_filename = db.Column(db.String(255), nullable=True)
+    stored_filename = db.Column(db.String(255), nullable=True)
+    url = db.Column(db.String(500), nullable=True)
+    uploaded_by = db.Column(db.Integer, db.ForeignKey("users.id"))
+```
+
+If `url` is set, it is a link-based document. If `stored_filename` is set,
+it is a file stored in the storage backend. The `original_filename` preserves
+the name the user uploaded (e.g., `2026_NOR_Midwinters.pdf`) while
+`stored_filename` is the UUID-based key used for storage.
+
+## Upload Route
+
+File: app/regattas/routes.py:338-385
+
+```python
+@bp.route("/regattas/<int:regatta_id>/upload", methods=["POST"])
 @login_required
-def subscribe():
-    if not current_user.calendar_token:
-        current_user.calendar_token = secrets.token_urlsafe(32)
+def upload_doc(regatta_id: int):
+    regatta = db.session.get(Regatta, regatta_id)
+    if not regatta or not can_manage_regatta(current_user, regatta):
+        flash("Event not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    doc_type = request.form.get("doc_type", "Other")
+    doc_url = request.form.get("doc_url", "").strip()
+    file = request.files.get("file")
+
+    if doc_url:
+        doc = Document(
+            regatta_id=regatta_id, doc_type=doc_type,
+            url=doc_url, uploaded_by=current_user.id,
+        )
+        db.session.add(doc)
         db.session.commit()
+    elif file and file.filename:
+        ext = os.path.splitext(file.filename)[1].lower()
+        stored_filename = f"{uuid.uuid4().hex}{ext}"
+        storage.upload_file(file, stored_filename)
+        doc = Document(
+            regatta_id=regatta_id, doc_type=doc_type,
+            original_filename=file.filename,
+            stored_filename=stored_filename,
+            uploaded_by=current_user.id,
+        )
+        db.session.add(doc)
+        db.session.commit()
+```
 
-    feed_url = url_for(
-        "calendar.ical_feed", token=current_user.calendar_token, _external=True
+Key design decisions:
+
+1. **UUID filenames**: `uuid.uuid4().hex` generates a 32-character hex
+   string like `a1b2c3d4e5f6...`. Combined with the original extension,
+   this prevents filename collisions and eliminates special-character issues.
+   The original filename is preserved in the database for display purposes.
+
+2. **Two paths**: URL-based documents skip the storage layer entirely --
+   they just store a link in the database. File-based documents go through
+   `storage.upload_file()`.
+
+3. **Permission check**: `can_manage_regatta()` ensures only the regatta
+   owner (or admin) can upload documents to an event.
+
+## Download Route
+
+File: app/regattas/routes.py:324-335
+
+```python
+@bp.route("/docs/<int:doc_id>")
+@login_required
+def download_doc(doc_id: int):
+    doc = db.session.get(Document, doc_id)
+    if not doc:
+        flash("Document not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if doc.url:
+        return redirect(doc.url)
+
+    return redirect(storage.get_file_url(doc.stored_filename))
+```
+
+The download route is elegant in its simplicity. For URL-based documents,
+it redirects to the external URL. For file-based documents, it redirects to
+the URL returned by `storage.get_file_url()` -- either a presigned S3 URL
+or a local `/uploads/...` path.
+
+## Delete Route
+
+File: app/regattas/routes.py:388-410
+
+```python
+@bp.route("/docs/<int:doc_id>/delete", methods=["POST"])
+@login_required
+def delete_doc(doc_id: int):
+    doc = db.session.get(Document, doc_id)
+    if not doc:
+        flash("Document not found.", "error")
+        return redirect(url_for("regattas.index"))
+
+    regatta = db.session.get(Regatta, doc.regatta_id)
+    if regatta and not can_manage_regatta(current_user, regatta):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    if doc.stored_filename:
+        storage.delete_file(doc.stored_filename)
+
+    db.session.delete(doc)
+    db.session.commit()
+```
+
+The delete route only calls `storage.delete_file()` if the document has a
+`stored_filename`. URL-based documents have no file to remove -- just the
+database record.
+
+# Part 5: Profile Image Upload
+
+Profile images follow a similar pattern to document uploads, but with
+additional validation for security and user experience.
+
+## Extension Validation
+
+File: app/auth/routes.py:19
+
+```python
+ALLOWED_PROFILE_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+```
+
+This is an allowlist approach -- only these five image formats are accepted.
+The set uses lowercase extensions and the validation code converts the
+uploaded filename's extension to lowercase before checking.
+
+## Size Validation
+
+File: app/auth/routes.py:22-28
+
+```python
+def _profile_image_limit_bytes() -> int:
+    return int(
+        current_app.config.get(
+            "PROFILE_IMAGE_MAX_BYTES",
+            current_app.config.get("MAX_CONTENT_LENGTH", 10 * 1024 * 1024),
+        )
     )
-    flash(Markup(
-        f'Subscribe to this URL in your calendar app: <a href="{feed_url}" class="alert-link">{feed_url}</a>'
-    ), "success")
-    return redirect(url_for("regattas.index"))
 ```
 
-LAZY TOKEN GENERATION:
-Token only created when user requests feed URL. Most users never subscribe, so
-this saves database space.
+The size limit is configurable via `PROFILE_IMAGE_MAX_BYTES`, falling back
+to `MAX_CONTENT_LENGTH`, and ultimately defaulting to 10 MB. This layered
+fallback means the limit works regardless of how the environment is
+configured.
 
-_EXTERNAL=TRUE:
-```python
-url_for("calendar.ical_feed", token=token, _external=True)
-```
+## The Upload Function
 
-Generates full URL with domain:
-`https://example.com/calendar/abc123.ics`
-
-Calendar apps need full URLs to subscribe.
-
-# Part 3: Feed Generation
-
-## iCal Feed Route
-File: race-crew-network/app/calendar/routes.py:34-92
+File: app/auth/routes.py:47-64
 
 ```python
-@bp.route("/calendar/<token>.ics")
-def ical_feed(token: str):
-    user = User.query.filter_by(calendar_token=token).first_or_404()
+def _upload_profile_image(file_storage) -> str:
+    safe_name = secure_filename(file_storage.filename or "")
+    ext = os.path.splitext(safe_name)[1].lower()
+    if ext not in ALLOWED_PROFILE_IMAGE_EXTENSIONS:
+        raise ValueError(
+            "Profile picture must be a JPG, JPEG, PNG, GIF, or WEBP file."
+        )
 
-    cal = Calendar()
-    cal.add("prodid", "-//Race Crew Network//EN")
-    cal.add("version", "2.0")
-    cal.add("calscale", "GREGORIAN")
-    cal.add("x-wr-calname", "Race Crew Network")
-    cal.add("method", "PUBLISH")
+    file_storage.stream.seek(0, os.SEEK_END)
+    file_size = file_storage.stream.tell()
+    file_storage.stream.seek(0)
+    if file_size > _profile_image_limit_bytes():
+        raise ValueError(
+            f"Profile picture must be {_profile_image_limit_mb()} MB or smaller."
+        )
 
-    regattas = Regatta.query.order_by(Regatta.start_date).all()
-
-    for regatta in regattas:
-        event = Event()
-        event.add("uid", f"regatta-{regatta.id}@racecrew.net")
-        if regatta.boat_class and regatta.boat_class != "TBD":
-            event.add("summary", f"{regatta.boat_class} — {regatta.name}")
-        else:
-            event.add("summary", regatta.name)
-        event.add("dtstart", regatta.start_date)
-        end = (regatta.end_date or regatta.start_date) + timedelta(days=1)
-        event.add("dtend", end)
-        event.add("location", regatta.location)
-
-        if regatta.location_url:
-            event.add("url", regatta.location_url)
-
-        # Build description with RSVPs
-        lines = []
-        if regatta.notes:
-            lines.append(regatta.notes)
-
-        rsvps = regatta.rsvps.all()
-        if rsvps:
-            crew_lines = [f"  {r.user.initials}: {r.status}" for r in rsvps]
-            lines.append("Crew:\n" + "\n".join(crew_lines))
-
-        my_rsvp = RSVP.query.filter_by(
-            regatta_id=regatta.id, user_id=user.id
-        ).first()
-        if my_rsvp:
-            lines.append(f"Your RSVP: {my_rsvp.status.capitalize()}")
-
-        if lines:
-            event.add("description", "\n\n".join(lines))
-
-        cal.add_component(event)
-
-    response = Response(cal.to_ical(), mimetype="text/calendar")
-    response.headers["Content-Disposition"] = (
-        "attachment; filename=race-crew-network.ics"
-    )
-    return response
+    stored_filename = f"profile-images/{uuid.uuid4().hex}{ext}"
+    storage.upload_file(file_storage, stored_filename)
+    return stored_filename
 ```
 
-CALENDAR METADATA:
+This function demonstrates several defensive techniques:
+
+1. **secure_filename()**: Werkzeug utility that strips directory separators,
+   null bytes, and other dangerous characters from the filename.
+2. **Extension check**: Validates against the allowlist after lowercasing.
+3. **Stream-based size check**: Seeks to the end of the file stream to
+   measure its size, then seeks back to the beginning before uploading.
+   This avoids reading the entire file into memory just to check its length.
+4. **Namespaced storage key**: Profile images go under `profile-images/`,
+   keeping them organized separately from document uploads. In S3, this
+   creates a logical folder structure.
+
+When the profile is updated, the old image key is cleaned up:
+
+```
+Profile Update Flow:
+  1. Upload new image  ->  storage.upload_file("profile-images/NEW.jpg")
+  2. Update DB record  ->  user.profile_image_key = "profile-images/NEW.jpg"
+  3. Commit to DB
+  4. Delete old image   ->  storage.delete_file("profile-images/OLD.jpg")
+```
+
+The old image is deleted after the commit succeeds. If the commit fails,
+the new image is cleaned up instead. This ordering prevents orphaned files
+in the storage backend.
+
+# Part 6: The Local Storage Blueprint
+
+In local development, when `_use_s3()` returns `False`, downloaded files
+are served by a tiny Flask blueprint:
+
+File: app/storage_routes.py:1-17
+
 ```python
-cal.add("prodid", "-//Race Crew Network//EN")
-cal.add("version", "2.0")
-cal.add("x-wr-calname", "Race Crew Network")
+from pathlib import Path
+from flask import Blueprint, current_app, send_from_directory
+from flask_login import login_required
+
+bp = Blueprint("storage_bp", __name__)
+
+@bp.route("/uploads/<path:filename>")
+@login_required
+def serve_file(filename: str):
+    """Serve a locally stored file. Only used when S3 is not configured."""
+    upload_folder = current_app.config.get("UPLOAD_FOLDER", "uploads")
+    base = Path(upload_folder)
+    if not base.is_absolute():
+        base = Path(current_app.root_path).parent / upload_folder
+    return send_from_directory(str(base), filename)
 ```
 
-Standard iCal properties identifying the calendar.
+Key points:
 
-EVENT PROPERTIES:
-- **uid**: Unique identifier (used for updates)
-- **summary**: Event title (includes boat class when set, e.g. "Thistle — Midwinters")
-- **dtstart**: Start date
-- **dtend**: End date
-- **location**: Location text
-- **url**: Associated URL
-- **description**: Event details
+- **`@login_required`**: Even in development, files are not publicly
+  accessible. Users must be logged in to download documents.
+- **`send_from_directory()`**: Flask's built-in secure file-serving function.
+  It handles Content-Type headers, range requests, and its own path traversal
+  protection.
+- **`<path:filename>`**: The `path` converter allows slashes in the URL,
+  supporting subdirectories like `profile-images/a1b2c3d4.jpg`.
 
-BOAT CLASS IN SUMMARY:
-```python
-if regatta.boat_class and regatta.boat_class != "TBD":
-    event.add("summary", f"{regatta.boat_class} — {regatta.name}")
-else:
-    event.add("summary", regatta.name)
-```
-When a boat class is specified, it's prepended to the event title so
-calendar entries clearly show what class the regatta is for.
-
-ALL-DAY EVENTS:
-```python
-event.add("dtstart", regatta.start_date)
-```
-
-When you pass a date object (not datetime), it's treated as all-day event.
-
-END DATE HANDLING:
-```python
-end = (regatta.end_date or regatta.start_date) + timedelta(days=1)
-event.add("dtend", end)
-```
-
-iCal end dates are EXCLUSIVE. A one-day event from Jan 1 has:
-- dtstart: Jan 1
-- dtend: Jan 2
-
-Adding timedelta(days=1) makes the math correct.
-
-# Part 4: Building Descriptions
-
-## Description with RSVPs
-```python
-lines = []
-if regatta.notes:
-    lines.append(regatta.notes)
-
-rsvps = regatta.rsvps.all()
-if rsvps:
-    crew_lines = [f"  {r.user.initials}: {r.status}" for r in rsvps]
-    lines.append("Crew:\n" + "\n".join(crew_lines))
-
-my_rsvp = RSVP.query.filter_by(regatta_id=regatta.id, user_id=user.id).first()
-if my_rsvp:
-    lines.append(f"Your RSVP: {my_rsvp.status.capitalize()}")
-
-if lines:
-    event.add("description", "\n\n".join(lines))
-```
-
-PERSONALIZATION:
-Each user's feed includes their own RSVP status in the description. This makes
-the calendar feed personal to each user.
-
-# Part 5: Response Format
-
-## iCal Response
-```python
-response = Response(cal.to_ical(), mimetype="text/calendar")
-response.headers["Content-Disposition"] = "attachment; filename=race-crew-network.ics"
-return response
-```
-
-MIME TYPE:
-`text/calendar` tells browsers and calendar apps this is iCal data.
-
-CONTENT-DISPOSITION:
-`attachment; filename=race-crew-network.ics` suggests a download filename.
-
-TO_ICAL():
-The icalendar library's method to serialize Calendar object to iCal format.
-
-# Part 6: Security Considerations
-
-## Public but Secret
-The feed URL is:
-- **Public**: No authentication required (calendar apps can't login)
-- **Secret**: URL contains unguessable token
-
-This is standard practice for calendar feeds. Anyone with the URL can access
-it, but the URL itself is the secret.
-
-TOKEN PROPERTIES:
-- 32 bytes from secrets.token_urlsafe()
-- URL-safe characters only
-- Cryptographically random
-
-REVOKING ACCESS:
-To revoke a user's calendar access:
-1. Set calendar_token to NULL
-2. Generate new token on next subscription request
+This blueprint is only useful in local development. In production, the
+`get_file_url()` function returns a presigned S3 URL, so the browser
+fetches files directly from S3 without hitting the Flask app at all.
 
 # Key Takeaways
 
-1. **iCal format (RFC 5545)** is the standard for calendar data. The
-   icalendar library handles formatting details.
+1. **The storage abstraction provides a clean dual-mode interface.** A single
+   boolean check on `BUCKET_NAME` switches all file operations between S3
+   and local filesystem. Application code never needs to know which backend
+   is active.
 
-2. **Token-based authentication** allows public access without login. The
-   token itself is the secret.
+2. **Path traversal protection is critical for local storage.** The
+   `_get_upload_path()` function resolves paths and verifies they stay within
+   the upload directory. This prevents attackers from reading or writing
+   files outside the intended location.
 
-3. **All-day events** use date objects (not datetime). End dates are
-   EXCLUSIVE in iCal format.
+3. **UUID-based filenames prevent collisions and security issues.** Original
+   filenames are preserved in the database for display, while storage uses
+   randomized hex strings. This eliminates special characters, encoding
+   problems, and name collisions.
 
-4. **Personalized feeds** include user-specific data (their RSVP status)
-   without exposing other private information.
+4. **Presigned URLs keep the S3 bucket private.** In production, files are
+   never served through the Flask application. Instead, users get temporary
+   signed URLs that grant direct access to S3 for one hour.
 
-5. **Calendar subscriptions** update automatically. Users see changes without
-   re-importing.
+5. **Profile images add extension and size validation on top of the storage
+   layer.** The allowlist pattern (only accept known-good extensions) is
+   safer than a blocklist (try to reject known-bad ones). Stream-based size
+   checking avoids loading the entire file into memory.
+
+6. **Documents support both files and URLs.** This flexibility lets skippers
+   link to external regatta websites (WWW type) or upload PDFs (NOR, SI
+   types) through the same interface.
 
 ## What's Next?
-In Day 9, we'll explore Docker and containerization in depth, covering the
-Dockerfile, docker-compose orchestration, Gunicorn, and GHCR publishing.
+In Day 9, we will explore the skipper and crew management system -- how
+skippers build their crew, invite new members, and how the self-referential
+many-to-many relationship on the User model makes it all work. You will see
+how the same User model serves as both "skipper" and "crew" depending on
+which side of the relationship you query.
+
+Questions to ponder:
+- What happens if the S3 upload succeeds but the database commit fails?
+- Why does the profile update delete the old image after the commit, not before?
+- How would you add virus scanning to uploaded files?
+- What would change if you needed to support files larger than 10 MB?
+
+See you in Day 9!

--- a/training/09-day9.md
+++ b/training/09-day9.md
@@ -1,334 +1,365 @@
-# Day 9: Docker and Containerization
+# Day 9: Skipper & Crew Management
 
 ## Learning Objectives
-
 By the end of this session, you will understand:
-- Dockerfile structure and best practices
-- Multi-container orchestration with docker-compose
-- Container networking and service discovery
-- Volume persistence for data
-- Health checks for dependencies
-- Gunicorn production configuration
-- GitHub Container Registry (GHCR)
+- How the skipper_crew association table enables self-referential many-to-many relationships
+- The self-service schedule creation and deletion flow
+- Crew invitation for both new and existing users
+- How crew members can leave a skipper's crew
+- The My Crew page and crew eligibility checks
 
 ## Concepts Covered
-
-- Docker images and containers
-- Multi-stage builds (not used here, but good to know)
-- Docker networking
-- Named volumes
-- Service dependencies
-- WSGI servers (Gunicorn)
-- Container registries (GHCR)
+- Self-referential many-to-many relationships
+- Association tables with metadata (created_at)
+- Self-service role escalation (create schedule)
+- Cascade cleanup on schedule deletion
+- Dual-path invite: existing user vs new user
+- Relationship manipulation (append/remove)
 
 ## File Focus
+For this session, examine:
+- race-crew-network/app/models.py:10-21 — skipper_crew table
+- race-crew-network/app/models.py:52-60 — crew_members/skippers relationships
+- race-crew-network/app/auth/routes.py:527-682 — crew management routes
+- race-crew-network/app/notifications/service.py:15-32 — get_eligible_crew
 
-- race-crew-network/Dockerfile - Web container build
-- race-crew-network/docker-compose.yml - Local dev orchestration
-- race-crew-network/gunicorn.conf.py - WSGI server config
+# Part 1: The skipper_crew Association Table
 
-# Part 1: Dockerfile
+## Self-Referential Many-to-Many
 
-## Dockerfile
+A skipper can have many crew members, and a crew member can be on multiple
+skippers' crews. Both sides are User records, creating a self-referential
+many-to-many relationship.
 
-File: race-crew-network/Dockerfile
-
-```dockerfile
-FROM python:3.13-slim
-
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    default-libmysqlclient-dev gcc pkg-config \
-    libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
-    libffi-dev libcairo2 \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
-RUN mkdir -p /app/uploads
-
-EXPOSE 8000
-
-CMD ["./entrypoint.sh"]
-```
-
-### Step-by-Step:
-
-**1. Base Image**:
-```dockerfile
-FROM python:3.13-slim
-```
-Official Python 3.13 slim image (Debian-based, minimal packages). Using
-the latest Python version reduces CVE exposure in the base image.
-
-**2. Working Directory**:
-```dockerfile
-WORKDIR /app
-```
-All subsequent commands run in /app.
-
-**3. System Dependencies**:
-```dockerfile
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    default-libmysqlclient-dev gcc pkg-config \
-    libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
-    libffi-dev libcairo2 \
-    && rm -rf /var/lib/apt/lists/*
-```
-
-- default-libmysqlclient-dev: MySQL client libraries
-- gcc: C compiler (needed for some Python packages)
-- pkg-config: Package configuration helper
-- libpango, libcairo, etc.: Required by WeasyPrint for PDF generation
-- rm -rf /var/lib/apt/lists/*: Clean up to reduce image size
-
-**4. Install Python Dependencies**:
-```dockerfile
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-```
-
-Copy requirements first (before copying app code) for better caching. If code
-changes but requirements don't, Docker reuses this layer.
-
-**5. Copy Application**:
-```dockerfile
-COPY . .
-```
-
-Copy entire application directory to /app in container.
-
-**6. Create Upload Directory**:
-```dockerfile
-RUN mkdir -p /app/uploads
-```
-
-Ensure directory exists (though volume will override this).
-
-**7. Expose Port**:
-```dockerfile
-EXPOSE 8000
-```
-
-Documentation that container listens on port 8000. Doesn't actually publish.
-
-**8. Default Command**:
-```dockerfile
-CMD ["./entrypoint.sh"]
-```
-
-Run entrypoint script on container start.
-
-# Part 2: Docker Compose
-
-## docker-compose.yml Review
-
-File: race-crew-network/docker-compose.yml (from Day 1)
-
-Two services: web, db (local development only)
-Two volumes: mysql_data, uploads
-
-Note: nginx was removed from the local setup. In production, the Lightsail
-Container Service handles HTTPS termination and load balancing.
-
-### Service Discovery:
-
-Docker creates a network where services can reach each other by name:
-- web can connect to mysql://db:3306
-
-### Depends_on:
-
-```yaml
-web:
-  depends_on:
-    db:
-      condition: service_healthy
-```
-
-web waits for db to pass health check before starting.
-
-### Health Checks:
-
-```yaml
-db:
-  healthcheck:
-    test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-    interval: 5s
-    timeout: 5s
-    retries: 10
-```
-
-Docker repeatedly runs health check until it passes (or retries exhausted).
-
-### Volumes:
-
-```yaml
-volumes:
-  - mysql_data:/var/lib/mysql
-  - uploads:/app/uploads
-```
-
-Named volumes persist across container recreations.
-
-### Restart Policy:
-
-```yaml
-restart: unless-stopped
-```
-
-Container restarts automatically unless manually stopped.
-
-# Part 3: Gunicorn Configuration
-
-## What Is Gunicorn?
-
-Gunicorn (Green Unicorn) is a Python WSGI HTTP server. It:
-- Runs Flask in production (never use `flask run` in production)
-- Manages multiple worker processes
-- Handles concurrent requests
-- Provides process supervision
-
-## Gunicorn Config
-
-File: race-crew-network/gunicorn.conf.py
+File: race-crew-network/app/models.py:10-21
 
 ```python
-bind = "0.0.0.0:8000"
-workers = 2
-accesslog = "-"
-errorlog = "-"
+skipper_crew = db.Table(
+    "skipper_crew",
+    db.Column("skipper_id", db.Integer, db.ForeignKey("users.id"), primary_key=True),
+    db.Column("crew_id", db.Integer, db.ForeignKey("users.id"), primary_key=True),
+    db.Column(
+        "created_at",
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    ),
+)
 ```
 
-**bind**:
-Listen on all interfaces (0.0.0.0) port 8000. Inside Docker, this is necessary
-for the port mapping to work.
+This is an association table — not a model class, but a raw Table object.
+Both columns are foreign keys to the same `users` table. The composite primary
+key (skipper_id, crew_id) prevents duplicates.
 
-**workers**:
-Number of worker processes. Rule of thumb: 2-4 x CPU cores. Two is fine for
-small traffic.
+The `created_at` column is extra metadata not strictly needed for the
+relationship, but useful for tracking when a crew member was added.
 
-**accesslog / errorlog**:
-"-" means stdout/stderr. Docker captures container output.
+## Relationship Definitions
 
-### WSGI Entry Point:
+File: race-crew-network/app/models.py:52-60
 
-```bash
-gunicorn -c gunicorn.conf.py wsgi:app
+```python
+# Skipper -> their crew members
+crew_members = db.relationship(
+    "User",
+    secondary=skipper_crew,
+    primaryjoin=id == skipper_crew.c.skipper_id,
+    secondaryjoin=id == skipper_crew.c.crew_id,
+    backref="skippers",
+    lazy="dynamic",
+)
 ```
 
-This loads gunicorn.conf.py for settings, then imports `app` from wsgi.py.
+Because both sides point to User, SQLAlchemy needs explicit join conditions:
+- **primaryjoin**: How to find the "skipper" side (User.id = skipper_crew.skipper_id)
+- **secondaryjoin**: How to find the "crew" side (User.id = skipper_crew.crew_id)
+- **backref="skippers"**: Creates the reverse — crew_member.skippers returns their skippers
+- **lazy="dynamic"**: Returns a query object, allowing further filtering
 
-# Part 4: GitHub Container Registry (GHCR)
+Usage:
+```python
+# Get all crew for a skipper
+skipper.crew_members.all()
+skipper.crew_members.order_by(User.display_name).all()
 
-## Container Image Publishing
+# Get all skippers for a crew member
+crew_member.skippers  # list via backref
 
-Docker images are built and published to GitHub Container Registry (GHCR)
-via GitHub Actions. This means production deployments pull pre-built images
-instead of building on the server.
-
-### Image Tags:
-
-Each build produces images tagged with:
-- **latest**: Always points to the most recent build
-- **git SHA**: Specific commit (e.g., ghcr.io/chris-edwards-pub/race-crew-network:abc1234)
-- **semantic version**: Release tag (e.g., :v0.34.2)
-
-### docker-compose.yml Reference:
-
-```yaml
-web:
-  build: .
-  image: ghcr.io/chris-edwards-pub/race-crew-network:latest
+# Check membership
+user in skipper.crew_members.all()
 ```
 
-The `build` directive builds locally for development. The `image` directive
-names the image so it can be pulled from GHCR in production.
+# Part 2: Self-Service Schedule Management
 
-### Benefits:
+## Creating a Schedule
 
-- **Zero-downtime deploys**: No building on server (no stopping containers to free RAM)
-- **Reproducible**: Same image in staging and production
-- **Fast rollback**: Previous image tags are always available
-- **Build caching**: GitHub Actions caches Docker layers for fast builds
+Any logged-in user who is not already a skipper can create their own schedule.
+This promotes them to the Skipper role.
 
-# Part 5: Request Flow
+File: race-crew-network/app/auth/routes.py:532-539
 
-## Full Request Path (Local Development)
-
-```
-  Client (Browser)
-    |
-    | HTTP request on port 80
-    v
-  Docker port mapping (80 → 8000)
-    |
-    v
-  Gunicorn (web container)
-    |
-    | WSGI interface
-    v
-  Flask application
-    |
-    | Query database
-    v
-  MySQL (db container) on port 3306
-    |
-    v
-  Flask renders template
-    |
-    v
-  Gunicorn returns response to client
+```python
+@bp.route("/create-schedule", methods=["POST"])
+@login_required
+def create_schedule():
+    if not current_user.is_skipper:
+        current_user.is_skipper = True
+        db.session.commit()
+        flash("Your schedule has been created!", "success")
+    return redirect(url_for("regattas.index"))
 ```
 
-### Network Isolation:
+This is triggered from the navbar dropdown. In the base template, users who
+are neither admin nor skipper see a "Create My Schedule" menu item that
+submits this form. Once is_skipper is True, they gain access to event CRUD,
+crew management, and notification features.
 
-- Only the web container's port 8000 is mapped to host port 80
-- db communicates on Docker's internal network
-- Database is never exposed to the internet
+## Deleting a Schedule
 
-### Production Request Path:
+Skippers can delete their schedule, which is a destructive action requiring
+confirmation. Admins are prevented from deleting their schedule.
 
-In production (Lightsail Container Service), the path is:
-  Client → Lightsail HTTPS endpoint → Gunicorn → Flask → Managed MySQL
+File: race-crew-network/app/auth/routes.py:542-574
 
-# Part 6: Production Enhancements
+```python
+@bp.route("/delete-schedule", methods=["POST"])
+@login_required
+def delete_schedule():
+    if current_user.is_admin:
+        flash("Admins cannot delete their schedule.", "error")
+        return redirect(url_for("regattas.index"))
 
-### Production Architecture (AWS Lightsail):
+    if not current_user.is_skipper:
+        flash("You don't have a schedule to delete.", "error")
+        return redirect(url_for("regattas.index"))
 
-This app uses Lightsail Container Service for production:
-- **Container Service**: Manages the web container (auto-restart, scaling)
-- **Managed MySQL**: Lightsail database with automated backups
-- **Object Storage**: S3-compatible bucket for file uploads
-- **HTTPS**: Lightsail handles SSL certificate and termination
-- **Custom Domain**: SSL cert provisioned for racecrew.net
+    confirm_text = request.form.get("confirm_text", "").strip().lower()
+    if confirm_text != "delete":
+        flash("Please type 'delete' to confirm.", "error")
+        return redirect(url_for("regattas.index"))
 
-No nginx container needed in production — Lightsail's load balancer
-handles HTTPS termination and routes traffic to the Gunicorn container.
+    # Cascade cleanup
+    for regatta in Regatta.query.filter_by(created_by=current_user.id).all():
+        db.session.delete(regatta)
+    RSVP.query.filter_by(user_id=current_user.id).delete()
+    Document.query.filter_by(uploaded_by=current_user.id).delete()
+    db.session.execute(
+        skipper_crew.delete().where(skipper_crew.c.skipper_id == current_user.id)
+    )
 
-See Day 10 for full deployment details and CI/CD pipeline.
+    current_user.is_skipper = False
+    db.session.commit()
+```
+
+The cascade is thorough:
+1. Delete all regattas created by this user (which cascades their docs and RSVPs)
+2. Delete any RSVPs this user made on other skippers' events
+3. Delete any documents this user uploaded
+4. Remove all crew associations (unlink crew members)
+5. Set is_skipper to False
+
+The confirmation text ("delete") prevents accidental clicks.
+
+# Part 3: My Crew Page
+
+## Listing Crew with Eligibility
+
+File: race-crew-network/app/auth/routes.py:577-589
+
+```python
+@bp.route("/my-crew")
+@login_required
+def my_crew():
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    crew = current_user.crew_members.order_by(User.display_name).all()
+    return render_template(
+        "my_crew.html",
+        crew=crew,
+        email_configured=is_email_configured(),
+    )
+```
+
+The template shows each crew member with their status and provides invite
+and remove actions. The `email_configured` flag controls whether email-related
+UI is shown.
+
+The notification service provides eligibility info for the notify modal:
+
+File: race-crew-network/app/notifications/service.py:15-32
+
+```python
+def get_eligible_crew(skipper: User) -> list[dict]:
+    result = []
+    for crew in skipper.crew_members.all():
+        if crew.invite_token is not None:
+            result.append(
+                {"user": crew, "eligible": False, "reason": "Registration pending"}
+            )
+        elif not crew.email_opt_in:
+            result.append(
+                {"user": crew, "eligible": False, "reason": "Opted out of emails"}
+            )
+        else:
+            result.append({"user": crew, "eligible": True, "reason": None})
+    return result
+```
+
+This returns structured data that the template uses to show checkboxes
+(checked for eligible, disabled for ineligible with reason shown).
+
+# Part 4: Inviting Crew
+
+## Dual-Path Invite
+
+The invite_crew route handles two scenarios: the email belongs to an existing
+user, or it's a brand new user who needs an invite token.
+
+File: race-crew-network/app/auth/routes.py:608-661
+
+```python
+@bp.route("/my-crew/invite", methods=["POST"])
+@login_required
+def invite_crew():
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    email = request.form.get("email", "").strip().lower()
+
+    existing_user = User.query.filter_by(email=email).first()
+    if existing_user:
+        # User already exists -- just add to crew
+        if existing_user in current_user.crew_members.all():
+            flash(f"{existing_user.display_name} is already on your crew.", "warning")
+        else:
+            current_user.crew_members.append(existing_user)
+            db.session.commit()
+            flash(f"{existing_user.display_name} added to your crew.", "success")
+        return redirect(url_for("auth.my_crew"))
+
+    # Create new invited user
+    token = secrets.token_urlsafe(32)
+    user = User(
+        email=email,
+        password_hash="pending",
+        display_name=email,
+        initials="??",
+        invite_token=token,
+        invited_by=current_user.id,
+        avatar_seed=User.generate_avatar_seed(),
+    )
+    db.session.add(user)
+    db.session.flush()  # Get user.id before appending to relationship
+    current_user.crew_members.append(user)
+    db.session.commit()
+```
+
+For existing users, it's a simple append to the relationship. For new users:
+1. Create User with placeholder data and invite_token
+2. Set invited_by to current skipper's id (used for auto-link on registration)
+3. Generate avatar_seed for their future avatar
+4. flush() to get the user.id before appending to crew_members
+5. Optionally send an email invite if configured
+
+When this invited user completes registration (Day 4), the auto-link in the
+register route adds them to their inviter's crew automatically.
+
+# Part 5: Removing Crew and Leaving
+
+## Remove Crew (Skipper Action)
+
+File: race-crew-network/app/auth/routes.py:664-681
+
+```python
+@bp.route("/my-crew/<int:user_id>/remove", methods=["POST"])
+@login_required
+def remove_crew(user_id: int):
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    user = db.session.get(User, user_id)
+    if user not in current_user.crew_members.all():
+        flash("That user is not on your crew.", "warning")
+    else:
+        current_user.crew_members.remove(user)
+        db.session.commit()
+        flash(f"{user.display_name} removed from your crew.", "success")
+
+    return redirect(url_for("auth.my_crew"))
+```
+
+## Leave Skipper (Crew Action)
+
+Crew members can leave a skipper's crew from their profile page:
+
+File: race-crew-network/app/auth/routes.py:592-605
+
+```python
+@bp.route("/leave-skipper/<int:skipper_id>", methods=["POST"])
+@login_required
+def leave_skipper(skipper_id: int):
+    skipper = db.session.get(User, skipper_id)
+    if not skipper:
+        flash("Skipper not found.", "warning")
+    elif skipper not in current_user.skippers:
+        flash("You are not on that skipper's crew.", "warning")
+    else:
+        skipper.crew_members.remove(current_user)
+        db.session.commit()
+        flash(f"You have left {skipper.display_name}'s crew.", "success")
+
+    return redirect(url_for("auth.profile"))
+```
+
+Notice the symmetry: the skipper uses `crew_members.remove(user)` and the
+crew member triggers `skipper.crew_members.remove(current_user)`. Both
+manipulate the same relationship from different sides.
+
+## Crew Management Flow
+
+```
+  Skipper                          Crew Member
+     |                                |
+     +-- /my-crew/invite ----------->|  (invite by email)
+     |                                |
+     |  /register/<token> <----------+  (complete registration)
+     |                                |
+     |  (auto-linked to crew) <------+  (invited_by check)
+     |                                |
+     +-- /my-crew/<id>/remove ------>|  (skipper removes)
+     |                                |
+     |  /leave-skipper/<id> <--------+  (crew leaves)
+     |                                |
+     +-- /delete-schedule            |  (removes all crew links)
+```
 
 # Key Takeaways
 
-1. **Docker Compose orchestrates multiple containers**. Service names provide
-   DNS for inter-container communication.
+1. **Self-referential M2M** uses an association table with both foreign keys
+   pointing to the same table. SQLAlchemy needs explicit primaryjoin and
+   secondaryjoin to disambiguate.
 
-2. **Gunicorn is the production WSGI server** for Flask. It manages worker
-   processes and handles concurrent requests.
+2. **Schedule creation is self-service** — any user can become a skipper.
+   Schedule deletion cascades comprehensively (regattas, RSVPs, docs, crew).
 
-3. **GHCR stores pre-built Docker images**. Production deployments pull
-   images instead of building on the server, enabling fast rollbacks.
+3. **Crew invites handle two cases**: existing users are added directly,
+   new users get an invite token. The invited_by field enables auto-linking
+   on registration.
 
-4. **Named volumes persist data** across container recreations. Critical for
-   database and uploaded files in local development.
+4. **Both sides can manage the relationship**: skippers remove crew,
+   crew members leave skippers. The relationship manipulation is the same
+   SQLAlchemy operation from different directions.
 
-5. **Health checks ensure startup order**. web waits for db to be ready
-   before starting.
+5. **Eligibility checks** prevent sending emails to users who haven't
+   completed registration or have opted out.
 
 ## What's Next?
+In Day 10, we'll explore the email service that powers invite emails, crew
+notifications, and RSVP alerts. You'll learn how AWS SES integration works
+with HMAC-based unsubscribe tokens and webhook handling for bounces.
 
-In Day 10, we'll explore database migrations with Flask-Migrate and Alembic,
-and discuss production deployment strategies.
+See you in Day 10!

--- a/training/10-day10.md
+++ b/training/10-day10.md
@@ -1,370 +1,331 @@
-# Day 10: Database Migrations and Deployment
+# Day 10: Email Service with AWS SES
 
 ## Learning Objectives
 By the end of this session, you will understand:
-- Flask-Migrate and Alembic for database migrations
-- Creating and applying migrations
-- Automatic migration on startup
-- AWS Lightsail Container Service deployment
-- GitHub Actions CI/CD pipeline
-- Environment variable management
-- Managed database and automated backups
+- How the application sends email via AWS Simple Email Service (SES)
+- HMAC-SHA256 token generation for secure unsubscribe links
+- RFC 8058 one-click unsubscribe implementation
+- Bounce and complaint webhook handling via SNS
+- The email opt-in/opt-out model and how it protects users
 
 ## Concepts Covered
-- Database schema versioning
-- Migration generation
-- Upgrade and downgrade functions
-- CI/CD pipelines with GitHub Actions
-- Container registries (GHCR)
-- Managed cloud services
-- Infrastructure as Code (Terraform)
+- AWS SES (Simple Email Service)
+- boto3 SES client with dedicated IAM credentials
+- HMAC-SHA256 for tamper-proof tokens
+- RFC 8058 List-Unsubscribe headers
+- MIME multipart email construction
+- SNS webhook processing
+- CSRF exemption for external webhooks
+- SiteSetting-based runtime configuration
 
 ## File Focus
-- race-crew-network/migrations/versions/* - Migration files
-- race-crew-network/entrypoint.sh - Auto-migration on startup
+For this session, examine:
+- race-crew-network/app/admin/email_service.py — SES integration
+- race-crew-network/app/email/routes.py — Unsubscribe and webhook routes
+- race-crew-network/app/models.py:260-277 — SiteSetting model
+- race-crew-network/app/models.py:44 — User.email_opt_in field
 
-# Part 1: What Are Database Migrations?
+# Part 1: Email Service Architecture
 
-## The Problem
-Your database schema changes as your app evolves:
-- Add new tables
-- Add/remove columns
-- Change column types
-- Add indexes
+## Overview
 
-How do you apply these changes to existing databases without data loss?
+```
+  [Flask App]
+       |
+       | send_email()
+       v
+  [email_service.py]
+       |
+       | boto3 SES client
+       v
+  [AWS SES] ----------> [Recipient]
+       |                      |
+       | SNS notification     | clicks unsubscribe
+       v                      v
+  [/webhooks/ses]       [/unsubscribe]
+  (bounce/complaint)    (opt-out)
+```
 
-## The Solution: Migrations
-Migrations are scripts that transform database schema from one version to the
-next. Each migration has:
-- **upgrade()**: Apply the change
-- **downgrade()**: Undo the change
+The email service is a thin wrapper around AWS SES. It loads sender
+configuration from the SiteSetting table (not environment variables), builds
+MIME messages with unsubscribe headers, and checks user opt-in before sending.
 
-Migrations form a version chain. You can upgrade or downgrade to any version.
+## SES Client Setup
 
-## Alembic
-Alembic is Python's database migration tool. Flask-Migrate wraps it for Flask
-apps.
-
-# Part 2: Migration File Structure
-
-## Example Migration
-File: migrations/versions/c82d4c9ce2d5_add_calendar_token_to_users.py
+File: race-crew-network/app/admin/email_service.py:15-33
 
 ```python
-"""Add calendar_token to users
-
-Revision ID: c82d4c9ce2d5
-Revises: b741dd3b02c6
-Create Date: 2026-02-15 13:42:23.880068
-
-"""
-from alembic import op
-import sqlalchemy as sa
-
-revision = 'c82d4c9ce2d5'
-down_revision = 'b741dd3b02c6'
-branch_labels = None
-depends_on = None
-
-def upgrade():
-    with op.batch_alter_table('users', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('calendar_token', sa.String(length=64), nullable=True))
-        batch_op.create_unique_constraint(None, ['calendar_token'])
-
-def downgrade():
-    with op.batch_alter_table('users', schema=None) as batch_op:
-        batch_op.drop_constraint(None, type_='unique')
-        batch_op.drop_column('calendar_token')
+def _get_ses_client(region: str | None = None):
+    if not region:
+        region = current_app.config["AWS_REGION"]
+    ses_key = current_app.config.get("SES_ACCESS_KEY_ID")
+    ses_secret = current_app.config.get("SES_SECRET_ACCESS_KEY")
+    if ses_key and ses_secret:
+        return boto3.client(
+            "ses",
+            region_name=region,
+            aws_access_key_id=ses_key,
+            aws_secret_access_key=ses_secret,
+        )
+    return boto3.client("ses", region_name=region)
 ```
 
-KEY ELEMENTS:
+SES uses dedicated IAM credentials (SES_ACCESS_KEY_ID/SECRET) separate from
+the S3 bucket credentials. If not set, it falls back to the default boto3
+credential chain (environment variables, instance profile, etc.).
 
-**Revision Chain**:
+## Loading Email Settings
+
+File: race-crew-network/app/admin/email_service.py:36-55
+
 ```python
-revision = 'c82d4c9ce2d5'  # This migration's ID
-down_revision = 'b741dd3b02c6'  # Previous migration
+def load_email_settings() -> dict:
+    sender = ""
+    region = current_app.config["AWS_REGION"]
+    sender_to = ""
+
+    setting = SiteSetting.query.filter_by(key="ses_sender").first()
+    if setting and setting.value:
+        sender = setting.value
+
+    to_setting = SiteSetting.query.filter_by(key="ses_sender_to").first()
+    if to_setting and to_setting.value:
+        sender_to = to_setting.value
+
+    region_setting = SiteSetting.query.filter_by(key="ses_region").first()
+    if region_setting and region_setting.value:
+        region = region_setting.value
+
+    return {"ses_sender": sender, "ses_sender_to": sender_to, "ses_region": region}
 ```
 
-Alembic uses this to track version order.
+Email settings are stored in the SiteSetting table, not environment variables.
+This allows admins to configure email from the web UI without restarting the
+application (see Day 15 for the admin settings page).
 
-**upgrade()**:
-Applies the change:
+# Part 2: Sending Email
+
+## The send_email Function
+
+File: race-crew-network/app/admin/email_service.py:86-141
+
 ```python
-batch_op.add_column(sa.Column('calendar_token', sa.String(length=64), nullable=True))
-batch_op.create_unique_constraint(None, ['calendar_token'])
+def send_email(to, subject, body_text, body_html=None):
+    # Check opt-in status
+    user = User.query.filter_by(email=to).first()
+    if user and not user.email_opt_in:
+        logger.info("Skipping email to %s: user has opted out", to)
+        return
+
+    settings = load_email_settings()
+    sender = settings["ses_sender"]
+    if not sender:
+        raise ValueError("Email not configured: no SES sender address set.")
+
+    region = settings["ses_region"]
+    client = _get_ses_client(region)
+
+    # Build MIME message for custom headers
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = f"Race Crew Network <{sender}>"
+    msg["To"] = to
+
+    # Add unsubscribe headers (RFC 8058)
+    unsubscribe_url = generate_unsubscribe_url(to)
+    msg["List-Unsubscribe"] = f"<{unsubscribe_url}>"
+    msg["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+
+    msg.attach(MIMEText(body_text, "plain", "utf-8"))
+
+    if body_html:
+        footer = (
+            '<hr style="margin-top:20px;border:none;border-top:1px solid #ddd;">'
+            '<p style="font-size:12px;color:#888;">'
+            f'<a href="{unsubscribe_url}">Unsubscribe</a> '
+            'from Race Crew Network emails.</p>'
+        )
+        body_html_with_footer = body_html + footer
+        msg.attach(MIMEText(body_html_with_footer, "html", "utf-8"))
+
+    client.send_raw_email(
+        Source=f"Race Crew Network <{sender}>",
+        Destinations=[to],
+        RawMessage={"Data": msg.as_string()},
+    )
 ```
 
-**downgrade()**:
-Reverses the change:
+Key design decisions:
+1. **Opt-in check first**: If the user opted out, silently skip (no error)
+2. **MIME multipart**: Using raw email (not SES's simple API) to add custom headers
+3. **List-Unsubscribe headers**: Required by RFC 8058 for one-click unsubscribe
+4. **HTML footer**: Every HTML email gets an unsubscribe link appended
+5. **send_raw_email**: Gives full control over headers and MIME structure
+
+# Part 3: Unsubscribe Tokens
+
+## HMAC-SHA256 Token Generation
+
+File: race-crew-network/app/admin/email_service.py:64-71
+
 ```python
-batch_op.drop_constraint(None, type_='unique')
-batch_op.drop_column('calendar_token')
+def generate_unsubscribe_token(email: str) -> str:
+    secret = current_app.config["SECRET_KEY"]
+    return hmac.new(
+        secret.encode("utf-8"),
+        email.lower().encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
 ```
 
-BATCH MODE:
+This creates a deterministic token from the email address and SECRET_KEY.
+The HMAC ensures:
+- Only the server can generate valid tokens (requires SECRET_KEY)
+- The token is tied to a specific email (can't reuse for other addresses)
+- No database lookup needed to validate — just recompute and compare
+
+## Token Verification
+
+File: race-crew-network/app/admin/email_service.py:74-77
+
 ```python
-with op.batch_alter_table('users', schema=None) as batch_op:
+def verify_unsubscribe_token(email: str, token: str) -> bool:
+    expected = generate_unsubscribe_token(email)
+    return hmac.compare_digest(expected, token)
 ```
 
-Required for SQLite (which doesn't support ALTER TABLE directly). Works with
-all databases.
+`hmac.compare_digest()` is timing-safe — it takes constant time regardless
+of how many characters match. This prevents timing attacks where an attacker
+could guess the token character by character.
 
-# Part 3: Creating Migrations
+# Part 4: Unsubscribe Routes
 
-## Workflow
+## GET and POST Unsubscribe
 
-1. **Modify models.py**:
-   Add/change model definitions.
+File: race-crew-network/app/email/routes.py:15-42
 
-2. **Generate migration**:
-   ```bash
-   flask db migrate -m "Add calendar_token to users"
-   ```
-
-   This compares models.py to database and generates migration script.
-
-3. **Review migration**:
-   Check migrations/versions/*.py file. Alembic isn't perfect; you may need
-   to edit.
-
-4. **Apply migration**:
-   ```bash
-   flask db upgrade
-   ```
-
-   Applies pending migrations to database.
-
-INITIAL MIGRATION:
-```bash
-flask db init       # One-time: creates migrations/ directory
-flask db migrate -m "Initial schema"
-flask db upgrade
-```
-
-CHECKING STATUS:
-```bash
-flask db current    # Show current version
-flask db history    # Show migration history
-```
-
-DOWNGRADING:
-```bash
-flask db downgrade  # Undo last migration
-flask db downgrade <revision>  # Downgrade to specific version
-```
-
-# Part 4: Automatic Migrations on Startup
-
-## Entrypoint Script Review
-File: race-crew-network/entrypoint.sh
-
-```bash
-#!/bin/sh
-set -e
-
-echo "Running database migrations..."
-flask db upgrade
-
-echo "Initializing admin account if needed..."
-flask init-admin
-
-echo "Starting Gunicorn..."
-exec gunicorn -c gunicorn.conf.py wsgi:app
-```
-
-**flask db upgrade**:
-Runs before starting Gunicorn. Ensures database schema is current.
-
-**flask init-admin**:
-Creates the initial admin user from INIT_ADMIN_EMAIL and INIT_ADMIN_PASSWORD
-environment variables. Safe to run repeatedly — skips if admin already exists.
-
-WHY THIS IS SAFE:
-- Migrations are idempotent (running twice doesn't break anything)
-- Alembic tracks applied migrations in alembic_version table
-- Already-applied migrations are skipped
-
-BENEFITS:
-- No manual migration step during deployment
-- Can deploy new version with `docker compose up --build`
-- Database always matches code
-
-# Part 5: Production Deployment
-
-## AWS Lightsail Container Service
-This application is deployed on AWS Lightsail Container Service, which provides:
-- **Managed containers**: Auto-restart, health monitoring
-- **HTTPS endpoint**: SSL certificate provisioned and renewed automatically
-- **Custom domain**: racecrew.net with DNS via Route53
-- **Managed MySQL**: Lightsail database with automated daily backups
-- **Object Storage**: S3-compatible bucket for file uploads
-
-ARCHITECTURE:
-
-```
-  Internet
-    |
-    | HTTPS (port 443)
-    v
-  Lightsail Container Service
-    |
-    | Routes to Gunicorn (port 8000)
-    v
-  Web Container (from GHCR image)
-    |
-    +---> Lightsail Managed MySQL
-    |
-    +---> Lightsail Object Storage (S3)
-```
-
-## GitHub Actions CI/CD
-The deployment pipeline runs automatically on push to master:
-
-1. **Build**: Docker image built with GitHub Actions
-2. **Scan**: Trivy scans image for CRITICAL/HIGH vulnerabilities
-3. **Push**: Image pushed to GHCR with SHA and version tags
-4. **Deploy**: AWS CLI deploys new image to Lightsail Container Service
-
-The pipeline blocks deployment if Trivy finds serious vulnerabilities.
-
-## Infrastructure as Code (Terraform)
-All AWS resources are managed with Terraform:
-- Lightsail Container Service
-- Managed MySQL database
-- Object Storage bucket
-- SSL certificate
-- Route53 DNS records
-
-Terraform state stored in S3 with versioning. Changes are planned on PR and
-applied on merge to master via GitHub Actions.
-
-## Environment Variables
-Production environment variables are stored in GitHub Secrets and passed to
-the Lightsail Container Service:
-
-```
-SECRET_KEY=<64-character-random-string>
-DATABASE_URL=mysql+pymysql://user:pass@host:3306/dbname
-BUCKET_NAME=<lightsail-bucket-name>
-AWS_REGION=us-east-1
-ANTHROPIC_API_KEY=<api-key>
-INIT_ADMIN_EMAIL=admin@racecrew.net
-INIT_ADMIN_PASSWORD=<strong-password>
-```
-
-**Generate SECRET_KEY**:
-```bash
-python3 -c "import secrets; print(secrets.token_hex(32))"
-```
-
-# Part 6: Backup Strategies
-
-## Database Backup (Production)
-Lightsail Managed MySQL provides automated backups:
-- **Daily snapshots**: Retained for 7 days
-- **Preferred window**: 06:00-06:30 UTC (2:00-2:30 AM ET)
-- **Point-in-time recovery**: Restore to any second within retention period
-- **Final snapshot**: Created automatically on database deletion
-
-No manual backup scripts needed for production.
-
-## Database Backup (Local Development)
-**Manual Backup**:
-```bash
-docker compose exec db mysqldump -u racecrew -pracecrew racecrew > backup.sql
-```
-
-**Restore**:
-```bash
-docker compose exec -T db mysql -u racecrew -pracecrew racecrew < backup.sql
-```
-
-## File Backup
-File uploads are stored in Lightsail Object Storage (S3-compatible) with
-**versioning enabled**. This protects against accidental deletion — previous
-versions of objects are retained.
-
-## Disaster Recovery
-To restore from scratch:
-1. Provision infrastructure with Terraform
-2. Restore database from Lightsail snapshot
-3. File uploads are already in Object Storage (versioned)
-4. Deploy container via GitHub Actions (or manual AWS CLI deploy)
-5. Admin account is created automatically from env vars on first start
-
-# Part 7: Migration Best Practices
-
-DO:
-- Review generated migrations before applying
-- Test migrations on dev database first
-- Backup before migrating production
-- Use descriptive migration messages
-- Keep migrations small and focused
-
-DON'T:
-- Edit applied migrations (create new ones instead)
-- Delete migration files
-- Manually modify alembic_version table
-- Skip downgrade() implementation
-
-COMMON MIGRATION TASKS:
-
-**Add column**:
 ```python
-batch_op.add_column(sa.Column('new_field', sa.String(100), nullable=True))
+@bp.route("/unsubscribe", methods=["GET", "POST"])
+def unsubscribe():
+    email = request.args.get("email", "").strip().lower()
+    token = request.args.get("token", "")
+
+    if not email or not token or not verify_unsubscribe_token(email, token):
+        abort(400)
+
+    user = User.query.filter_by(email=email).first()
+    if not user:
+        abort(404)
+
+    if request.method == "POST":
+        user.email_opt_in = False
+        db.session.commit()
+        return "", 204
+
+    # GET -- show confirmation page and opt out
+    user.email_opt_in = False
+    db.session.commit()
+    return render_template("unsubscribe.html")
 ```
 
-**Remove column**:
+Two paths serve RFC 8058 compliance:
+- **POST with 204**: Email clients that support one-click unsubscribe send a
+  POST request. The 204 (No Content) response confirms the action.
+- **GET with page**: Users who click the link in the email footer see a
+  confirmation page. The opt-out happens on GET for simplicity.
+
+# Part 5: Bounce and Complaint Webhooks
+
+## SNS Webhook Processing
+
+File: race-crew-network/app/email/routes.py:45-85
+
 ```python
-batch_op.drop_column('old_field')
+@bp.route("/webhooks/ses", methods=["POST"])
+@csrf.exempt
+def ses_webhook():
+    try:
+        payload = json.loads(request.get_data(as_text=True))
+    except (json.JSONDecodeError, TypeError):
+        abort(400)
+
+    msg_type = payload.get("Type")
+
+    # Handle subscription confirmation
+    if msg_type == "SubscriptionConfirmation":
+        subscribe_url = payload.get("SubscribeURL")
+        if subscribe_url:
+            requests.get(subscribe_url, timeout=10)
+        return "", 200
+
+    # Handle notifications
+    if msg_type == "Notification":
+        message = json.loads(payload.get("Message", "{}"))
+        notification_type = message.get("notificationType")
+
+        if notification_type == "Bounce":
+            _handle_bounce(message)
+        elif notification_type == "Complaint":
+            _handle_complaint(message)
+
+        return "", 200
+
+    return "", 200
 ```
 
-**Change column type**:
+Key points:
+- **@csrf.exempt**: This webhook comes from AWS, not a browser form. CSRF
+  tokens would block legitimate requests.
+- **SubscriptionConfirmation**: When you create an SNS topic subscription,
+  AWS sends a confirmation request. The app auto-confirms by fetching the URL.
+- **Bounce handling**: Hard bounces (permanent delivery failure) opt the user
+  out. Soft bounces (temporary) are logged but ignored.
+- **Complaint handling**: When a recipient marks email as spam, the user is
+  opted out immediately.
+
+## Bounce Handler
+
+File: race-crew-network/app/email/routes.py:88-106
+
 ```python
-batch_op.alter_column('field_name', type_=sa.String(255))
+def _handle_bounce(message: dict) -> None:
+    bounce = message.get("bounce", {})
+    bounce_type = bounce.get("bounceType")
+    recipients = bounce.get("bouncedRecipients", [])
+
+    for recipient in recipients:
+        email = recipient.get("emailAddress", "").lower()
+        if bounce_type == "Permanent":
+            user = User.query.filter_by(email=email).first()
+            if user:
+                user.email_opt_in = False
+                db.session.commit()
 ```
 
-**Add index**:
-```python
-batch_op.create_index('idx_email', ['email'])
-```
+Only permanent bounces trigger opt-out. Soft bounces (mailbox full, temporary
+server issues) are transient and don't change user preferences.
 
 # Key Takeaways
 
-1. **Migrations version database schema**. Each migration transforms schema
-   from one version to the next.
+1. **SES configuration lives in SiteSetting**, not environment variables.
+   This allows runtime changes from the admin UI without container restarts.
 
-2. **Flask-Migrate wraps Alembic** for Flask apps. Use `flask db` commands
-   to manage migrations.
+2. **Every email includes unsubscribe headers** (RFC 8058). This is both a
+   legal requirement in many jurisdictions and improves email deliverability.
 
-3. **Automatic migration on startup** ensures database matches code. The
-   entrypoint script runs `flask db upgrade` before starting Gunicorn.
+3. **HMAC tokens are stateless** — no database table needed. The SECRET_KEY
+   and email address together generate a deterministic, verifiable token.
 
-4. **CI/CD automates deployment**. GitHub Actions builds images, scans for
-   vulnerabilities, and deploys to Lightsail on every push to master.
+4. **Bounce and complaint webhooks** automatically protect your sender
+   reputation by opting out unreachable or complaining recipients.
 
-5. **Managed services reduce operations burden**. Lightsail handles HTTPS
-   certificates, database backups, and container health monitoring.
+5. **The opt-in check happens at send time**, not at the route level. This
+   means calling code doesn't need to check — send_email silently skips
+   opted-out users.
 
-6. **Infrastructure as Code** (Terraform) makes infrastructure reproducible
-   and version-controlled alongside application code.
+## What's Next?
+In Day 11, we'll explore the notification system that builds on this email
+service. You'll learn about manual crew notifications, RSVP alerts, scheduled
+reminders, digest mode, and deduplication via NotificationLog.
 
-## Congratulations!
-You've completed the 10-day Flask training! You now understand:
-- Flask application architecture (factory pattern, blueprints)
-- Database modeling with SQLAlchemy (5 models, relationships)
-- Authentication and authorization (Flask-Login, invite system)
-- File uploads with S3 cloud storage
-- iCal calendar feeds
-- Docker containerization and GHCR
-- CI/CD with GitHub Actions
-- Production deployment on AWS Lightsail
-
-NEXT STEPS:
-- Deploy your own instance
-- Customize features for your needs
-- Explore the appendix for quick references
-- Review earlier sessions as needed
-
-See you in the appendix for quick reference materials!
+See you in Day 11!

--- a/training/11-day11.md
+++ b/training/11-day11.md
@@ -1,0 +1,463 @@
+# Day 11: Notification System
+
+## Learning Objectives
+By the end of this session, you will understand:
+- How the manual crew notification flow works (events + crew selection)
+- RSVP-to-skipper notifications with per-event and digest delivery modes
+- Scheduled reminders: RSVP reminder (14 days) and coming-up (3 days)
+- Crew digest emails that batch multiple reminders into one message
+- How NotificationLog prevents duplicate notifications
+- Digest flush when switching from digest to instant delivery
+
+## Concepts Covered
+- Event-driven notifications (RSVP changes, crew joined)
+- Scheduled batch processing (daily digests, reminders)
+- Deduplication via NotificationLog
+- User preference-driven delivery modes (per_rsvp vs digest)
+- SiteSetting for configurable reminder windows
+- Flask CLI commands for scheduled tasks
+
+## File Focus
+For this session, examine:
+- race-crew-network/app/notifications/service.py — All notification logic
+- race-crew-network/app/models.py:240-257 — NotificationLog model
+- race-crew-network/app/models.py:91-103 — notification_preferences property
+- race-crew-network/app/commands.py:65-71 — send-reminders CLI command
+- race-crew-network/app/regattas/routes.py — notify_crew_action trigger
+
+# Part 1: Notification Architecture
+
+## Overview
+
+```
+  Notification Types
+  ==================
+
+  Trigger-based (immediate):
+    Skipper clicks "Notify Crew"  --> notify_crew()
+    Crew member RSVPs             --> notify_rsvp_to_skipper()
+    Invited crew completes reg    --> notify_crew_joined()
+
+  Scheduled (daily cron):
+    14 days before event          --> send_rsvp_reminders()
+    3 days before event           --> send_coming_up_reminders()
+    Daily RSVP summary            --> send_rsvp_digests()
+    Daily crew reminder batch     --> send_crew_digests()
+
+  All funnel through:
+    send_email() (Day 10) --> AWS SES --> Recipient
+```
+
+The notification system builds on the email service from Day 10. Every
+notification function checks `is_email_configured()` before doing anything,
+so the app works fine without email set up — notifications just silently skip.
+
+## NotificationLog — The Deduplication Table
+
+File: race-crew-network/app/models.py:240-257
+
+```python
+class NotificationLog(db.Model):
+    __tablename__ = "notification_log"
+
+    id = db.Column(db.Integer, primary_key=True)
+    notification_type = db.Column(db.String(50), nullable=False)
+    regatta_id = db.Column(db.Integer, db.ForeignKey("regattas.id"), nullable=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    sent_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    trigger_date = db.Column(db.Date, default=date.today, nullable=False)
+
+    __table_args__ = (
+        db.Index("ix_notification_type_regatta", "notification_type", "regatta_id"),
+    )
+```
+
+Every notification creates a log entry with:
+- **notification_type**: Identifies what was sent (e.g., `notify_crew`,
+  `rsvp_reminder`, `coming_up_reminder`, `rsvp_digest`, `crew_joined`)
+- **regatta_id**: Which event (nullable for non-event notifications)
+- **user_id**: Who received or triggered the notification
+- **sent_at**: When the email was sent (UTC)
+- **trigger_date**: The calendar date that triggered it
+
+The composite index on `(notification_type, regatta_id)` makes deduplication
+queries fast — the system checks "was this user already reminded about this
+regatta?" before sending.
+
+# Part 2: Manual Crew Notification
+
+## Notify Crew Flow
+
+When a skipper clicks "Notify Crew" from the schedule page, they select
+events and crew members. The route calls `notify_crew()`.
+
+File: race-crew-network/app/notifications/service.py:35-109
+
+```python
+def notify_crew(
+    regattas: list[Regatta],
+    crew_members: list[User],
+    message: str | None,
+    skipper: User,
+) -> int:
+    if not is_email_configured():
+        return 0
+
+    if not regattas or not crew_members:
+        return 0
+
+    sent_count = 0
+    for crew in crew_members:
+        if crew.invite_token is not None or not crew.email_opt_in:
+            continue
+
+        subject = f"Race Schedule Update from {skipper.display_name}"
+        body_html = render_template(
+            "email/notify_crew.html",
+            crew_name=crew.display_name,
+            skipper_name=skipper.display_name,
+            regattas=regattas,
+            custom_message=message,
+            ...
+        )
+        try:
+            send_email(to=crew.email, subject=subject, ...)
+            for regatta in regattas:
+                db.session.add(
+                    NotificationLog(
+                        notification_type="notify_crew",
+                        regatta_id=regatta.id,
+                        user_id=crew.id,
+                        trigger_date=date.today(),
+                    )
+                )
+            sent_count += 1
+        except Exception:
+            logger.exception("Failed to send crew notification to %s", crew.email)
+
+    if sent_count:
+        db.session.commit()
+    return sent_count
+```
+
+Key design decisions:
+1. **One email per crew member** containing all selected regattas (not one per regatta)
+2. **One log entry per (crew, regatta) pair** — this is what scheduled reminders
+   check to know whether the crew member was ever notified about that event
+3. **Skip ineligible**: invite_token set = registration pending, email_opt_in
+   False = user opted out (see Day 10)
+4. **Custom message**: Skipper can include a personal note in the notification
+5. **Return count** lets the route show "Notified X crew members"
+
+## Why notify_crew Logs Matter
+
+The `notify_crew` log entries serve as a prerequisite for scheduled reminders.
+The RSVP reminder and coming-up reminder functions both check
+`_was_crew_notified()` before sending — if a crew member was never told about
+an event, they won't get a reminder for it.
+
+File: race-crew-network/app/notifications/service.py:227-236
+
+```python
+def _was_crew_notified(user_id: int, regatta_id: int) -> bool:
+    return (
+        NotificationLog.query.filter_by(
+            notification_type="notify_crew",
+            user_id=user_id,
+            regatta_id=regatta_id,
+        ).first()
+        is not None
+    )
+```
+
+# Part 3: RSVP Notifications to Skipper
+
+## Per-RSVP Mode (Default)
+
+When a crew member RSVPs, the regattas route calls `notify_rsvp_to_skipper()`.
+
+File: race-crew-network/app/notifications/service.py:112-175
+
+```python
+def notify_rsvp_to_skipper(rsvp) -> None:
+    if not is_email_configured():
+        return
+
+    skipper = rsvp.regatta.creator
+    if not skipper or not skipper.email_opt_in:
+        return
+
+    prefs = skipper.notification_preferences
+    if not prefs.get("rsvp_notification", True):
+        return
+
+    # Digest mode: skip immediate send
+    if prefs.get("rsvp_delivery") == "digest":
+        return
+
+    subject = f"RSVP Update: {rsvp.user.display_name} — {rsvp.regatta.name}"
+    # ... render and send email ...
+```
+
+The function respects three preference checks:
+1. **email_opt_in**: Global opt-out (from unsubscribe, Day 10)
+2. **rsvp_notification**: Skipper can disable all RSVP notifications
+3. **rsvp_delivery**: If set to "digest", the immediate send is skipped and
+   the RSVP will be included in the next daily digest instead
+
+## Notification Preferences
+
+File: race-crew-network/app/models.py:91-103
+
+```python
+@property
+def notification_preferences(self) -> dict:
+    defaults = {
+        "rsvp_notification": True,
+        "rsvp_delivery": "per_rsvp",
+    }
+    if self.notification_prefs:
+        try:
+            stored = json.loads(self.notification_prefs)
+            defaults.update(stored)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return defaults
+```
+
+The `notification_prefs` column stores a JSON string. The property provides
+defaults and merges stored values. Two keys are supported:
+- **rsvp_notification**: Boolean — whether to receive RSVP alerts at all
+- **rsvp_delivery**: `"per_rsvp"` (instant) or `"digest"` (daily batch)
+
+## Crew Joined Notification
+
+File: race-crew-network/app/notifications/service.py:178-219
+
+When an invited crew member completes registration (Day 4), the registration
+route calls `notify_crew_joined()`. This sends the inviting skipper an email
+confirming their crew member joined, with a link to view the new member's
+profile.
+
+# Part 4: Scheduled Reminders
+
+## RSVP Reminder (14 Days Before)
+
+File: race-crew-network/app/notifications/service.py:499-603
+
+```python
+def send_rsvp_reminders(days_before: int | None = None) -> int:
+    if days_before is None:
+        days_before = int(_get_setting("reminder_rsvp_days_before", "14"))
+
+    target_date = today + timedelta(days=days_before)
+    regattas = Regatta.query.filter(Regatta.start_date == target_date).all()
+```
+
+This function finds regattas starting exactly N days from now, then for each:
+
+1. **Find notified crew**: Query NotificationLog for `notify_crew` entries
+2. **Exclude already reminded**: Query NotificationLog for `rsvp_reminder`
+3. **Exclude already RSVPed**: Query RSVP table
+4. **Set difference**: `notified - reminded - rsvped = eligible`
+5. **Skip digest-mode users**: They get reminders in their crew digest
+6. **Send and log**: Email each eligible user, create NotificationLog entry
+
+The days_before default (14) comes from the `reminder_rsvp_days_before`
+SiteSetting, allowing admins to adjust the reminder window from the settings
+page without code changes.
+
+## Coming-Up Reminder (3 Days Before)
+
+File: race-crew-network/app/notifications/service.py:606-712
+
+Similar structure to RSVP reminders, but with different eligibility:
+
+```python
+# RSVPed yes or maybe
+yes_maybe = RSVP.query.filter(
+    RSVP.regatta_id == regatta.id,
+    RSVP.status.in_(["yes", "maybe"]),
+).all()
+yes_maybe_user_ids = {r.user_id for r in yes_maybe}
+
+eligible_ids = (notified_user_ids & yes_maybe_user_ids) - reminded_user_ids
+```
+
+The key difference: RSVP reminders target crew who **haven't** RSVPed, while
+coming-up reminders target crew who **have** RSVPed yes or maybe. Both require
+the user to have been notified about the event first.
+
+## Reminder Eligibility Flow
+
+```
+  For RSVP Reminders (14 days):
+    Was notified about event?  --> No  --> Skip
+    Already RSVPed?            --> Yes --> Skip
+    Already reminded?          --> Yes --> Skip
+    Using digest mode?         --> Yes --> Skip (goes to crew digest)
+    --> Send RSVP reminder
+
+  For Coming-Up Reminders (3 days):
+    Was notified about event?  --> No  --> Skip
+    RSVPed yes or maybe?       --> No  --> Skip
+    Already reminded?          --> Yes --> Skip
+    Using digest mode?         --> Yes --> Skip (goes to crew digest)
+    --> Send coming-up reminder
+```
+
+# Part 5: Digest Emails
+
+## RSVP Digest (Skipper)
+
+File: race-crew-network/app/notifications/service.py:245-360
+
+Skippers who choose digest mode receive a daily summary instead of individual
+RSVP emails:
+
+```python
+def send_rsvp_digests() -> int:
+    for skipper in skippers:
+        prefs = skipper.notification_preferences
+        if prefs.get("rsvp_delivery") != "digest":
+            continue
+
+        # Find RSVPs since last digest
+        last_digest = NotificationLog.query.filter_by(
+            notification_type="rsvp_digest",
+            user_id=skipper.id,
+        ).order_by(NotificationLog.sent_at.desc()).first()
+
+        since = last_digest.sent_at if last_digest else (now - 1 day)
+
+        recent_rsvps = RSVP.query.filter(
+            RSVP.regatta_id.in_(skipper_regatta_ids),
+            RSVP.updated_at > since,
+        ).all()
+```
+
+The digest groups RSVPs by regatta and sends one email with all updates. The
+`sent_at` timestamp from the last `rsvp_digest` log entry acts as the
+high-water mark — only RSVPs after that timestamp are included.
+
+## Crew Digest
+
+File: race-crew-network/app/notifications/service.py:363-496
+
+Crew members with digest mode get RSVP reminders and coming-up reminders
+batched into a single daily email instead of individual messages:
+
+```python
+def send_crew_digests() -> int:
+    for user in all_users:
+        prefs = user.notification_preferences
+        if prefs.get("rsvp_delivery") != "digest":
+            continue
+
+        # Collect both types of reminders
+        rsvp_needed = [...]  # events needing RSVP
+        coming_up = [...]    # events coming soon
+```
+
+The crew digest runs the same eligibility logic as the individual reminder
+functions but combines results into one email per crew member.
+
+## Running Reminders
+
+File: race-crew-network/app/commands.py:65-71
+
+```python
+@app.cli.command("send-reminders")
+def send_reminders() -> None:
+    """Send all scheduled reminder emails."""
+    from app.notifications.service import send_all_reminders
+    summary = send_all_reminders()
+    click.echo(json.dumps(summary, indent=2))
+```
+
+The `send_all_reminders()` orchestrator runs all four scheduled functions:
+
+File: race-crew-network/app/notifications/service.py:715-726
+
+```python
+def send_all_reminders() -> dict:
+    digests = send_rsvp_digests()
+    crew_digests = send_crew_digests()
+    rsvp_reminders = send_rsvp_reminders()
+    coming_up_reminders = send_coming_up_reminders()
+    return {
+        "digests": digests,
+        "crew_digests": crew_digests,
+        "rsvp_reminders": rsvp_reminders,
+        "coming_up_reminders": coming_up_reminders,
+    }
+```
+
+In production, a scheduled job (cron or external trigger) runs
+`flask send-reminders` daily. The function returns a summary dict for logging.
+
+# Part 6: Digest Flush
+
+## Problem: Switching Delivery Mode
+
+When a skipper switches from digest to instant (per_rsvp), there may be RSVPs
+that arrived during digest mode but haven't been sent yet. The next daily digest
+won't run because the user is now on instant mode. Those RSVPs would be lost.
+
+## Solution: Flush on Switch
+
+File: race-crew-network/app/notifications/service.py:734-831
+
+```python
+def flush_skipper_digest(skipper: User) -> bool:
+    """Send a final catch-up RSVP digest for a skipper switching to instant."""
+    # Find RSVPs since last digest
+    last_digest = NotificationLog.query.filter_by(
+        notification_type="rsvp_digest",
+        user_id=skipper.id,
+    ).order_by(NotificationLog.sent_at.desc()).first()
+
+    since = last_digest.sent_at if last_digest else (now - 1 day)
+
+    recent_rsvps = RSVP.query.filter(
+        RSVP.regatta_id.in_(skipper_regatta_ids),
+        RSVP.updated_at > since,
+    ).all()
+    # ... send digest if any pending RSVPs exist ...
+```
+
+The profile route calls `flush_skipper_digest()` when it detects the delivery
+mode changed from "digest" to "per_rsvp". Similarly, `flush_crew_digest()`
+handles crew members switching modes, sending any pending RSVP reminders and
+coming-up reminders.
+
+# Key Takeaways
+
+1. **Two delivery modes** — per_rsvp (instant) and digest (daily batch) — let
+   users control notification frequency. The notification_preferences JSON
+   property provides defaults with override capability.
+
+2. **NotificationLog enables deduplication**. Every sent notification is logged,
+   and every function checks for existing logs before sending. The
+   `_was_crew_notified()` check links scheduled reminders to the original
+   crew notification — if a crew member was never told about an event, they
+   won't get reminders for it.
+
+3. **Scheduled reminders are date-driven**. RSVP reminders fire 14 days before
+   an event's start_date, coming-up reminders fire 3 days before. Both windows
+   are configurable via SiteSetting.
+
+4. **Digest flush prevents notification loss** when switching from digest to
+   instant mode. Any pending items are sent immediately as a final batch.
+
+5. **`flask send-reminders`** is the single entry point for all scheduled
+   notifications. It runs all four batch functions and returns a summary.
+
+## What's Next?
+In Day 12, we'll explore the calendar integration that lets crew members
+subscribe to an iCal feed. You'll learn about RFC 5545, token-based feed
+authentication, webcal:// URLs, and how RSVP status appears in calendar events.
+
+See you in Day 12!

--- a/training/12-day12.md
+++ b/training/12-day12.md
@@ -1,0 +1,291 @@
+# Day 12: Calendar Integration
+
+## Learning Objectives
+By the end of this session, you will understand:
+- How the iCalendar format (RFC 5545) represents events
+- Token-based feed authentication without login
+- The subscribe page with webcal:// URL generation
+- How the feed is scoped to only yes/maybe RSVPs
+- How RSVP status appears in calendar event descriptions
+- How notification emails link to the calendar subscribe page
+
+## Concepts Covered
+- iCalendar (RFC 5545) format
+- The icalendar Python library
+- Token-based authentication for external clients
+- webcal:// URL scheme for calendar app auto-detection
+- Flask Response with custom MIME type
+- Scoped queries with visible_regattas()
+
+## File Focus
+For this session, examine:
+- race-crew-network/app/calendar/routes.py — Subscribe page and iCal feed
+- race-crew-network/app/models.py:44 — User.calendar_token field
+- race-crew-network/app/templates/calendar/subscribe.html — Subscribe page UI
+
+# Part 1: Calendar Architecture
+
+## Overview
+
+```
+  User visits /calendar/subscribe
+       |
+       | (logged in, generates token if needed)
+       v
+  Subscribe page shows webcal:// URL
+       |
+       | User copies URL or clicks "Subscribe"
+       v
+  Calendar app (Apple Calendar, Google, Outlook)
+       |
+       | Periodically fetches /calendar/<token>.ics
+       v
+  Flask generates iCal with user's visible regattas
+  (filtered to yes/maybe RSVPs only)
+```
+
+Calendar feeds solve a key usability problem: crew members shouldn't have to
+visit the app to check their schedule. Instead, subscribed events appear
+directly in their phone's calendar app, updating automatically.
+
+## Why Token-Based Auth?
+
+Calendar apps can't log in with a username/password or use cookies. They need
+a URL they can fetch anonymously. The `calendar_token` is a secret URL segment
+that authenticates the request:
+
+```
+https://racecrew.example.com/calendar/aBcD3f...xYz.ics
+                                       ^^^^^^^^^^^^^^^^^
+                                       secret token = authentication
+```
+
+Anyone with the URL can access the feed, so the token must remain private.
+
+# Part 2: Subscribe Page
+
+## Token Generation and URL Display
+
+File: race-crew-network/app/calendar/routes.py:13-29
+
+```python
+@bp.route("/calendar/subscribe")
+@login_required
+def subscribe():
+    if not current_user.calendar_token:
+        current_user.calendar_token = secrets.token_urlsafe(32)
+        db.session.commit()
+
+    feed_url = url_for(
+        "calendar.ical_feed", token=current_user.calendar_token, _external=True
+    )
+    webcal_url = feed_url.replace("https://", "webcal://", 1).replace(
+        "http://", "webcal://", 1
+    )
+    return render_template(
+        "calendar/subscribe.html", feed_url=feed_url, webcal_url=webcal_url
+    )
+```
+
+Key details:
+1. **Lazy token generation**: The token is created on first visit, not at
+   registration. This avoids generating tokens for users who never use the
+   calendar feature.
+2. **secrets.token_urlsafe(32)**: 32 bytes of randomness encoded as URL-safe
+   base64 — 43 characters, 256 bits of entropy.
+3. **webcal:// scheme**: Replacing `https://` with `webcal://` tells the
+   operating system to open the URL in the default calendar app instead of the
+   browser.
+4. **Two URLs provided**: `feed_url` (https) for manual copy, `webcal_url` for
+   one-click subscribe buttons.
+
+# Part 3: iCal Feed Generation
+
+## The Feed Route
+
+File: race-crew-network/app/calendar/routes.py:32-97
+
+```python
+@bp.route("/calendar/<token>.ics")
+def ical_feed(token: str):
+    user = User.query.filter_by(calendar_token=token).first_or_404()
+
+    cal = Calendar()
+    cal.add("prodid", "-//Race Crew Network//EN")
+    cal.add("version", "2.0")
+    cal.add("calscale", "GREGORIAN")
+    cal.add("x-wr-calname", "Race Crew Network")
+    cal.add("method", "PUBLISH")
+```
+
+The feed uses the `icalendar` library to build a valid RFC 5545 document.
+Calendar metadata fields:
+- **prodid**: Identifies the application that generated the feed
+- **version**: iCalendar format version (always 2.0)
+- **x-wr-calname**: Display name in the calendar app
+- **method**: PUBLISH indicates a read-only subscription
+
+## Scoped Event Query
+
+```python
+    regattas = (
+        user.visible_regattas()
+        .join(RSVP, (RSVP.regatta_id == Regatta.id) & (RSVP.user_id == user.id))
+        .filter(RSVP.status.in_(["yes", "maybe"]))
+        .order_by(Regatta.start_date)
+        .all()
+    )
+```
+
+The query chains three filters:
+1. **visible_regattas()**: Only events the user can see (their skipper's events,
+   or all events if admin — see Day 3)
+2. **JOIN with RSVP**: Only events where this user has an RSVP
+3. **Filter yes/maybe**: Exclude "no" RSVPs — no point showing events you
+   declined in your calendar
+
+This means the feed is personalized: it shows exactly the events the crew
+member plans to attend.
+
+## Building Calendar Events
+
+```python
+    for regatta in regattas:
+        event = Event()
+        event.add("uid", f"regatta-{regatta.id}@racecrew.net")
+        if regatta.boat_class:
+            event.add("summary", f"{regatta.boat_class} — {regatta.name}")
+        else:
+            event.add("summary", regatta.name)
+        event.add("dtstart", regatta.start_date)
+        end = (regatta.end_date or regatta.start_date) + timedelta(days=1)
+        event.add("dtend", end)
+        event.add("location", regatta.location)
+```
+
+Key iCalendar concepts:
+- **uid**: Globally unique identifier. Calendar apps use this to detect updates
+  vs new events. The format `regatta-{id}@racecrew.net` ensures uniqueness.
+- **summary**: The event title displayed in the calendar.
+- **dtstart/dtend**: Start and end dates. For all-day events (dates, not
+  datetimes), the end date is exclusive in iCal, so we add 1 day.
+- **location**: Shows as the event location, often linked to maps.
+
+## RSVP Status in Description
+
+```python
+        lines = []
+        if regatta.notes:
+            lines.append(regatta.notes)
+
+        rsvps = regatta.rsvps.all()
+        if rsvps:
+            status_map = {"yes": "Yes", "no": "No", "maybe": "Maybe"}
+            crew_lines = [
+                f"  {r.user.initials}: {status_map.get(r.status, r.status)}"
+                for r in rsvps
+            ]
+            lines.append("Crew:\n" + "\n".join(crew_lines))
+
+        my_rsvp = RSVP.query.filter_by(
+            regatta_id=regatta.id, user_id=user.id
+        ).first()
+        if my_rsvp:
+            lines.append(f"Your RSVP: {my_rsvp.status.capitalize()}")
+```
+
+The event description includes:
+1. **Notes**: Any notes from the regatta (location details, etc.)
+2. **Crew roster**: All crew RSVPs with initials and status
+3. **Your RSVP**: The subscribing user's own RSVP status
+
+This gives crew members at-a-glance visibility into who else is coming, right
+from their calendar app.
+
+## Response with Correct MIME Type
+
+```python
+    response = Response(cal.to_ical(), mimetype="text/calendar")
+    response.headers["Content-Disposition"] = (
+        "attachment; filename=race-crew-network.ics"
+    )
+    return response
+```
+
+- **text/calendar**: The MIME type that tells clients this is an iCalendar file
+- **Content-Disposition**: Suggests a filename for clients that download rather
+  than subscribe
+- **cal.to_ical()**: Serializes the Calendar object to RFC 5545 byte format
+
+# Part 4: Calendar Links in Emails
+
+Notification emails from Day 11 include a link to the calendar subscribe page.
+The `notify_crew()` function passes `subscribe_url`:
+
+```python
+subscribe_url = url_for("calendar.subscribe", _external=True)
+
+body_html = render_template(
+    "email/notify_crew.html",
+    ...
+    subscribe_url=subscribe_url,
+)
+```
+
+This encourages crew members to subscribe to the calendar feed after receiving
+their first notification email, keeping their personal calendar in sync with
+the race schedule.
+
+# Part 5: No Login Required for Feed
+
+Notice that the `ical_feed` route has **no `@login_required` decorator**:
+
+```python
+@bp.route("/calendar/<token>.ics")
+def ical_feed(token: str):
+    user = User.query.filter_by(calendar_token=token).first_or_404()
+```
+
+This is intentional. Calendar apps make background HTTP requests and cannot
+participate in Flask-Login sessions. The token in the URL is the only
+authentication. If the token doesn't match any user, `first_or_404()` returns
+a 404 response.
+
+The subscribe page, however, **does** require login:
+
+```python
+@bp.route("/calendar/subscribe")
+@login_required
+def subscribe():
+```
+
+This ensures only the authenticated user can see (and generate) their own
+calendar token.
+
+# Key Takeaways
+
+1. **Token-based feed auth** is necessary because calendar apps can't use
+   cookies or login forms. The `calendar_token` is generated lazily on first
+   visit to the subscribe page.
+
+2. **The feed is scoped** to visible regattas with yes/maybe RSVPs. Crew
+   members only see events they plan to attend, personalized to their
+   skipper assignments.
+
+3. **webcal:// URLs** trigger the operating system's calendar app. The
+   subscribe page provides both webcal:// and https:// URLs for flexibility.
+
+4. **iCal event descriptions include crew RSVP status**, giving users
+   at-a-glance attendance visibility directly in their calendar app.
+
+5. **The `icalendar` library** handles RFC 5545 serialization. Key fields
+   are uid (for update detection), dtstart/dtend (exclusive end for
+   all-day events), and location.
+
+## What's Next?
+In Day 13, we'll explore the AI-powered schedule import feature. You'll learn
+how the Claude API extracts structured event data from URLs and files, how
+SSE streaming provides progress updates, and how SSRF protection secures
+URL fetching.
+
+See you in Day 13!

--- a/training/13-day13.md
+++ b/training/13-day13.md
@@ -1,0 +1,438 @@
+# Day 13: AI-Powered Schedule Import
+
+## Learning Objectives
+By the end of this session, you will understand:
+- How the Claude API extracts structured event data from web pages and files
+- Prompt engineering for reliable JSON extraction
+- File import support for PDF, DOCX, and TXT
+- ImportCache for caching extraction results
+- SSE (Server-Sent Events) streaming for real-time progress
+- SSRF protection when fetching external URLs
+- Two-level document discovery (level-1 detail pages, level-2 deep crawl)
+
+## Concepts Covered
+- Anthropic Claude API (anthropic SDK)
+- Prompt engineering for structured data extraction
+- Server-Sent Events (SSE) for streaming responses
+- SSRF (Server-Side Request Forgery) protection
+- BeautifulSoup HTML parsing
+- File text extraction (pypdf, python-docx)
+- ImportCache and TaskResult models
+- JSON-LD and data attribute extraction
+
+## File Focus
+For this session, examine:
+- race-crew-network/app/admin/ai_service.py — Claude API integration
+- race-crew-network/app/admin/file_utils.py — PDF/DOCX/TXT extraction
+- race-crew-network/app/admin/routes.py:145-155 — SSRF protection
+- race-crew-network/app/admin/routes.py:252-303 — URL content fetching
+- race-crew-network/app/admin/routes.py:569-648 — SSE extraction endpoint
+- race-crew-network/app/models.py:207-257 — ImportCache and TaskResult models
+
+# Part 1: Import Architecture
+
+## Overview
+
+```
+  Admin/Skipper
+       |
+       | URL, paste, or file upload
+       v
+  [Import Page]
+       |
+       | POST to SSE endpoint
+       v
+  [_fetch_url_content()] ------> SSRF check
+       |                          |
+       | HTML/text content        | blocked if private IP
+       v
+  [extract_regattas()] --------> Claude API
+       |                          |
+       | JSON array of events     | claude-sonnet-4-20250514
+       v
+  [Preview Page] -------> [Confirm] --> Save to DB
+       |
+       | Optional: discover documents
+       v
+  [discover_documents()] -------> Claude API (per event)
+       |
+       | NOR/SI/WWW links
+       v
+  [Document Review] --> Attach to regattas
+```
+
+The import pipeline has three stages: extract events from content, preview
+for admin review, and confirm to save. Document discovery is an optional
+follow-up step that finds NOR (Notice of Race) and SI (Sailing Instructions)
+documents for each imported event.
+
+# Part 2: Claude API Integration
+
+## The Extraction Prompt
+
+File: race-crew-network/app/admin/ai_service.py:9-38
+
+```python
+EXTRACTION_PROMPT = """\
+You are a data extraction assistant. Extract regatta/sailing event information \
+from the provided text and return a JSON array.
+
+Each object in the array must have these fields:
+- "name": string (event name)
+- "boat_class": string or null
+- "location": string (city, yacht club, or venue)
+- "location_url": string or null
+- "start_date": string in "YYYY-MM-DD" format
+- "end_date": string in "YYYY-MM-DD" format or null
+- "notes": string or null
+- "detail_url": string or null
+
+Rules:
+- The year is {year} unless the text explicitly states otherwise.
+- If a date says only "Mar 15", interpret as {year}-03-15.
+- Return ONLY the JSON array, no markdown fences, no explanation.
+- If no events are found, return an empty array: []
+
+Text to extract from:
+{content}"""
+```
+
+Key prompt engineering decisions:
+1. **Explicit schema**: Every field is defined with its type and nullability
+2. **Year injection**: `{year}` prevents the model from guessing years
+3. **Date interpretation rules**: Handles ambiguous date formats ("Mar 15-16")
+4. **Output format constraint**: "ONLY the JSON array" — no markdown, no explanation
+5. **Empty case**: Explicit instruction to return `[]` if nothing found
+
+## Calling the Claude API
+
+File: race-crew-network/app/admin/ai_service.py:104-150
+
+```python
+def extract_regattas(content: str, year: int) -> list[dict]:
+    api_key = current_app.config.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError("ANTHROPIC_API_KEY is not configured.")
+
+    client = anthropic.Anthropic(api_key=api_key)
+    prompt = EXTRACTION_PROMPT.format(year=year, content=content)
+
+    try:
+        message = client.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=4096,
+            messages=[{"role": "user", "content": prompt}],
+            timeout=30.0,
+        )
+    except anthropic.APITimeoutError:
+        raise ConnectionError("Claude API request timed out.")
+    except anthropic.RateLimitError:
+        raise ConnectionError("Claude API rate limit exceeded.")
+    except anthropic.APIStatusError as e:
+        raise ConnectionError(f"Claude API error: {e.message}")
+
+    raw = message.content[0].text.strip()
+    # Strip markdown code fences if present
+    if raw.startswith("```"):
+        lines = raw.split("\n")
+        lines = [ln for ln in lines[1:] if ln.strip() != "```"]
+        raw = "\n".join(lines)
+
+    data = json.loads(raw)
+    return data
+```
+
+Design choices:
+- **Error mapping**: anthropic SDK exceptions are converted to ConnectionError
+  with user-friendly messages
+- **Code fence stripping**: Despite the prompt saying "no markdown", LLMs
+  sometimes wrap output in code fences — the function handles this gracefully
+- **30-second timeout**: Prevents hung requests from blocking the worker
+
+# Part 3: File Import
+
+## Text Extraction Pipeline
+
+File: race-crew-network/app/admin/file_utils.py
+
+```python
+def extract_text_from_file(file_storage: FileStorage, filename: str) -> str:
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+
+    if ext == "pdf":
+        text = extract_text_from_pdf(file_storage)
+    elif ext == "docx":
+        text = extract_text_from_docx(file_storage)
+    elif ext == "txt":
+        text = file_storage.stream.read().decode("utf-8", errors="replace")
+    else:
+        raise ValueError(f"Unsupported file type: .{ext}")
+
+    text = text.strip()
+    if not text:
+        raise ValueError("File appears to be empty.")
+    return text
+```
+
+Three format handlers:
+- **PDF**: Uses `pypdf` to extract text from each page
+- **DOCX**: Uses `python-docx` to extract paragraphs and table cells
+- **TXT**: Direct UTF-8 decode with error replacement
+
+The DOCX handler deserves a closer look:
+
+File: race-crew-network/app/admin/file_utils.py:19-35
+
+```python
+def extract_text_from_docx(file_storage: FileStorage) -> str:
+    doc = DocxDocument(file_storage.stream)
+    parts = []
+
+    for para in doc.paragraphs:
+        text = para.text.strip()
+        if text:
+            parts.append(text)
+
+    for table in doc.tables:
+        for row in table.rows:
+            cells = [cell.text.strip() for cell in row.cells if cell.text.strip()]
+            if cells:
+                parts.append(" | ".join(cells))
+
+    return "\n".join(parts)
+```
+
+Tables are common in schedule documents (event name | date | location). The
+extractor joins cells with `|` separators so the AI can identify tabular data.
+
+# Part 4: SSRF Protection
+
+## Why SSRF Matters
+
+When a web application fetches URLs on behalf of users, an attacker could
+submit URLs pointing to internal services (e.g., `http://169.254.169.254/`
+for AWS metadata, or `http://localhost:5432/` for internal databases). This
+is a Server-Side Request Forgery (SSRF) attack.
+
+## The Guard
+
+File: race-crew-network/app/admin/routes.py:145-155
+
+```python
+def _is_private_ip(hostname: str) -> bool:
+    """Check if a hostname resolves to a private/loopback IP (SSRF guard)."""
+    try:
+        results = getaddrinfo(hostname, None)
+        for _, _, _, _, sockaddr in results:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if ip.is_private or ip.is_loopback or ip.is_reserved:
+                return True
+    except Exception:
+        return True  # Fail closed — if DNS fails, block it
+    return False
+```
+
+The function resolves the hostname to IP addresses using `getaddrinfo()`, then
+checks each against Python's `ipaddress` module:
+- **is_private**: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
+- **is_loopback**: 127.x.x.x (localhost)
+- **is_reserved**: Link-local (169.254.x.x), documentation ranges, etc.
+
+The fail-closed approach (returning True on exception) means DNS failures or
+unusual hostnames are blocked rather than allowed.
+
+## URL Content Fetching
+
+File: race-crew-network/app/admin/routes.py:252-303
+
+```python
+def _fetch_url_content(url: str) -> str:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname:
+        raise ValueError("Invalid URL.")
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("Only HTTP and HTTPS URLs are supported.")
+    if _is_private_ip(parsed.hostname):
+        raise ValueError("URLs pointing to private networks are not allowed.")
+
+    resp = requests.get(url, timeout=15, headers={"User-Agent": "RaceCrewNetwork/1.0"})
+    resp.raise_for_status()
+```
+
+Three layers of validation:
+1. **Scheme check**: Only http/https (no file://, ftp://, etc.)
+2. **SSRF check**: Hostname must resolve to a public IP
+3. **Timeout**: 15 seconds prevents slow-loris attacks
+
+For HTML responses, the function extracts clean text using BeautifulSoup:
+- Removes script, style, nav, footer, header tags
+- Preserves link URLs inline: `"Event Page [https://example.com/event]"`
+- Extracts JSON-LD structured data (schema.org Events)
+- Extracts data attributes (Vue/React hydration data)
+- Truncates to 20,000 characters to stay within API limits
+
+# Part 5: SSE Streaming
+
+## Server-Sent Events for Progress
+
+File: race-crew-network/app/admin/routes.py:569-648
+
+```python
+@bp.route("/admin/import-schedule/extract", methods=["POST"])
+@login_required
+def import_schedule_extract():
+    """SSE endpoint that streams extraction progress."""
+    task_id = str(uuid.uuid4())
+
+    def _sse(event: dict) -> str:
+        return f"data: {json.dumps(event)}\n\n"
+
+    def generate():
+        yield _sse({"type": "progress", "message": f"Fetching {schedule_url}..."})
+
+        try:
+            content = _fetch_url_content(schedule_url)
+        except (ValueError, requests.RequestException) as e:
+            yield _sse({"type": "error", "message": f"Could not fetch URL: {e}"})
+            yield _sse({"type": "failed"})
+            return
+
+        yield _sse({"type": "progress", "message": "Sending to AI for extraction..."})
+
+        regattas = extract_regattas(content, year)
+
+        yield _sse({"type": "progress", "message": f"Found {len(regattas)} events"})
+        yield _sse({"type": "done", "redirect": preview_url})
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="text/event-stream",
+    )
+```
+
+SSE provides real-time feedback during the multi-step extraction process:
+1. **"Fetching URL..."** — URL download in progress
+2. **"Sending to AI..."** — Claude API call in progress
+3. **"Found X events"** — Extraction complete
+4. **Error events** — Something failed, show message to user
+
+The browser uses JavaScript's `EventSource` API to listen for these events
+and update the progress UI in real time. The final `done` event includes a
+redirect URL to the preview page.
+
+## TaskResult for Cross-Request Data
+
+Extraction results need to survive between the SSE request and the preview
+page request. The `TaskResult` model stores them temporarily:
+
+```python
+def _store_task_result(task_id: str, result_type: str, data: dict) -> None:
+    row = TaskResult(id=task_id, result_type=result_type, data_json=json.dumps(data))
+    db.session.add(row)
+    db.session.commit()
+```
+
+The preview page retrieves and deletes the result:
+
+```python
+def _pop_task_result(task_id: str, result_type: str) -> dict | None:
+    row = TaskResult.query.filter_by(id=task_id, result_type=result_type).first()
+    if not row:
+        return None
+    data = json.loads(row.data_json)
+    db.session.delete(row)
+    db.session.commit()
+    return data
+```
+
+Stale results (older than 1 hour) are cleaned up automatically. This is a
+simple alternative to server-side sessions or Redis for passing data between
+requests.
+
+# Part 6: ImportCache
+
+File: race-crew-network/app/models.py:207-225
+
+The ImportCache stores extraction results keyed by URL. When the same URL is
+imported again, the cached results are returned immediately instead of making
+another Claude API call. The cache shows its age ("extracted 3 days ago") and
+offers a "Force Re-Extract" option to bypass it.
+
+```python
+class ImportCache(db.Model):
+    __tablename__ = "import_cache"
+
+    id = db.Column(db.Integer, primary_key=True)
+    url = db.Column(db.String(2048), nullable=False, unique=True, index=True)
+    year = db.Column(db.Integer, nullable=False)
+    results_json = db.Column(db.Text, nullable=False)
+    regatta_count = db.Column(db.Integer, nullable=False, default=0)
+    extracted_at = db.Column(db.DateTime, ...)
+```
+
+# Part 7: Document Discovery
+
+## Two-Level Discovery
+
+After importing events, the admin can discover NOR and SI documents:
+
+**Level 1**: For each event with a `detail_url`, fetch that page and ask Claude
+to find NOR, SI, and WWW (event website) links.
+
+**Level 2 (deep crawl)**: If level 1 found a WWW link (e.g., a regatta
+registration site), fetch that page too and look for NOR/SI documents there.
+
+```
+  Import produces events with detail_url
+       |
+       | Level 1: Fetch detail page
+       v
+  [discover_documents()] --> finds NOR, SI, WWW links
+       |
+       | Level 2: If WWW found, fetch that page too
+       v
+  [discover_documents_deep()] --> finds more NOR, SI
+       |
+       v
+  [Document Review Page] --> Admin selects which to attach
+```
+
+## Discovery Prompts
+
+File: race-crew-network/app/admin/ai_service.py:40-74
+
+The level-1 prompt looks for three document types (NOR, SI, WWW). The level-2
+deep discovery prompt only looks for NOR and SI — since we're already on the
+event website, we don't need to find more website links.
+
+Both prompts include the regatta name and source URL for context, helping the
+AI distinguish relevant documents from unrelated links on the page.
+
+# Key Takeaways
+
+1. **Prompt engineering for structured output** requires explicit schemas,
+   format constraints, and handling for edge cases (years, date ranges, empty
+   results). The code also handles LLMs that wrap output in code fences
+   despite instructions.
+
+2. **SSRF protection is critical** for any feature that fetches user-supplied
+   URLs. The `_is_private_ip()` check resolves hostnames and blocks private,
+   loopback, and reserved addresses. It fails closed on errors.
+
+3. **SSE streaming** provides real-time progress feedback for multi-step
+   operations. Flask's `stream_with_context()` and `text/event-stream` MIME
+   type enable this without WebSockets.
+
+4. **ImportCache avoids redundant API calls** by caching extraction results
+   per URL. TaskResult provides temporary cross-request data passing for the
+   SSE-to-preview flow.
+
+5. **Two-level document discovery** follows links from schedule pages to
+   event detail pages to event websites, progressively finding more documents.
+
+## What's Next?
+In Day 14, we'll explore the user interface layer — Bootstrap 5 responsive
+design, the navbar with mobile collapse, the avatar system with Multiavatar
+SVG and profile photos, and how template filters power the UI.
+
+See you in Day 14!

--- a/training/14-day14.md
+++ b/training/14-day14.md
@@ -1,0 +1,351 @@
+# Day 14: User Interface and Responsive Design
+
+## Learning Objectives
+By the end of this session, you will understand:
+- How Bootstrap 5 provides the responsive grid and component system
+- The navbar structure with mobile collapse and role-based visibility
+- The avatar system: Multiavatar SVG generation with profile photo override
+- How the user_icon template filter implements the photo-with-fallback pattern
+- The impersonation banner and how it surfaces admin context
+- Mobile-friendly layout patterns used throughout the app
+
+## Concepts Covered
+- Bootstrap 5 responsive grid and breakpoints
+- Navbar with expand-md, collapse, and mobile toggler
+- Multiavatar SVG avatars
+- Template filters for UI rendering (avatar_svg, user_icon)
+- sort_rsvps and regatta_days display helpers
+- Flash message rendering with Bootstrap alerts
+- Conditional Google Analytics injection
+- Mobile-first responsive design patterns
+
+## File Focus
+For this session, examine:
+- race-crew-network/app/templates/base.html — Base template with navbar
+- race-crew-network/app/__init__.py:106-153 — Template filters
+- race-crew-network/app/__init__.py:80-104 — Site settings context processor
+- race-crew-network/app/static/css/style.css — Custom styles
+
+# Part 1: Base Template Structure
+
+## The HTML Shell
+
+File: race-crew-network/app/templates/base.html
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Race Crew Network{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/.../bootstrap.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+</head>
+```
+
+Key elements:
+- **viewport meta tag**: `width=device-width, initial-scale=1.0` is essential
+  for responsive design — without it, mobile browsers render at desktop width
+  and zoom out
+- **Bootstrap 5.3.3 from CDN**: The CSS framework that provides the grid,
+  components, and utilities
+- **Custom stylesheet**: Loaded after Bootstrap to override defaults
+- **Block title**: Child templates can override the page title
+
+## Template Inheritance
+
+Every page extends base.html:
+
+```html
+{% extends "base.html" %}
+{% block title %}My Page{% endblock %}
+{% block content %}
+    <h1>Page content here</h1>
+{% endblock %}
+{% block scripts %}
+    <script>/* page-specific JS */</script>
+{% endblock %}
+```
+
+Three extension points:
+- **title**: The `<title>` tag content
+- **content**: The main page body (inside a `.container`)
+- **scripts**: Page-specific JavaScript (loaded after Bootstrap JS)
+
+# Part 2: Responsive Navbar
+
+## Structure and Breakpoints
+
+File: race-crew-network/app/templates/base.html:24-70
+
+```html
+<nav class="navbar navbar-expand-md navbar-dark bg-dark">
+    <div class="container">
+        <a class="navbar-brand" href="...">
+            <img src="..." alt="Race Crew Network" class="navbar-logo">
+        </a>
+        {% if current_user.is_authenticated %}
+        <button class="navbar-toggler" type="button"
+                data-bs-toggle="collapse" data-bs-target="#navMenu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navMenu">
+            <div class="navbar-nav ms-auto align-items-center gap-2">
+                <a class="nav-link" href="...">Home</a>
+                <a class="nav-link" href="...">Calendar</a>
+                {% if current_user.is_admin or current_user.is_skipper %}
+                <a class="nav-link" href="...">My Crew</a>
+                {% endif %}
+                ...
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</nav>
+```
+
+Bootstrap responsive classes:
+- **navbar-expand-md**: On medium screens (≥768px) and larger, the nav items
+  display horizontally. Below that, they collapse into a hamburger menu.
+- **navbar-toggler**: The hamburger button, only visible on small screens
+- **collapse navbar-collapse**: The collapsible content area
+- **ms-auto**: Pushes nav items to the right (margin-start: auto)
+
+## Role-Based Visibility
+
+The navbar shows different items based on the user's role:
+
+```html
+<!-- Everyone sees: Home, Calendar -->
+<a class="nav-link" href="...">Home</a>
+<a class="nav-link" href="...">Calendar</a>
+
+<!-- Skipper and Admin see: My Crew -->
+{% if current_user.is_admin or current_user.is_skipper %}
+<a class="nav-link" href="...">My Crew</a>
+{% endif %}
+
+<!-- Admin only sees: Admin dropdown -->
+{% if current_user.is_admin %}
+<li class="nav-item dropdown">
+    <a class="dropdown-toggle" ...>Admin</a>
+    <ul class="dropdown-menu">
+        <li><a href="...">Users</a></li>
+        <li><a href="...">Analytics Settings</a></li>
+        <li><a href="...">Email Settings</a></li>
+    </ul>
+</li>
+{% endif %}
+
+<!-- Non-skipper, non-admin: Create My Schedule -->
+{% if not current_user.is_skipper and not current_user.is_admin %}
+<form method="POST" action="{{ url_for('auth.create_schedule') }}">
+    <button type="submit" class="dropdown-item">Create My Schedule</button>
+</form>
+{% endif %}
+```
+
+The "Create My Schedule" option appears in the user dropdown only for crew
+members. Once they create a schedule (becoming a skipper), it disappears and
+"My Crew" appears in the main nav instead.
+
+# Part 3: Avatar System
+
+## Multiavatar SVG Generation
+
+File: race-crew-network/app/__init__.py:106-109
+
+```python
+@app.template_filter("avatar_svg")
+def avatar_svg_filter(user, size=20):
+    """Render a Multiavatar inline SVG for a user."""
+    return _avatar_svg_markup(user, size)
+```
+
+Every user has an `avatar_seed` (generated at registration). The `avatar_svg`
+filter renders a unique SVG avatar based on this seed using the Multiavatar
+library. The SVG is inline — no image request needed, it renders instantly.
+
+## user_icon: Photo with Fallback
+
+File: race-crew-network/app/__init__.py:111-132
+
+```python
+@app.template_filter("user_icon")
+def user_icon_filter(user, size=20):
+    """Render profile picture when present; otherwise render avatar fallback."""
+    if user and getattr(user, "profile_image_key", None):
+        try:
+            image_url = escape(storage.get_file_url(user.profile_image_key))
+            display_name = escape(getattr(user, "display_name", "User"))
+            return Markup(
+                f'<span class="avatar-icon" style="display:inline-block;'
+                f"width:{size}px;height:{size}px;vertical-align:middle;"
+                '">'
+                f'<img class="avatar-photo" src="{image_url}" '
+                f'alt="{display_name}" '
+                f'style="width:100%;height:100%;border-radius:50%;'
+                f'object-fit:cover;">'
+                "</span>"
+            )
+        except Exception:
+            pass
+    return _avatar_svg_markup(user, size)
+```
+
+The fallback chain:
+1. If the user has a `profile_image_key` → render a circular `<img>` tag
+   with `border-radius:50%` and `object-fit:cover` for uniform cropping
+2. If the image URL fails (storage error) → fall through to step 3
+3. Render the Multiavatar SVG as fallback
+
+Usage in templates is clean:
+
+```html
+{{ current_user|user_icon(28) }}  {# navbar #}
+{{ user|user_icon(48) }}          {# crew list #}
+```
+
+The size parameter controls both width and height in pixels.
+
+# Part 4: Display Helper Filters
+
+## sort_rsvps
+
+File: race-crew-network/app/__init__.py:134-139
+
+```python
+@app.template_filter("sort_rsvps")
+def sort_rsvps(rsvps):
+    order = {"yes": 0, "no": 1, "maybe": 2}
+    return sorted(
+        rsvps, key=lambda r: (order.get(r.status, 3), r.user.display_name)
+    )
+```
+
+Sorts RSVPs for display: Yes first, then No, then Maybe, then any unknown
+status. Within each group, sorted alphabetically by display name. This makes
+the RSVP list scannable — you immediately see who's coming.
+
+## regatta_days
+
+File: race-crew-network/app/__init__.py:141-153
+
+```python
+@app.template_filter("regatta_days")
+def regatta_days(start_date, end_date=None):
+    if not end_date or end_date <= start_date:
+        return start_date.strftime("%a")       # "Sat"
+    day_span = (end_date - start_date).days
+    if day_span == 1:
+        return f"{start_date.strftime('%a')} & {end_date.strftime('%a')}"  # "Sat & Sun"
+    return f"{start_date.strftime('%a')} thru {end_date.strftime('%a')}"   # "Fri thru Sun"
+```
+
+Formats date ranges into human-friendly day descriptions:
+- Single day: "Sat"
+- Two days: "Sat & Sun"
+- Three+ days: "Fri thru Sun"
+
+Used in the schedule table to show at-a-glance duration without full dates.
+
+# Part 5: Impersonation Banner
+
+File: race-crew-network/app/templates/base.html:72-80
+
+```html
+{% if session.get('impersonating_admin_id') %}
+<div class="alert alert-warning text-center mb-0 rounded-0 py-2">
+    <strong>Viewing as {{ current_user.display_name }}</strong> —
+    <form method="POST" action="{{ url_for('auth.stop_impersonation') }}"
+          class="d-inline">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="btn btn-sm btn-warning">Exit</button>
+    </form>
+</div>
+{% endif %}
+```
+
+When an admin is impersonating a user (Day 5), a yellow warning banner appears
+below the navbar on every page. It shows who they're viewing as and provides
+an "Exit" button to return to their admin identity. The banner uses:
+- **alert-warning**: Yellow background for visual prominence
+- **rounded-0**: No border radius (spans full width like a toolbar)
+- **d-inline**: The form renders inline with the text
+- **CSRF token**: The exit action is a POST to prevent CSRF
+
+# Part 6: Flash Messages
+
+File: race-crew-network/app/templates/base.html:82-92
+
+```html
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+{% for category, message in messages %}
+<div class="alert alert-{{ 'danger' if category == 'error' else category }}
+            alert-dismissible fade show" role="alert">
+    {{ message }}
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+</div>
+{% endfor %}
+{% endif %}
+{% endwith %}
+```
+
+Flash messages provide one-time feedback after form submissions. The category
+maps to Bootstrap alert classes:
+- `flash("Created!", "success")` → green `alert-success`
+- `flash("Access denied.", "error")` → red `alert-danger`
+- `flash("Already exists.", "warning")` → yellow `alert-warning`
+
+The `error` → `danger` mapping handles the naming mismatch between Flask
+flash categories and Bootstrap alert classes.
+
+# Part 7: Conditional Google Analytics
+
+File: race-crew-network/app/templates/base.html:14-22
+
+```html
+{% if ga_measurement_id and not is_dev_or_test %}
+<script async src="https://www.googletagmanager.com/gtag/js?id=..."></script>
+{% endif %}
+```
+
+The context processor (Day 15) provides `ga_measurement_id` and
+`is_dev_or_test`. GA is disabled when:
+- No measurement ID is configured in SiteSetting
+- Running in test mode (`TESTING=True`)
+- Running on localhost or 127.0.0.1
+
+This prevents local development and test runs from polluting production
+analytics data.
+
+# Key Takeaways
+
+1. **Bootstrap 5 navbar-expand-md** gives a responsive navbar that collapses
+   into a hamburger menu below 768px. Role-based Jinja conditionals show
+   different nav items to Admin, Skipper, and Crew users.
+
+2. **The user_icon filter** implements a photo-with-SVG-fallback pattern.
+   Users with uploaded profile photos see their photo; everyone else gets a
+   unique Multiavatar SVG generated from their avatar_seed.
+
+3. **Template filters** (sort_rsvps, regatta_days, avatar_svg, user_icon)
+   keep display logic out of route handlers and templates. They're registered
+   globally in the app factory and available in every template.
+
+4. **The impersonation banner** uses session state to show a persistent warning
+   when an admin is viewing the app as another user, with a CSRF-protected
+   exit button.
+
+5. **Flash messages** map Flask categories to Bootstrap alert classes, with
+   a special `error` → `danger` translation. Dismissible alerts clean up
+   the UI after the user acknowledges the message.
+
+## What's Next?
+In Day 15, we'll explore the SiteSetting model that powers runtime
+configuration — Google Analytics settings, email settings, and how they
+differ from environment variables.
+
+See you in Day 15!

--- a/training/15-day15.md
+++ b/training/15-day15.md
@@ -1,0 +1,316 @@
+# Day 15: Site Settings and Admin Configuration
+
+## Learning Objectives
+By the end of this session, you will understand:
+- How the SiteSetting model provides a key/value store for runtime config
+- The Google Analytics settings page and conditional GA injection
+- The email settings page (SES sender, region, reminder windows)
+- How runtime configuration differs from environment variables
+- The context processor that bridges database settings to templates
+- The reminder API endpoint with token-based authentication
+
+## Concepts Covered
+- Key/value store pattern with SiteSetting model
+- Runtime configuration vs environment variables
+- Admin settings forms (GET/POST pattern)
+- Context processors for global template variables
+- Test email functionality
+- Token-authenticated API endpoints
+- _upsert pattern for database records
+
+## File Focus
+For this session, examine:
+- race-crew-network/app/models.py:260-277 — SiteSetting model
+- race-crew-network/app/admin/routes.py:435-567 — Settings routes
+- race-crew-network/app/__init__.py:80-104 — inject_site_settings context processor
+
+# Part 1: SiteSetting Model
+
+## Key/Value Store
+
+File: race-crew-network/app/models.py:260-277
+
+```python
+class SiteSetting(db.Model):
+    __tablename__ = "site_settings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    key = db.Column(db.String(100), nullable=False, unique=True, index=True)
+    value = db.Column(db.Text, nullable=False, default="")
+    created_at = db.Column(db.DateTime, ...)
+    updated_at = db.Column(db.DateTime, ..., onupdate=...)
+```
+
+SiteSetting is a simple key/value table. Each row has a unique `key` string
+and a text `value`. The index on `key` makes lookups fast. The `updated_at`
+column auto-updates on modification.
+
+## Why Not Environment Variables?
+
+Environment variables are set at deployment time. Changing them requires
+restarting the container (or redeploying). SiteSetting values live in the
+database and can be changed from the admin web UI without any restart.
+
+| | Environment Variables | SiteSetting |
+|---|---|---|
+| Changed via | `.env` file, deployment config | Admin web UI |
+| Takes effect | After container restart | Immediately |
+| Good for | Secrets, infrastructure config | Feature settings, display config |
+| Examples | SECRET_KEY, DATABASE_URL | GA measurement ID, SES sender |
+
+The rule of thumb: if it's a secret or changes the application's
+infrastructure connections, use an environment variable. If it's a setting
+that admins should be able to adjust without developer intervention, use
+SiteSetting.
+
+## Current SiteSetting Keys
+
+| Key | Used By | Default |
+|-----|---------|---------|
+| `ga_measurement_id` | Google Analytics injection | "" (disabled) |
+| `ses_sender` | Email sender address | "" |
+| `ses_sender_to` | Default test email recipient | "" |
+| `ses_region` | SES AWS region | config["AWS_REGION"] |
+| `reminder_rsvp_days_before` | RSVP reminder window | "14" |
+| `reminder_upcoming_days_before` | Coming-up reminder window | "3" |
+| `reminder_api_token` | Reminder API authentication | "" |
+
+# Part 2: Google Analytics Settings
+
+## The Settings Route
+
+File: race-crew-network/app/admin/routes.py:435-463
+
+```python
+@bp.route("/admin/settings/analytics", methods=["GET", "POST"])
+@login_required
+def analytics_settings():
+    denied = _require_admin()
+    if denied:
+        return denied
+
+    if request.method == "POST":
+        ga_measurement_id = request.form.get("ga_measurement_id", "").strip().upper()
+        _upsert_site_setting("ga_measurement_id", ga_measurement_id)
+
+        if ga_measurement_id and not re.match(r"^(G|GT)-[A-Z0-9]+$", ga_measurement_id):
+            flash(
+                "Measurement ID saved, but format looks unusual.",
+                "warning",
+            )
+
+        flash("Google Analytics settings updated.", "success")
+        return redirect(url_for("admin.analytics_settings"))
+
+    # GET: load current value
+    setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
+    ga_measurement_id = setting.value if setting and setting.value else ""
+
+    return render_template(
+        "admin/analytics_settings.html",
+        ga_measurement_id=ga_measurement_id,
+    )
+```
+
+This follows the standard Flask GET/POST pattern:
+- **GET**: Load the current value from SiteSetting, render the form
+- **POST**: Validate and save the new value, redirect back (POST-redirect-GET)
+
+The format validation is soft — it saves the value even if the format looks
+unusual, but shows a warning. This avoids blocking admins who might have a
+valid but unexpected measurement ID format.
+
+## Context Processor: GA Injection
+
+File: race-crew-network/app/__init__.py:80-104
+
+```python
+@app.context_processor
+def inject_site_settings():
+    ga_measurement_id = ""
+    try:
+        ga_setting = SiteSetting.query.filter_by(key="ga_measurement_id").first()
+        if ga_setting and ga_setting.value:
+            ga_measurement_id = ga_setting.value.strip()
+    except SQLAlchemyError:
+        ga_measurement_id = ""
+
+    is_local_host = False
+    if has_request_context():
+        host = (request.host or "").split(":", 1)[0].lower()
+        is_local_host = host in {"localhost", "127.0.0.1"}
+
+    is_dev_or_test = bool(app.config.get("TESTING")) or is_local_host
+
+    return {
+        "ga_measurement_id": ga_measurement_id,
+        "is_dev_or_test": is_dev_or_test,
+    }
+```
+
+This context processor runs on every request, making `ga_measurement_id` and
+`is_dev_or_test` available in every template. The base template uses them to
+conditionally inject the Google Analytics script (Day 14).
+
+The try/except around the database query handles the case where the
+site_settings table doesn't exist yet (first deploy before migrations).
+
+# Part 3: Email Settings
+
+## The Email Settings Route
+
+File: race-crew-network/app/admin/routes.py:466-519
+
+```python
+@bp.route("/admin/settings/email", methods=["GET", "POST"])
+@login_required
+def email_settings():
+    denied = _require_admin()
+    if denied:
+        return denied
+
+    if request.method == "POST":
+        ses_sender = request.form.get("ses_sender", "").strip()
+        ses_sender_to = request.form.get("ses_sender_to", "").strip()
+        ses_region = request.form.get("ses_region", "").strip()
+
+        _upsert_site_setting("ses_sender", ses_sender)
+        _upsert_site_setting("ses_sender_to", ses_sender_to)
+        if ses_region:
+            _upsert_site_setting("ses_region", ses_region)
+
+        # Reminder settings
+        rsvp_days = request.form.get("reminder_rsvp_days_before", "").strip()
+        upcoming_days = request.form.get("reminder_upcoming_days_before", "").strip()
+        api_token = request.form.get("reminder_api_token", "").strip()
+
+        if rsvp_days:
+            _upsert_site_setting("reminder_rsvp_days_before", rsvp_days)
+        if upcoming_days:
+            _upsert_site_setting("reminder_upcoming_days_before", upcoming_days)
+        _upsert_site_setting("reminder_api_token", api_token)
+
+        flash("Email settings updated.", "success")
+        return redirect(url_for("admin.email_settings"))
+```
+
+The email settings page manages two groups:
+1. **SES configuration**: Sender address, test recipient, AWS region
+2. **Reminder configuration**: RSVP reminder window (days), coming-up
+   reminder window (days), API token for external trigger
+
+## Test Email
+
+File: race-crew-network/app/admin/routes.py:522-545
+
+```python
+@bp.route("/admin/settings/email/test", methods=["POST"])
+@login_required
+def email_test():
+    if not current_user.is_admin:
+        return jsonify({"success": False, "error": "Access denied."}), 403
+
+    try:
+        settings = load_email_settings()
+        recipient = settings["ses_sender_to"] or current_user.email
+        send_email(
+            to=recipient,
+            subject="Race Crew Network — Test Email",
+            body_text="This is a test email...",
+            body_html="<p>This is a test email...</p>",
+        )
+        return jsonify({"success": True, "message": f"Test email sent to {recipient}."})
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 400
+    except ClientError as exc:
+        error_msg = exc.response["Error"].get("Message", str(exc))
+        return jsonify({"success": False, "error": error_msg}), 500
+```
+
+The test email endpoint returns JSON (not HTML) because it's called via
+JavaScript from the settings page. It sends to `ses_sender_to` if configured,
+otherwise to the admin's own email. Errors from both the application
+(ValueError) and AWS (ClientError) are returned as JSON with appropriate
+HTTP status codes.
+
+# Part 4: Reminder API Endpoint
+
+## Token-Authenticated Trigger
+
+File: race-crew-network/app/admin/routes.py:547-567
+
+```python
+@bp.route("/admin/api/send-reminders", methods=["GET"])
+@csrf.exempt
+def send_reminders_api():
+    """Token-authenticated endpoint to trigger all scheduled reminders."""
+    token = request.args.get("token", "")
+    if not token:
+        return jsonify({"error": "Missing token"}), 403
+
+    stored_token = SiteSetting.query.filter_by(key="reminder_api_token").first()
+    if not stored_token or not stored_token.value or stored_token.value != token:
+        return jsonify({"error": "Invalid token"}), 403
+
+    from app.notifications.service import send_all_reminders
+    summary = send_all_reminders()
+    return jsonify(summary)
+```
+
+This endpoint provides an alternative to the `flask send-reminders` CLI
+command (Day 11). It's designed for external schedulers like AWS EventBridge
+that trigger it via HTTP GET with a token parameter.
+
+Key design choices:
+- **@csrf.exempt**: External services can't provide CSRF tokens
+- **GET method**: Simple for webhook triggers (no request body needed)
+- **Token comparison**: The `reminder_api_token` SiteSetting must match the
+  request's `token` query parameter
+- **No login required**: Uses token auth instead of session auth
+
+# Part 5: The Upsert Pattern
+
+The settings routes use `_upsert_site_setting()` to create-or-update:
+
+```python
+def _upsert_site_setting(key: str, value: str) -> None:
+    setting = SiteSetting.query.filter_by(key=key).first()
+    if setting:
+        setting.value = value
+    else:
+        setting = SiteSetting(key=key, value=value)
+        db.session.add(setting)
+    db.session.commit()
+```
+
+This is a common database pattern: look up by key, update if exists, insert
+if not. It's simpler than SQL's INSERT ON DUPLICATE KEY UPDATE but achieves
+the same result in ORM code.
+
+# Key Takeaways
+
+1. **SiteSetting provides runtime configuration** without container restarts.
+   It's a simple key/value store with unique indexed keys, ideal for settings
+   that admins change through the web UI.
+
+2. **Environment variables vs SiteSetting**: Use env vars for secrets and
+   infrastructure (DATABASE_URL, SECRET_KEY). Use SiteSetting for feature
+   configuration that admins manage (GA ID, email sender, reminder windows).
+
+3. **Context processors bridge database to templates**. The
+   `inject_site_settings` processor runs on every request, making GA
+   configuration available in base.html without any route-specific code.
+
+4. **The test email endpoint** returns JSON for JavaScript consumption.
+   AWS SDK errors (ClientError) are translated to user-friendly JSON responses.
+
+5. **The reminder API endpoint** uses token-based auth stored in SiteSetting,
+   allowing external schedulers to trigger notifications without Flask-Login
+   sessions.
+
+## What's Next?
+In Day 16, we'll explore Docker and containerization — how the Dockerfile
+builds the application image, Docker Compose for local development, the
+entrypoint script, and Gunicorn configuration.
+
+See you in Day 16!

--- a/training/16-day16.md
+++ b/training/16-day16.md
@@ -1,0 +1,315 @@
+# Day 16: Docker and Containerization
+
+## Learning Objectives
+By the end of this session, you will understand:
+- How the Dockerfile builds the application image layer by layer
+- Why system dependencies are needed (MySQL client, WeasyPrint, Cairo)
+- Docker Compose orchestration for local development
+- The entrypoint script: migrations, admin init, and Gunicorn startup
+- Gunicorn configuration for production serving
+- GitHub Container Registry (GHCR) image publishing
+- Volume management for persistent data
+
+## Concepts Covered
+- Multi-stage Docker build optimization
+- Python 3.13-slim base image
+- System dependency management for Python packages
+- Docker Compose service orchestration
+- Health checks and startup ordering
+- Entrypoint scripts and exec
+- Gunicorn WSGI server configuration
+- Named volumes vs bind mounts
+- Container registry publishing
+
+## File Focus
+For this session, examine:
+- race-crew-network/Dockerfile — Container build instructions
+- race-crew-network/docker-compose.yml — Local development orchestration
+- race-crew-network/entrypoint.sh — Container startup script
+- race-crew-network/gunicorn.conf.py — WSGI server configuration
+- race-crew-network/wsgi.py — Application entry point
+
+# Part 1: Dockerfile
+
+## Layer-by-Layer Build
+
+File: race-crew-network/Dockerfile
+
+```dockerfile
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    default-libmysqlclient-dev gcc pkg-config \
+    libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+    libffi-dev libcairo2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN mkdir -p /app/uploads
+
+EXPOSE 8000
+
+CMD ["./entrypoint.sh"]
+```
+
+Each instruction creates a layer. Docker caches layers, so order matters for
+build speed:
+
+### Layer 1: Base Image
+```dockerfile
+FROM python:3.13-slim
+```
+The `slim` variant (~150 MB) includes Python and minimal system packages.
+The full image (~900 MB) includes compilers and development tools we don't
+need at runtime. We install only the specific build tools we need.
+
+### Layer 2: System Dependencies
+```dockerfile
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    default-libmysqlclient-dev gcc pkg-config \
+    libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+    libffi-dev libcairo2 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Two groups of dependencies:
+- **MySQL**: `default-libmysqlclient-dev`, `gcc`, `pkg-config` — needed to
+  compile the `mysqlclient` Python package (C extension)
+- **WeasyPrint/Cairo**: `libpango*`, `libgdk-pixbuf*`, `libffi-dev`,
+  `libcairo2` — needed for PDF generation (Day 7)
+
+The `--no-install-recommends` flag and `rm -rf /var/lib/apt/lists/*` cleanup
+reduce image size.
+
+### Layer 3: Python Dependencies
+```dockerfile
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+```
+
+requirements.txt is copied and installed **before** the application code.
+This means Docker can cache the pip install layer — if only your Python code
+changes (not requirements.txt), Docker reuses the cached dependencies and
+skips the slow pip install.
+
+### Layer 4: Application Code
+```dockerfile
+COPY . .
+RUN mkdir -p /app/uploads
+```
+
+The application code changes most frequently, so it's copied last. The uploads
+directory is created for local file storage.
+
+### Metadata
+```dockerfile
+EXPOSE 8000
+CMD ["./entrypoint.sh"]
+```
+
+- **EXPOSE 8000**: Documents that Gunicorn listens on port 8000 (informational)
+- **CMD**: Default command — runs the entrypoint script
+
+# Part 2: Docker Compose
+
+## Local Development Orchestration
+
+File: race-crew-network/docker-compose.yml
+
+```yaml
+services:
+  web:
+    build: .
+    image: ghcr.io/chris-edwards-pub/race-crew-network:latest
+    env_file: .env
+    ports:
+      - "80:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - uploads:/app/uploads
+    restart: unless-stopped
+
+  db:
+    image: mysql:8.0
+    env_file: .env
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  mysql_data:
+  uploads:
+```
+
+## Service Startup Sequence
+
+```
+  1. Docker pulls mysql:8.0 (if needed)
+  2. Docker builds web image from Dockerfile (if needed)
+  3. db starts, begins MySQL initialization
+  4. Healthcheck runs every 5s: mysqladmin ping
+  5. After 10 successful pings, db is "healthy"
+  6. web starts (depends_on condition met)
+  7. entrypoint.sh runs: migrations → admin init → Gunicorn
+  8. Gunicorn binds to 0.0.0.0:8000
+  9. Docker maps host port 80 → container port 8000
+```
+
+## Key Docker Compose Concepts
+
+**depends_on with service_healthy**: Ensures the database is accepting
+connections before the web container starts. Without the health check, the web
+container might start before MySQL is ready, causing migration failures.
+
+**Named volumes**: `mysql_data` and `uploads` persist across container
+restarts. Removing containers (`docker compose down`) keeps the data.
+Adding `-v` (`docker compose down -v`) deletes the volumes too.
+
+**env_file**: Both services load from `.env`. The web container uses
+`SECRET_KEY`, `DATABASE_URL`, etc. The db container uses `MYSQL_ROOT_PASSWORD`,
+`MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD`.
+
+**Port mapping**: `80:8000` maps host port 80 to the container's port 8000.
+Gunicorn listens on 8000 inside the container; you access the app at
+http://localhost:80 (or just http://localhost).
+
+# Part 3: Entrypoint Script
+
+File: race-crew-network/entrypoint.sh
+
+```bash
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+flask db upgrade
+
+echo "Initializing admin account if needed..."
+flask init-admin
+
+echo "Starting Gunicorn..."
+exec gunicorn -c gunicorn.conf.py wsgi:app
+```
+
+Three steps on every container start:
+
+1. **`flask db upgrade`**: Runs all pending database migrations. Safe to run
+   repeatedly — Alembic tracks which migrations have been applied (Day 17).
+
+2. **`flask init-admin`**: Creates the initial admin account if none exists.
+   Uses INIT_ADMIN_EMAIL and INIT_ADMIN_PASSWORD from the environment. If an
+   admin already exists, it prints a message and continues.
+
+3. **`exec gunicorn`**: The `exec` replaces the shell process with Gunicorn.
+   This is important — without `exec`, the shell would be PID 1 and Gunicorn
+   would be a child process. Docker sends signals (SIGTERM for graceful
+   shutdown) to PID 1, so `exec` ensures Gunicorn receives them directly.
+
+**`set -e`**: Exit immediately if any command fails. If migrations fail, the
+container doesn't start Gunicorn with a broken database.
+
+# Part 4: Gunicorn Configuration
+
+File: race-crew-network/gunicorn.conf.py
+
+```python
+bind = "0.0.0.0:8000"
+workers = 2
+accesslog = "-"
+errorlog = "-"
+```
+
+- **bind**: Listen on all interfaces (0.0.0.0) port 8000
+- **workers**: 2 worker processes handle requests in parallel
+- **accesslog/errorlog**: `-` means stdout/stderr, which Docker captures as
+  container logs (`docker compose logs web`)
+
+## WSGI Entry Point
+
+File: race-crew-network/wsgi.py
+
+```python
+from app import create_app
+
+app = create_app()
+```
+
+Gunicorn needs a module and variable name: `wsgi:app`. This file creates
+the Flask application instance using the factory (Day 2) and exposes it
+as `app` for Gunicorn to serve.
+
+# Part 5: GitHub Container Registry
+
+The CI/CD pipeline (Day 18) builds and pushes the Docker image to GHCR:
+
+```
+ghcr.io/chris-edwards-pub/race-crew-network:latest
+```
+
+The deploy workflow builds the image, tags it with both `latest` and the
+commit SHA, and pushes to GHCR. Production then pulls this image for
+deployment to AWS Lightsail.
+
+The Docker Compose file references this same image name:
+
+```yaml
+image: ghcr.io/chris-edwards-pub/race-crew-network:latest
+```
+
+For local development, `docker compose up --build` builds from the Dockerfile.
+For production, the pre-built image is pulled from GHCR.
+
+# Part 6: Storage Blueprint for Local Development
+
+In local development, uploaded files are stored in the `/app/uploads` volume.
+The storage blueprint (Day 8) serves these files directly:
+
+```
+Production: S3 bucket → presigned URL → browser downloads
+Local dev:  /app/uploads → storage blueprint → browser downloads
+```
+
+The storage abstraction (`app/storage.py`) switches between S3 and local
+based on whether a `BUCKET_NAME` is configured. Docker Compose mounts the
+`uploads` volume so files persist across container restarts.
+
+# Key Takeaways
+
+1. **Layer ordering matters** in Dockerfiles. Copy requirements.txt before
+   application code to cache the expensive pip install layer when only
+   Python code changes.
+
+2. **System dependencies** serve two purposes: compilation tools for C
+   extensions (mysqlclient) and runtime libraries for features like PDF
+   generation (WeasyPrint/Cairo).
+
+3. **The entrypoint script** runs migrations and admin initialization on
+   every container start. `exec` ensures Gunicorn receives Docker signals
+   for graceful shutdown.
+
+4. **Docker Compose health checks** prevent the web container from starting
+   before MySQL is ready. The `service_healthy` condition uses mysqladmin
+   ping to verify database readiness.
+
+5. **Named volumes** persist database data and uploaded files across container
+   restarts. Use `docker compose down -v` only when you want a complete reset.
+
+## What's Next?
+In Day 17, we'll explore database migrations with Flask-Migrate and Alembic,
+followed by the test suite — pytest fixtures, test patterns, and how to mock
+external APIs.
+
+See you in Day 17!

--- a/training/17-day17.md
+++ b/training/17-day17.md
@@ -1,0 +1,368 @@
+# Day 17: Database Migrations and Testing
+
+## Learning Objectives
+By the end of this session, you will understand:
+- How Flask-Migrate and Alembic manage database schema changes
+- The migration history (16 versioned migrations)
+- How to create and apply migrations
+- pytest fixtures: session-scoped app, autouse cleanup, role-based clients
+- Test patterns for admin, skipper, and crew users
+- How to mock external APIs (Anthropic, SES, requests)
+
+## Concepts Covered
+- Flask-Migrate and Alembic fundamentals
+- Migration file structure and versioning
+- SQLite in-memory database for testing
+- StaticPool connection pooling
+- pytest fixtures (scope, autouse, dependency chains)
+- Test client authentication patterns
+- unittest.mock.patch for external APIs
+
+## File Focus
+For this session, examine:
+- race-crew-network/migrations/versions/ — 16 migration files
+- race-crew-network/tests/conftest.py — Test fixtures
+- race-crew-network/tests/test_models.py — Model tests
+- race-crew-network/tests/test_admin_routes.py — Route tests with mocking
+- race-crew-network/tests/test_ai_service.py — AI service tests
+
+# Part 1: Flask-Migrate and Alembic
+
+## What Is Alembic?
+
+Alembic is a database migration tool for SQLAlchemy. Flask-Migrate wraps it
+for Flask. Migrations are versioned Python scripts that describe schema
+changes — adding tables, columns, indexes, etc.
+
+Without migrations, you'd have to manually run `ALTER TABLE` SQL statements
+every time the schema changes. With migrations, schema changes are tracked in
+version control, applied automatically, and can be rolled back.
+
+## Migration Commands
+
+```bash
+# Apply all pending migrations (runs on every container start)
+flask db upgrade
+
+# Create a new migration from model changes
+flask db migrate -m "Add phone to users"
+
+# Downgrade one migration
+flask db downgrade -1
+
+# Show current migration version
+flask db current
+```
+
+`flask db upgrade` is idempotent — Alembic tracks applied migrations in the
+`alembic_version` table. If all migrations are already applied, it does
+nothing. This is why the entrypoint script (Day 16) can safely run it on
+every container start.
+
+## Migration File Structure
+
+Each migration has a revision ID, a reference to its parent, and `upgrade()`
+and `downgrade()` functions:
+
+```python
+"""Add phone to users."""
+revision = "e4b2c7f9a123"
+down_revision = "d4b5e6f7a8c9"
+
+def upgrade():
+    op.add_column("users", sa.Column("phone", sa.String(30), nullable=True))
+
+def downgrade():
+    op.drop_column("users", "phone")
+```
+
+- **revision**: Unique ID for this migration
+- **down_revision**: Parent migration (forms a chain)
+- **upgrade()**: Apply the change
+- **downgrade()**: Reverse the change (for rollbacks)
+
+## Migration History
+
+The project has 16 migrations, building up the schema progressively:
+
+```
+b741dd3b02c6  Initial schema (users, regattas, documents, rsvps)
+a5b6c7d8e9f0  Add skipper_crew association table
+f5a3d8e1b234  Add boat_class to regattas
+c3d4e5f6a7b8  Blank default for boat_class
+b2c3d4e5f678  Add source_url to regattas
+d3a1f5e8b901  Add url to documents
+1f34ac0f8204  Add email_opt_in to users
+9a8b7c6d5e4f  Add site_settings table
+a1b2c3d4e567  Add import_cache table
+c82d4c9ce2d5  Add calendar_token to users
+d4b5e6f7a8c9  Add task_results table
+e4b2c7f9a123  Add phone to users
+f6b7c8d9e0f1  Add profile_image_key to users
+g7c8d9e0f1a2  Add avatar_seed to users
+h8d9e0f1a2b3  Backfill avatar_seed
+i9e0f1a2b3c4  Add notification system
+```
+
+Each migration corresponds to a feature addition. The chain from initial
+schema through notification system tracks the complete evolution of the
+database.
+
+## Creating a Migration
+
+When you add a new column or model to `app/models.py`, Flask-Migrate detects
+the difference:
+
+```bash
+flask db migrate -m "Add new_column to users"
+```
+
+This auto-generates a migration file by comparing the current models to the
+database schema. Always review the generated migration before applying it —
+auto-detection works well for simple changes but may need manual edits for
+complex operations (data migrations, column renames).
+
+# Part 2: Test Configuration
+
+## Test Fixtures
+
+File: race-crew-network/tests/conftest.py
+
+```python
+TEST_CONFIG = {
+    "TESTING": True,
+    "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+    "WTF_CSRF_ENABLED": False,
+    "SERVER_NAME": "localhost",
+    "ANTHROPIC_API_KEY": "test-key",
+    "SQLALCHEMY_ENGINE_OPTIONS": {
+        "poolclass": StaticPool,
+        "connect_args": {"check_same_thread": False},
+    },
+}
+```
+
+Key test configuration:
+- **SQLite in-memory**: No MySQL needed for testing — fast and disposable
+- **CSRF disabled**: Test clients can POST forms without CSRF tokens
+- **SERVER_NAME**: Required for `url_for()` to work outside requests
+- **StaticPool**: Critical for SQLite in-memory databases (explained below)
+
+## The StaticPool Solution
+
+SQLite in-memory databases exist only within a single connection. The default
+connection pool recycles connections, which destroys the in-memory database
+and its tables mid-test-suite. `StaticPool` keeps a single connection alive
+for the entire session.
+
+`check_same_thread: False` allows the connection to be used from multiple
+threads — necessary because Flask's test client may use different threads
+than the fixture setup.
+
+## Session-Scoped App Fixture
+
+```python
+@pytest.fixture(scope="session")
+def app():
+    """Create a Flask app and tables once per test session."""
+    app = create_app(test_config=TEST_CONFIG)
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.drop_all()
+```
+
+`scope="session"` means this fixture runs once for the entire test session:
+1. Create the Flask app with test config
+2. Create all database tables (from models, not migrations)
+3. Yield the app for tests to use
+4. Drop all tables when tests finish
+
+Using `create_all()` instead of migrations is faster and avoids needing the
+migration chain to be SQLite-compatible.
+
+## Autouse Cleanup
+
+```python
+@pytest.fixture(autouse=True)
+def _clean_db(app):
+    """Delete all rows after each test (no schema rebuild)."""
+    yield
+    _db.session.rollback()
+    for table in reversed(_db.metadata.sorted_tables):
+        _db.session.execute(table.delete())
+    _db.session.commit()
+    _db.session.close()
+    g.pop("_login_user", None)
+```
+
+`autouse=True` means this runs for every test automatically. After each test:
+1. **Rollback** any uncommitted transaction
+2. **Delete all rows** from every table (in reverse FK order)
+3. **Commit** the deletes
+4. **Close session** to clear the ORM identity map
+5. **Clear Flask-Login** to prevent login state leaking between tests
+
+This approach (truncate, not recreate) is fast — tables stay, only data is
+cleared.
+
+# Part 3: Role-Based Test Clients
+
+## User Fixtures
+
+```python
+@pytest.fixture()
+def admin_user(db):
+    user = User(
+        email="admin@test.com",
+        display_name="Admin",
+        initials="AD",
+        is_admin=True,
+        is_skipper=True,
+    )
+    user.set_password("password")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+@pytest.fixture()
+def skipper_user(db):
+    user = User(email="skipper@test.com", ..., is_skipper=True)
+    ...
+
+@pytest.fixture()
+def crew_user(db, skipper_user):
+    user = User(email="crew@test.com", ..., invited_by=skipper_user.id)
+    db.session.flush()
+    skipper_user.crew_members.append(user)
+    ...
+```
+
+Three pre-built users for testing different permission levels:
+- **admin_user**: Admin + Skipper (full access)
+- **skipper_user**: Skipper only (can CRUD own events, manage crew)
+- **crew_user**: Crew only (linked to skipper_user, can RSVP)
+
+## Authenticated Client Fixtures
+
+```python
+@pytest.fixture()
+def logged_in_client(client, admin_user):
+    client.post(
+        "/login",
+        data={"email": "admin@test.com", "password": "password"},
+        follow_redirects=True,
+    )
+    return client
+
+@pytest.fixture()
+def logged_in_skipper(client, skipper_user):
+    ...
+
+@pytest.fixture()
+def logged_in_crew(client, crew_user):
+    ...
+```
+
+Each fixture posts to the login route, authenticating the test client. The
+fixture dependency chain ensures the user exists before login:
+
+```
+logged_in_client → client → app
+                 → admin_user → db → app
+```
+
+# Part 4: Test Patterns
+
+## Testing Access Control
+
+```python
+def test_admin_page_requires_admin(logged_in_skipper):
+    resp = logged_in_skipper.get("/admin/settings/analytics")
+    assert resp.status_code == 302  # Redirected (access denied)
+
+def test_admin_page_works_for_admin(logged_in_client):
+    resp = logged_in_client.get("/admin/settings/analytics")
+    assert resp.status_code == 200
+```
+
+Each role-based fixture tests a different permission boundary. Skippers
+should be denied admin pages; admins should succeed.
+
+## Mocking External APIs
+
+```python
+from unittest.mock import patch, MagicMock
+
+@patch("app.admin.ai_service.anthropic.Anthropic")
+def test_extract_regattas(mock_anthropic_class, app):
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+    mock_client.messages.create.return_value.content = [
+        MagicMock(text='[{"name": "Test Regatta", "start_date": "2026-04-01"}]')
+    ]
+
+    with app.app_context():
+        result = extract_regattas("Some schedule text", 2026)
+        assert len(result) == 1
+        assert result[0]["name"] == "Test Regatta"
+```
+
+External APIs (Anthropic, SES, requests) are mocked to:
+- Avoid real API calls in tests (cost, rate limits, flakiness)
+- Control the response data exactly
+- Test error handling paths
+
+The `@patch` decorator replaces the import target with a `MagicMock`. The
+test configures the mock's return value, then verifies the function handles
+the response correctly.
+
+## Testing Model Relationships
+
+```python
+def test_crew_relationship(db, skipper_user, crew_user):
+    assert crew_user in skipper_user.crew_members.all()
+    assert skipper_user in crew_user.skippers
+
+def test_cascade_delete(db, admin_user):
+    regatta = Regatta(name="Test", created_by=admin_user.id, ...)
+    db.session.add(regatta)
+    db.session.commit()
+
+    db.session.delete(regatta)
+    db.session.commit()
+    assert Document.query.filter_by(regatta_id=regatta.id).count() == 0
+```
+
+Model tests verify:
+- Relationships work in both directions
+- Cascading deletes remove dependent records
+- Query methods return correct results for different roles
+
+# Key Takeaways
+
+1. **Flask-Migrate tracks schema evolution** through versioned migration files.
+   `flask db upgrade` is safe to run repeatedly and runs automatically on
+   container start.
+
+2. **SQLite in-memory + StaticPool** provides fast, disposable test databases.
+   The `autouse` cleanup fixture truncates data between tests without
+   recreating tables.
+
+3. **Three fixture tiers** (admin/skipper/crew users and their authenticated
+   clients) make permission testing straightforward. Each test explicitly
+   declares which role it needs.
+
+4. **unittest.mock.patch** replaces external dependencies (Anthropic, SES)
+   with controllable mocks. This keeps tests fast, free, and deterministic.
+
+5. **Tests use `create_all()`** instead of migrations for speed. The migration
+   chain applies to the real MySQL database; tests create tables directly from
+   the current model definitions.
+
+## What's Next?
+In Day 18, we'll explore the CI/CD pipeline, security practices, and
+production deployment — GitHub Actions workflows, Trivy vulnerability
+scanning, Terraform infrastructure, and AWS Lightsail.
+
+See you in Day 18!

--- a/training/18-day18.md
+++ b/training/18-day18.md
@@ -1,0 +1,297 @@
+# Day 18: CI/CD, Security and Deployment
+
+## Learning Objectives
+By the end of this session, you will understand:
+- The three GitHub Actions workflows (deploy, vulnerability scan, terraform)
+- How Trivy vulnerability scanning gates deployments
+- Terraform infrastructure as code for AWS resources
+- AWS Lightsail Container Service deployment
+- Security practices used throughout the application
+
+## Concepts Covered
+- GitHub Actions workflows and triggers
+- Container image scanning with Trivy
+- Deploy gates (scan must pass before deploy)
+- Terraform for infrastructure as code
+- AWS Lightsail Container Service
+- AWS SES with DKIM, SPF, DMARC, MAIL FROM
+- CloudFront for apex domain redirect
+- Security patterns: CSRF, SSRF, path traversal, HMAC, timing-safe comparison
+
+## File Focus
+For this session, examine:
+- race-crew-network/.github/workflows/deploy.yml — Build, scan, and deploy
+- race-crew-network/.github/workflows/vulnerability-scan.yml — Daily scan
+- race-crew-network/.github/workflows/terraform.yml — Infrastructure automation
+- race-crew-network/terraform/main.tf — AWS resource definitions
+
+# Part 1: Deploy Workflow
+
+## Three-Stage Pipeline
+
+File: race-crew-network/.github/workflows/deploy.yml
+
+```
+  Push to master
+       |
+       v
+  [build-and-push]     Build Docker image, push to GHCR
+       |                  Tags: latest, SHA, version
+       v
+  [scan-image]          Trivy scans for CRITICAL/HIGH vulns
+       |                  exit-code: 1 (fail on findings)
+       v                  Results → SARIF + artifact + summary
+  [deploy]              Deploy to AWS Lightsail
+                          Uses SHA tag for immutability
+```
+
+Each stage depends on the previous one (`needs:`), creating a gated pipeline.
+
+### Stage 1: Build and Push
+
+```yaml
+- name: Extract version from app/__init__.py
+  run: |
+    VERSION=$(grep -oP '(?<=__version__ = ")[^"]+' app/__init__.py)
+    echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+- name: Build and push
+  uses: docker/build-push-action@v7
+  with:
+    push: true
+    tags: |
+      ghcr.io/.../race-crew-network:latest
+      ghcr.io/.../race-crew-network:${{ github.sha }}
+      ghcr.io/.../race-crew-network:${{ steps.version.outputs.version }}
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+Three tags per build:
+- **latest**: Convenient for pulling the most recent version
+- **SHA**: Immutable — this exact commit's build, used for deployment
+- **version**: Semantic version extracted from `app/__init__.py`
+
+GitHub Actions build cache (`type=gha`) speeds up subsequent builds by
+reusing unchanged Docker layers.
+
+### Stage 2: Vulnerability Scan (Deploy Gate)
+
+```yaml
+scan-image:
+    needs: build-and-push
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ghcr.io/.../race-crew-network:${{ github.sha }}
+          exit-code: 1              # Fail the job if vulns found
+          ignore-unfixed: true      # Only fixable vulnerabilities
+          severity: CRITICAL,HIGH   # Skip MEDIUM/LOW
+```
+
+**exit-code: 1** is the deploy gate. If Trivy finds any CRITICAL or HIGH
+vulnerability with an available fix, the scan job fails and the deploy job
+is skipped. The team must fix the vulnerability before the deploy proceeds.
+
+Results are reported three ways:
+1. **Table artifact**: Downloadable text report (retained 30 days)
+2. **SARIF upload**: Integrates with GitHub's Security tab
+3. **Job summary**: Visible in the workflow run page
+
+### Stage 3: Deploy to Lightsail
+
+```yaml
+deploy:
+    needs: scan-image
+    steps:
+      - name: Deploy to Lightsail Container Service
+        run: |
+          aws lightsail create-container-service-deployment \
+            --service-name ${{ vars.CONTAINER_SERVICE_NAME }} \
+            --containers '{
+              "web": {
+                "image": "ghcr.io/.../race-crew-network:${{ github.sha }}",
+                "ports": {"8000": "HTTP"},
+                "environment": { ... }
+              }
+            }' \
+            --public-endpoint '{
+              "containerName": "web",
+              "containerPort": 8000,
+              "healthCheck": { "path": "/", "successCodes": "200-499" }
+            }'
+```
+
+The deploy creates a new Lightsail deployment with the SHA-tagged image.
+Environment variables are injected from GitHub Secrets and Variables. Lightsail
+performs a rolling deployment — the new container must pass the health check
+before traffic switches.
+
+# Part 2: Daily Vulnerability Scan
+
+File: race-crew-network/.github/workflows/vulnerability-scan.yml
+
+```yaml
+on:
+  schedule:
+    - cron: "0 6 * * *"   # Daily at 6 AM UTC
+```
+
+The daily scan runs against the `latest` image (the current production image)
+with **exit-code: 0** — it reports but doesn't fail. This catches new
+vulnerabilities discovered after deployment.
+
+## Automated Issue Management
+
+The workflow manages GitHub Issues based on scan results:
+
+```
+  Vulns found + no open issue    → Create new issue
+  Vulns found + open issue       → Add comment with latest results
+  Clean scan + open issue        → Comment "clean" and close issue
+  Clean scan + no open issue     → Do nothing
+```
+
+This means the security issue is automatically opened when vulnerabilities
+appear and closed when they're resolved, providing a persistent audit trail.
+
+# Part 3: Terraform Infrastructure
+
+File: race-crew-network/.github/workflows/terraform.yml
+
+The Terraform workflow runs only when files in `terraform/` change:
+
+```yaml
+on:
+  push:
+    branches: [master]
+    paths: [terraform/**]
+  pull_request:
+    paths: [terraform/**]
+```
+
+On PRs: plan only (shows what would change). On push to master: plan + apply.
+
+## AWS Resources Managed by Terraform
+
+File: race-crew-network/terraform/main.tf
+
+### Compute and Storage
+- **aws_lightsail_container_service**: The container service that runs the app
+- **aws_lightsail_database**: Managed MySQL 8.0 instance
+- **aws_lightsail_bucket**: S3-compatible storage for file uploads
+- **aws_lightsail_bucket_access_key**: IAM credentials for the app
+
+### DNS and SSL
+- **aws_lightsail_certificate**: SSL certificate for the app domain
+- **aws_route53_record (app)**: CNAME pointing to Lightsail's public endpoint
+- **aws_route53_record (cert_validation)**: DNS validation for the certificate
+
+### Apex Domain Redirect
+- **aws_s3_bucket + website_configuration**: S3 redirect from example.com
+  to www.example.com
+- **aws_cloudfront_distribution**: CDN for the apex redirect with SSL
+- **aws_acm_certificate**: SSL cert for the apex domain (CloudFront requires
+  ACM in us-east-1)
+- **aws_route53_record (apex)**: A/AAAA alias to CloudFront
+
+### Email (SES)
+- **aws_ses_domain_identity**: Registers the domain with SES
+- **aws_ses_domain_dkim**: DKIM signing for email authentication
+- **aws_ses_domain_mail_from**: Custom MAIL FROM domain
+- **aws_route53_record (ses_dkim, spf, dmarc, mail_from_mx, mail_from_spf)**:
+  DNS records for email deliverability
+- **aws_iam_user + policy + access_key**: Dedicated IAM user for SES sending
+- **aws_sns_topic + subscription**: Bounce/complaint notifications to the app's
+  webhook endpoint (Day 10)
+- **aws_ses_identity_notification_topic**: Links SES bounce/complaint events
+  to the SNS topic
+
+## The Email Deliverability Stack
+
+```
+  SES sends email
+       |
+       | DKIM: Proves the email is from your domain (DNS TXT records)
+       | SPF:  Authorizes SES to send for your domain (DNS TXT record)
+       | DMARC: Policy for handling auth failures (DNS TXT record)
+       | MAIL FROM: Custom return-path domain (DNS MX + TXT records)
+       |
+       v
+  Recipient's mail server validates all four → inbox (not spam)
+```
+
+All five DNS record types are managed by Terraform, ensuring the complete
+email authentication stack is configured correctly.
+
+# Part 4: Security Practices Summary
+
+Throughout this 18-day curriculum, you've encountered security patterns at
+every layer. Here's a consolidated reference:
+
+## Authentication and Authorization
+- **Password hashing** (Day 3): bcrypt with salt — passwords are never stored
+  in plaintext
+- **Flask-Login sessions** (Day 4): Secure cookie-based session management
+- **Token-based registration** (Day 4): `secrets.token_urlsafe(32)` for
+  invite links
+- **Role-based access** (Day 5): `require_admin`, `require_skipper` decorators
+  and `can_manage_regatta()` checks
+- **Admin impersonation** (Day 5): Session-based with audit trail
+
+## Input Validation and Output Encoding
+- **CSRF protection** (Day 4): Flask-WTF CSRF tokens on all forms, with
+  explicit `@csrf.exempt` for webhooks and external APIs
+- **Path traversal protection** (Day 8): `secure_filename()` and path
+  validation in storage operations
+- **File upload validation** (Day 8): Extension checks, size limits,
+  content-type validation
+
+## Cryptographic Security
+- **HMAC-SHA256 tokens** (Day 10): Tamper-proof unsubscribe URLs using
+  `hmac.new()` with SECRET_KEY
+- **Timing-safe comparison** (Day 10): `hmac.compare_digest()` prevents
+  timing attacks on token verification
+- **Calendar feed tokens** (Day 12): `secrets.token_urlsafe(32)` for
+  feed authentication
+
+## Network Security
+- **SSRF protection** (Day 13): `_is_private_ip()` blocks requests to
+  internal networks, fails closed on DNS errors
+- **URL scheme validation** (Day 13): Only HTTP/HTTPS allowed
+- **Request timeouts** (Day 13): 15-second timeout on outbound requests
+
+## Infrastructure Security
+- **Secrets in GitHub Secrets** (Day 18): Never hardcoded in code or workflows
+- **Trivy scanning** (Day 18): Deploy gate blocks vulnerable images
+- **Dedicated IAM users** (Day 18): Separate credentials for SES and S3
+- **Email authentication** (Day 18): DKIM + SPF + DMARC + MAIL FROM
+
+# Key Takeaways
+
+1. **The deploy pipeline has three stages**: build → scan → deploy. The Trivy
+   scan is a hard gate — CRITICAL/HIGH vulnerabilities with fixes block
+   deployment.
+
+2. **Daily scans catch post-deploy vulnerabilities** and manage GitHub Issues
+   automatically (open when found, close when resolved).
+
+3. **Terraform manages 30+ AWS resources** across compute, storage, DNS, SSL,
+   email, and CDN. Changes are planned on PRs and applied on merge to master.
+
+4. **Email deliverability requires four DNS mechanisms**: DKIM, SPF, DMARC,
+   and a custom MAIL FROM domain. All are managed as Terraform resources.
+
+5. **Security is layered throughout the application**: authentication (bcrypt,
+   sessions, tokens), input validation (CSRF, path traversal, SSRF), crypto
+   (HMAC, timing-safe), and infrastructure (scanning, IAM, secrets management).
+
+## Course Complete!
+
+Congratulations on completing the 18-day Race Crew Network training
+curriculum! You now have a comprehensive understanding of a production Flask
+application — from the factory pattern and database models to AI integration,
+email notifications, and cloud deployment.
+
+For quick reference on any topic, see the 99-appendix.md file.

--- a/training/99-appendix.md
+++ b/training/99-appendix.md
@@ -1,7 +1,111 @@
 # Appendix: Quick Reference
 
-This appendix provides quick reference materials for Flask, SQLAlchemy, Jinja2,
-Docker, and common troubleshooting scenarios.
+This appendix provides quick reference materials for all topics covered in
+the 18-day curriculum.
+
+# Model Reference
+
+## Models Summary (8 + 1 Association Table)
+
+| Model | Table | Key Fields | Day |
+|-------|-------|------------|-----|
+| User | users | email, is_admin, is_skipper, avatar_seed, profile_image_key, email_opt_in, notification_prefs, calendar_token | 3 |
+| Regatta | regattas | name, boat_class, start_date, end_date, location, created_by | 3 |
+| Document | documents | filename, doc_type, storage_key, regatta_id, uploaded_by | 3 |
+| RSVP | rsvps | user_id, regatta_id, status (yes/no/maybe) | 3 |
+| ImportCache | import_cache | url, year, results_json, regatta_count | 13 |
+| TaskResult | task_results | id (UUID), result_type, data_json | 13 |
+| NotificationLog | notification_log | notification_type, regatta_id, user_id, sent_at, trigger_date | 11 |
+| SiteSetting | site_settings | key (unique), value | 15 |
+| skipper_crew | skipper_crew | skipper_id, crew_id, created_at (association table) | 9 |
+
+## User Fields
+
+| Field | Type | Purpose | Day |
+|-------|------|---------|-----|
+| email | String | Login identifier, unique | 3 |
+| password_hash | String | bcrypt hash | 3 |
+| display_name | String | Shown in UI | 3 |
+| initials | String(5) | Shown in RSVP badges | 3 |
+| is_admin | Boolean | Admin role flag | 3 |
+| is_skipper | Boolean | Skipper role flag | 3 |
+| invite_token | String | Pending registration token | 4 |
+| invited_by | Integer FK | Who invited this user | 4 |
+| avatar_seed | String | Multiavatar SVG seed | 14 |
+| profile_image_key | String | S3/local storage key | 8 |
+| email_opt_in | Boolean | Email preference (default True) | 10 |
+| notification_prefs | Text | JSON: rsvp_notification, rsvp_delivery | 11 |
+| phone | String(30) | Optional phone number | 3 |
+| calendar_token | String | iCal feed auth token | 12 |
+
+# Permission Patterns Reference
+
+## Decorators and Helpers (app/permissions.py)
+
+| Function | Usage | Day |
+|----------|-------|-----|
+| `require_admin` | Decorator: redirects non-admin users | 5 |
+| `require_skipper` | Decorator: redirects non-skipper/non-admin users | 5 |
+| `can_manage_regatta(user, regatta)` | Returns True if user can edit/delete | 5 |
+| `can_rsvp_to_regatta(user, regatta)` | Returns True if user can RSVP | 5 |
+
+## Permission Matrix
+
+| Action | Admin | Skipper | Crew |
+|--------|-------|---------|------|
+| View all schedules | Yes | Yes | Yes |
+| Create/edit/delete own events | Yes | Yes | No |
+| Create/edit/delete any event | Yes | No | No |
+| RSVP to events | Yes | Yes | Yes |
+| Manage crew | Yes | Own crew | No |
+| Send notifications | Yes | Own crew | No |
+| Import schedules | Yes | Own events | No |
+| Admin settings | Yes | No | No |
+| Impersonate users | Yes | No | No |
+
+# Notification Types Reference
+
+| Type | Trigger | Recipient | Day |
+|------|---------|-----------|-----|
+| `notify_crew` | Skipper clicks "Notify Crew" | Selected crew members | 11 |
+| `rsvp_notification` | Crew RSVPs (per_rsvp mode) | Event's skipper | 11 |
+| `rsvp_digest` | Daily cron (digest mode) | Skipper with digest pref | 11 |
+| `crew_joined` | Crew completes registration | Inviting skipper | 11 |
+| `rsvp_reminder` | 14 days before event | Crew who haven't RSVPed | 11 |
+| `coming_up_reminder` | 3 days before event | Crew who RSVPed yes/maybe | 11 |
+
+# SiteSetting Keys Reference
+
+| Key | Used By | Default | Day |
+|-----|---------|---------|-----|
+| `ga_measurement_id` | Google Analytics injection | "" (disabled) | 15 |
+| `ses_sender` | SES sender email address | "" | 10 |
+| `ses_sender_to` | Default test email recipient | "" | 15 |
+| `ses_region` | SES AWS region | config["AWS_REGION"] | 10 |
+| `reminder_rsvp_days_before` | RSVP reminder window | "14" | 11 |
+| `reminder_upcoming_days_before` | Coming-up reminder window | "3" | 11 |
+| `reminder_api_token` | Reminder API auth token | "" | 15 |
+
+# Template Filters Reference
+
+| Filter | Usage | Purpose | Day |
+|--------|-------|---------|-----|
+| `avatar_svg` | `{{ user\|avatar_svg(20) }}` | Render Multiavatar SVG | 14 |
+| `user_icon` | `{{ user\|user_icon(28) }}` | Photo with SVG fallback | 14 |
+| `sort_rsvps` | `{{ rsvps\|sort_rsvps }}` | Sort: yes → no → maybe | 14 |
+| `regatta_days` | `{{ start\|regatta_days(end) }}` | "Sat", "Sat & Sun", "Fri thru Sun" | 14 |
+
+# Email Templates
+
+| Template | Used By | Description |
+|----------|---------|-------------|
+| `email/notify_crew.html/.txt` | `notify_crew()` | Crew notification with event list |
+| `email/rsvp_notification.html/.txt` | `notify_rsvp_to_skipper()` | Per-RSVP alert to skipper |
+| `email/rsvp_digest.html/.txt` | `send_rsvp_digests()` | Daily RSVP summary for skipper |
+| `email/rsvp_reminder.html/.txt` | `send_rsvp_reminders()` | "Please RSVP" reminder |
+| `email/coming_up_reminder.html/.txt` | `send_coming_up_reminders()` | "Event in 3 days" reminder |
+| `email/crew_digest.html/.txt` | `send_crew_digests()` | Daily digest for crew |
+| `email/invite_crew.html/.txt` | `invite_crew()` | Crew invitation email |
 
 # Flask Routing Reference
 
@@ -30,45 +134,27 @@ def login():
 ```python
 @app.route("/user/<int:user_id>")
 def user_profile(user_id: int):
-    user = User.query.get_or_404(user_id)
+    user = db.session.get(User, user_id)
     return render_template("profile.html", user=user)
 
 @app.route("/search")
 def search():
     query = request.args.get("q", "")  # /search?q=flask
-    return f"Searching for {query}"
 ```
 
 ## Redirects and url_for
 ```python
 from flask import redirect, url_for
 
-@app.route("/old-path")
-def old():
-    return redirect(url_for("new_path"))
-
-@app.route("/new-path")
-def new_path():
-    return "New location"
+return redirect(url_for("auth.profile"))
+return redirect(url_for("regattas.edit", regatta_id=regatta.id))
 ```
 
 ## Flash Messages
 ```python
-from flask import flash
-
-flash("Operation successful!", "success")
-flash("An error occurred.", "error")
-flash("Please note...", "info")
-```
-
-## Decorators
-```python
-from flask_login import login_required
-
-@app.route("/protected")
-@login_required
-def protected():
-    return "Only logged-in users see this"
+flash("Operation successful!", "success")   # green
+flash("An error occurred.", "error")         # red (maps to alert-danger)
+flash("Please note...", "warning")           # yellow
 ```
 
 # SQLAlchemy Query Reference
@@ -78,67 +164,35 @@ def protected():
 # Get all
 users = User.query.all()
 
-# Get one
-user = User.query.first()
-user = User.query.get(1)  # By primary key
-user = User.query.get_or_404(1)  # Or 404 error
+# Get by primary key
+user = db.session.get(User, 1)
 
 # Filter
 users = User.query.filter_by(is_admin=True).all()
 users = User.query.filter(User.email.like("%@example.com")).all()
 
-# Order
-users = User.query.order_by(User.display_name).all()
-users = User.query.order_by(User.created_at.desc()).all()
-
-# Limit
-users = User.query.limit(10).all()
+# Order and limit
+users = User.query.order_by(User.display_name).limit(10).all()
 
 # Count
-count = User.query.count()
+count = User.query.filter_by(is_admin=True).count()
 ```
 
 ## Filtering
 ```python
-# Equals
-User.query.filter_by(email=email)
-User.query.filter(User.email == email)
-
-# Not equals
-User.query.filter(User.email != email)
-
-# Greater than / Less than
-Regatta.query.filter(Regatta.start_date >= today)
-
 # IN list
 User.query.filter(User.id.in_([1, 2, 3]))
 
-# LIKE pattern
-User.query.filter(User.email.like("%@example.com"))
-
-# IS NULL
+# IS NULL / IS NOT NULL
 User.query.filter(User.invite_token.is_(None))
 User.query.filter(User.invite_token.isnot(None))
 
-# AND (multiple filters)
-User.query.filter_by(is_admin=True).filter_by(email=email)
-User.query.filter((User.is_admin == True) & (User.email == email))
+# AND (chain filters)
+User.query.filter_by(is_admin=True).filter_by(is_skipper=True)
 
 # OR
 from sqlalchemy import or_
-User.query.filter(or_(User.is_admin == True, User.email == email))
-```
-
-## Relationships
-```python
-# Access related objects
-user = User.query.first()
-regattas = user.created_regattas  # One-to-many
-rsvps = user.rsvps  # One-to-many
-
-regatta = Regatta.query.first()
-creator = regatta.creator  # Many-to-one (backref)
-documents = regatta.documents  # One-to-many
+User.query.filter(or_(User.is_admin == True, User.is_skipper == True))
 ```
 
 ## Create, Update, Delete
@@ -155,352 +209,157 @@ db.session.commit()
 # Delete
 db.session.delete(user)
 db.session.commit()
-
-# Rollback on error
-try:
-    db.session.commit()
-except:
-    db.session.rollback()
-    raise
 ```
 
-# Jinja2 Template Reference
+# Docker Compose Commands
 
-## Variables
-```html
-{{ variable }}
-{{ user.display_name }}
-{{ regatta.start_date.strftime('%B %d, %Y') }}
-```
-
-## Filters
-```html
-{{ name|upper }}
-{{ text|truncate(100) }}
-{{ price|round(2) }}
-{{ items|length }}
-{{ rsvps|sort_rsvps }}  <!-- Custom filter -->
-```
-
-## Control Flow
-```html
-{% if current_user.is_admin %}
-    <a href="/admin">Admin Panel</a>
-{% elif current_user.is_authenticated %}
-    <p>Welcome, {{ current_user.display_name }}</p>
-{% else %}
-    <a href="/login">Login</a>
-{% endif %}
-
-{% for regatta in regattas %}
-    <li>{{ regatta.name }}</li>
-{% else %}
-    <li>No regattas found.</li>
-{% endfor %}
-```
-
-## Template Inheritance
-```html
-<!-- base.html -->
-<!DOCTYPE html>
-<html>
-<head>
-    <title>{% block title %}Default Title{% endblock %}</title>
-</head>
-<body>
-    {% block content %}{% endblock %}
-</body>
-</html>
-
-<!-- page.html -->
-{% extends "base.html" %}
-
-{% block title %}My Page{% endblock %}
-
-{% block content %}
-    <h1>Page Content</h1>
-{% endblock %}
-```
-
-## Include
-```html
-{% include "navbar.html" %}
-```
-
-## Forms
-```html
-<form method="post">
-    {{ csrf_token() }}
-    <input type="text" name="name" value="{{ regatta.name if regatta }}">
-    <button type="submit">Save</button>
-</form>
-```
-
-## URL Generation
-```html
-<a href="{{ url_for('auth.login') }}">Login</a>
-<a href="{{ url_for('regattas.edit', regatta_id=regatta.id) }}">Edit</a>
-<a href="{{ url_for('static', filename='css/style.css') }}">CSS</a>
-```
-
-# Docker Compose Reference
-
-## Basic Commands
 ```bash
 # Start services
-docker compose up
-
-# Start in background
-docker compose up -d
-
-# Rebuild and start
-docker compose up --build
+docker compose up --build          # Build and start
+docker compose up -d               # Start in background
 
 # Stop services
-docker compose down
+docker compose down                # Stop (keep volumes)
+docker compose down -v             # Stop and delete volumes
 
-# Stop and remove volumes
-docker compose down -v
+# Logs
+docker compose logs                # All logs
+docker compose logs -f web         # Follow web logs
 
-# View logs
-docker compose logs
-docker compose logs -f web  # Follow logs for web service
-
-# Restart a service
-docker compose restart web
-
-# Execute command in container
+# Execute in container
 docker compose exec web flask create-admin
+docker compose exec web flask db current
 docker compose exec db mysql -u racecrew -p
 
-# View running containers
-docker compose ps
+# Status
+docker compose ps                  # Running containers
 ```
 
-## Building and Cleaning
+# Flask CLI Commands
+
 ```bash
-# Build images without starting
-docker compose build
+# Custom commands (this app)
+flask init-admin                   # Create admin from env vars
+flask create-admin                 # Interactive admin creation
+flask send-reminders               # Run all scheduled reminders
 
-# Remove all stopped containers
-docker compose down --remove-orphans
-
-# Remove images
-docker compose down --rmi all
-
-# Prune unused Docker resources
-docker system prune
-docker volume prune
+# Migration commands
+flask db upgrade                   # Apply pending migrations
+flask db migrate -m "message"      # Generate migration from model changes
+flask db downgrade -1              # Undo last migration
+flask db current                   # Show current version
+flask db history                   # Show migration history
 ```
 
-# Flask CLI Reference
+# Terraform Commands
 
-## Custom Commands (This App)
 ```bash
-flask create-admin          # Create admin user interactively
-flask init-admin            # Create admin from env vars (INIT_ADMIN_EMAIL/PASSWORD)
+cd terraform/
+
+terraform init                     # Download providers
+terraform fmt -check               # Check formatting
+terraform validate                 # Validate config
+terraform plan                     # Preview changes
+terraform apply                    # Apply changes
+terraform destroy                  # Tear down all resources
 ```
 
-## Migration Commands
-```bash
-flask db init               # Initialize migrations directory
-flask db migrate -m "msg"   # Generate migration
-flask db upgrade            # Apply migrations
-flask db downgrade          # Undo last migration
-flask db current            # Show current version
-flask db history            # Show migration history
-```
+# Trivy Commands
 
-## Flask Development
 ```bash
-flask run                   # Start development server (don't use in production!)
-flask run --host=0.0.0.0    # Listen on all interfaces
-flask run --port=5001       # Custom port
-flask shell                 # Interactive Python shell with app context
+# Scan a local image
+trivy image ghcr.io/chris-edwards-pub/race-crew-network:latest
+
+# Scan with severity filter
+trivy image --severity CRITICAL,HIGH --ignore-unfixed \
+  ghcr.io/chris-edwards-pub/race-crew-network:latest
+
+# Output as SARIF
+trivy image --format sarif --output results.sarif \
+  ghcr.io/chris-edwards-pub/race-crew-network:latest
 ```
 
 # Troubleshooting Guide
 
-## Problem: Can't Connect to Localhost
-**Symptoms**: Browser shows "can't connect" or "connection refused"
+## Can't Connect to Localhost
+1. Check containers: `docker compose ps`
+2. Check logs: `docker compose logs`
+3. Verify port 80 isn't in use: `lsof -i :80`
+4. Restart: `docker compose restart`
 
-**Solutions**:
-1. Check containers are running:
-   ```bash
-   docker compose ps
-   ```
+## Database Connection Errors
+1. Check db health: `docker compose ps` (should show "healthy")
+2. Verify DATABASE_URL in .env matches MySQL credentials
+3. Check db logs: `docker compose logs db`
+4. Fresh start: `docker compose down -v && docker compose up --build`
 
-2. Check logs for errors:
-   ```bash
-   docker compose logs
-   ```
+## Migration Errors
+1. Check current version: `docker compose exec web flask db current`
+2. Check history: `docker compose exec web flask db history`
+3. If stuck, fresh start: `docker compose down -v && docker compose up --build`
 
-3. Verify port 80 isn't already in use:
-   ```bash
-   lsof -i :80  # On Mac/Linux
-   ```
-
-4. Restart containers:
-   ```bash
-   docker compose restart
-   ```
-
-## Problem: Database Connection Errors
-**Symptoms**: "Can't connect to MySQL server" or "Unknown database"
-
-**Solutions**:
-1. Check db container is healthy:
-   ```bash
-   docker compose ps
-   ```
-
-2. Verify DATABASE_URL in .env:
-   ```
-   DATABASE_URL=mysql+pymysql://racecrew:racecrew@db:3306/racecrew
-   ```
-
-3. Check db health check:
-   ```bash
-   docker compose logs db
-   ```
-
-4. Recreate database volume:
-   ```bash
-   docker compose down -v
-   docker compose up --build
-   ```
-
-## Problem: Permission Errors
-**Symptoms**: "Permission denied" when writing files
-
-**Solutions**:
-1. Check upload directory permissions:
-   ```bash
-   docker compose exec web ls -la /app/uploads
-   ```
-
-2. Create directory if missing:
-   ```bash
-   docker compose exec web mkdir -p /app/uploads
-   ```
-
-## Problem: Migration Errors
-**Symptoms**: "Can't locate revision" or "Multiple heads detected"
-
-**Solutions**:
-1. Check migration history:
-   ```bash
-   docker compose exec web flask db current
-   docker compose exec web flask db history
-   ```
-
-2. If database is corrupted, start fresh:
-   ```bash
-   docker compose down -v
-   docker compose up --build
-   ```
-
-## Problem: Static Files Not Loading
-**Symptoms**: CSS not applied, images not showing
-
-**Solutions**:
-1. Check browser console for 404 errors
-2. Verify file paths in templates
-3. Clear browser cache
-4. Check web container logs:
-   ```bash
-   docker compose logs web
-   ```
-
-## Problem: Session Cookie Not Persisting
-**Symptoms**: Logged out after every page refresh
-
-**Solutions**:
+## Session Cookie Not Persisting
 1. Check SECRET_KEY is set in .env
-2. Ensure .env file is being loaded:
-   ```bash
-   docker compose exec web env | grep SECRET
-   ```
-3. Generate new SECRET_KEY if needed
+2. Verify: `docker compose exec web env | grep SECRET`
+3. Generate new key: `python3 -c "import secrets; print(secrets.token_hex(32))"`
+
+## Static Files Not Loading
+1. Check browser console for 404 errors
+2. Verify file paths in templates use `url_for('static', filename=...)`
+3. Clear browser cache
+4. Check container logs for errors
 
 # Security Best Practices
 
 ## Passwords
-- Never hardcode passwords in source code
-- Use environment variables for all secrets
-- Generate strong SECRET_KEY (64+ characters)
-- Use bcrypt for password hashing (already implemented)
-- Enforce minimum password length (6+ characters minimum)
+- Use bcrypt for hashing (implemented)
+- Generate strong SECRET_KEY (64+ hex chars)
+- Never hardcode secrets in source code
+- Use environment variables or GitHub Secrets
 
 ## File Uploads
-- Validate file types before accepting
-- Use UUID filenames (already implemented)
-- Set MAX_CONTENT_LENGTH (already set to 10MB)
-- Store uploads outside web root
-- Use send_from_directory() for serving (already implemented)
+- Validate file extensions before accepting
+- Use UUID filenames to prevent collisions
+- Set MAX_CONTENT_LENGTH (10 MB default)
+- Use path traversal protection (secure_filename)
 
-## Database
-- Use parameterized queries (SQLAlchemy does this)
-- Validate and sanitize all user input
-- Use foreign key constraints
-- Regular backups (see Day 10)
+## Network
+- SSRF protection for all URL fetching (_is_private_ip)
+- CSRF tokens on all forms (@csrf.exempt only for webhooks)
+- HMAC tokens for stateless verification
+- Timing-safe comparison (hmac.compare_digest)
+- Request timeouts on outbound HTTP calls
 
-## Authentication
-- Use CSRF protection (already implemented with Flask-WTF)
-- Implement rate limiting for login attempts (not implemented)
-- Use HTTPS in production (see Day 10)
-- Set secure cookie flags in production
-
-## General
-- Keep dependencies updated:
-  ```bash
-  pip list --outdated
-  pip install --upgrade package-name
-  ```
-
-- Don't expose debug mode in production:
-  ```python
-  # NEVER do this in production:
-  app.run(debug=True)
-  ```
-
-- Review Flask security docs:
-  https://flask.palletsprojects.com/security/
+## Infrastructure
+- Trivy scanning gates deployment (CRITICAL/HIGH = block)
+- Dedicated IAM users with minimal permissions
+- Email authentication: DKIM + SPF + DMARC
+- Secrets in GitHub Secrets, not in code
 
 # Further Reading
 
 ## Flask
 - Official Documentation: https://flask.palletsprojects.com/
 - Flask Mega-Tutorial: https://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-i-hello-world
-- Real Python Flask: https://realpython.com/tutorials/flask/
 
 ## SQLAlchemy
 - Official Documentation: https://docs.sqlalchemy.org/
-- SQLAlchemy ORM Tutorial: https://docs.sqlalchemy.org/orm/tutorial.html
+- ORM Tutorial: https://docs.sqlalchemy.org/orm/tutorial.html
 
 ## Docker
 - Official Documentation: https://docs.docker.com/
 - Docker Compose: https://docs.docker.com/compose/
-- Best Practices: https://docs.docker.com/develop/dev-best-practices/
 
-## Python
-- Python Documentation: https://docs.python.org/3/
-- PEP 8 Style Guide: https://peps.python.org/pep-0008/
-
-## Web Development
-- MDN Web Docs: https://developer.mozilla.org/
-- HTTP Status Codes: https://httpstatuses.com/
-- RESTful API Design: https://restfulapi.net/
+## AWS
+- Lightsail Containers: https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-container-services.html
+- SES Developer Guide: https://docs.aws.amazon.com/ses/latest/dg/
 
 ## Security
 - OWASP Top 10: https://owasp.org/www-project-top-ten/
 - Flask Security: https://flask.palletsprojects.com/security/
-- Let's Encrypt: https://letsencrypt.org/
 
 # End of Appendix
 
-You now have a complete reference for Flask development with this application.
-Return to this appendix whenever you need a quick reminder of syntax or
-commands.
-
-Good luck with your Flask journey!
+This appendix covers the complete Race Crew Network v0.61.0 application.
+Return to it whenever you need a quick reference for any topic covered in
+the 18-day curriculum.

--- a/training/plan.md
+++ b/training/plan.md
@@ -1,6 +1,6 @@
 # Overview
 
-Create a 10-day training curriculum for an IT professional with Python/Docker experience but no Flask knowledge. The curriculum will explain the Race Crew Network Regatta Schedule Flask application through 12 text files.
+Create an 18-day training curriculum for an IT professional with Python/Docker experience but no Flask knowledge. The curriculum will explain the Race Crew Network v0.61.0 Flask application through 21 text files.
 
 ## User Requirements
 
@@ -16,16 +16,17 @@ Create a 10-day training curriculum for an IT professional with Python/Docker ex
 ### Index File
 
 Path: 00-index.md
-Status: Already created
-Contents: Course overview, prerequisites, roadmap, navigation guide
+Contents: Course overview, prerequisites, 18-day roadmap, navigation guide
 
-### Daily Lesson Files (10 files)
+### Daily Lesson Files (18 files)
 
-Paths: 01-day1.md through 10-day10.md
+Paths: 01-day1.md through 18-day18.md
+
+#### Phase 1: Foundations (Days 1-4)
 
 **Day 1: Introduction & Environment Setup**
-- Application overview and feature tour
-- Docker Compose architecture (3 containers: web, db, nginx)
+- Application overview and feature tour (3 roles, 6 blueprints)
+- Docker Compose architecture (web, db containers)
 - Running the app locally
 - Creating admin account with Flask CLI
 - Basic Flask concepts: routes, templates, blueprints
@@ -34,86 +35,154 @@ Paths: 01-day1.md through 10-day10.md
 - The create_app() factory pattern
 - Extension initialization (SQLAlchemy, Flask-Login, Flask-Migrate, CSRF)
 - Configuration management with environment variables
-- Blueprint registration
-- Application context and lifecycle
+- Blueprint registration (6 blueprints)
+- Context processors and template filters (avatar_svg, user_icon, sort_rsvps, regatta_days)
 
 **Day 3: Database Models & SQLAlchemy ORM**
 - Object-Relational Mapping concepts
-- User model (password hashing with bcrypt)
-- Regatta model (events with dates/locations)
-- Document model (file uploads + external URLs)
-- RSVP model (many-to-many relationships)
-- Database schema design and foreign keys
+- 8 models: User, Regatta, Document, RSVP, ImportCache, TaskResult, NotificationLog, SiteSetting
+- skipper_crew association table (self-referential M2M)
+- User model expansion (avatar_seed, profile_image_key, notification_prefs, email_opt_in)
+- visible_regattas() and permission scoping
 
 **Day 4: Authentication & User Management**
 - Flask-Login integration and UserMixin
 - Login/logout implementation
-- Invite-based registration system with tokens
-- User profile management
-- Admin user administration
-- Authorization patterns (@login_required, role checks)
+- Invite-based registration with tokens
+- Skipper invites and email invites
+- Auto-link crew to inviting skipper
+- Avatar seed generation on registration
+- Admin user administration (edit, delete, impersonate)
 
-**Day 5: Regatta Management (CRUD Operations)**
+#### Phase 2: Core Features (Days 5-9)
+
+**Day 5: Multi-User Role System & Permissions**
+- Three roles: Admin, Skipper, Crew
+- permissions.py: require_admin, require_skipper, can_manage_regatta, can_rsvp_to_regatta
+- Admin impersonation flow (session-based)
+- Role-based navbar and UI visibility
+
+**Day 6: Event Management (CRUD Operations)**
 - RESTful route design in Flask
 - Create, Read, Update, Delete operations
-- Form processing with request.form
-- Date handling in Python
-- Permission checks (admin-only routes)
-- Flash messages for user feedback
+- Updated permissions model (skipper can CRUD own events)
+- Bulk delete with checkbox selection
+- Auto-generated Google Maps links
+- Schedule filters (skipper, RSVP status)
 
-**Day 6: RSVP System & Database Relationships**
-- Many-to-many relationship implementation
-- Upsert pattern (update or insert logic)
-- SQLAlchemy lazy vs eager loading
-- Custom Jinja2 template filters
-- Status display and crew initials
+**Day 7: RSVP System & Schedule View**
+- Schedule switcher (My Schedule / All Schedules)
+- RSVP with filter state preservation
+- PDF schedule generation with WeasyPrint
+- RSVP notification triggers
+- Custom template filters (sort_rsvps, regatta_days)
 
-**Day 7: Document Upload & File Handling**
-- File upload processing in Flask
-- UUID-based secure filename generation
-- Supporting both uploads and external URLs
-- Docker volume management for storage
-- Secure file downloads with send_from_directory
-- File size limits and validation
+**Day 8: Document Upload & Storage**
+- File upload processing with Flask
+- S3/local storage abstraction (app/storage.py)
+- Profile image uploads with validation
+- Path traversal protection
+- Presigned URLs for secure downloads
+- Storage blueprint for local file serving
 
-**Day 8: Calendar Integration (iCal Feeds)**
+**Day 9: Skipper & Crew Management**
+- My Crew page and crew listing
+- Invite crew (new user or existing user)
+- Remove crew member
+- Create/delete schedule (self-service skipper)
+- Leave skipper (crew self-service)
+
+#### Phase 3: Communication & Integration (Days 10-13)
+
+**Day 10: Email Service with AWS SES**
+- AWS SES integration via boto3
+- HMAC-SHA256 unsubscribe tokens
+- RFC 8058 one-click unsubscribe
+- Bounce and complaint webhook handling (SNS)
+- Email opt-in/opt-out model
+- SiteSetting-based email configuration
+
+**Day 11: Notification System**
+- Manual crew notification (skipper selects events + crew)
+- RSVP-to-skipper notifications (per-RSVP and digest modes)
+- Scheduled reminders (RSVP reminder, coming-up reminder)
+- Crew digest emails
+- NotificationLog for deduplication
+- Digest flush on preference switch
+
+**Day 12: Calendar Integration**
 - iCalendar format (RFC 5545)
-- Using the icalendar Python library
 - Token-based feed authentication
-- Generating calendar events
-- All-day event handling
-- Calendar subscription URLs
+- Subscribe page with webcal:// URLs
+- Scoped feeds (only yes/maybe RSVPs)
+- RSVP status in event descriptions
+- Email links to calendar subscribe
 
-**Day 9: Docker & Containerization**
-- Dockerfile structure and best practices
-- Multi-container orchestration with docker-compose
-- Container networking and service discovery
-- Volume persistence for data
-- Health checks for database dependencies
-- Gunicorn production configuration
-- Nginx reverse proxy setup
+**Day 13: AI-Powered Schedule Import**
+- Claude API integration (anthropic SDK)
+- Extraction prompt engineering
+- File import (PDF, DOCX, TXT via file_utils.py)
+- ImportCache for result caching
+- SSE streaming progress
+- SSRF protection (_is_private_ip)
+- Document discovery (level-1 and deep crawl)
 
-**Day 10: Database Migrations & Deployment**
+#### Phase 4: Operations & Advanced Topics (Days 14-18)
+
+**Day 14: User Interface & Responsive Design**
+- Bootstrap 5 responsive grid and breakpoints
+- Navbar (expand-md, collapse, mobile toggler)
+- Avatar system (Multiavatar SVG + profile photos)
+- user_icon template filter (photo with avatar fallback)
+- Impersonation banner
+- Mobile-friendly layout patterns
+
+**Day 15: Site Settings & Admin Configuration**
+- SiteSetting model (key/value store)
+- Google Analytics settings page
+- Email settings page (SES sender, region)
+- Runtime config vs environment variables
+- Context processor for GA injection
+
+**Day 16: Docker & Containerization**
+- Dockerfile structure (Python 3.13-slim base)
+- Docker Compose for local dev
+- GHCR image publishing
+- Entrypoint script (migrations + admin init + Gunicorn)
+- Gunicorn configuration
+- Local storage via storage blueprint
+
+**Day 17: Database Migrations & Testing**
 - Flask-Migrate and Alembic
+- Migration history (16 migrations)
 - Creating and applying migrations
-- Automatic migration on startup
-- Production deployment considerations
-- Environment variables management
-- SSL/HTTPS setup guidance
-- Backup strategies
+- pytest fixtures (session-scoped app, autouse cleanup)
+- Test patterns (admin/skipper/crew clients)
+- Mocking external APIs (Anthropic, SES)
+
+**Day 18: CI/CD, Security & Deployment**
+- GitHub Actions workflows (deploy, vulnerability scan, terraform)
+- Trivy vulnerability scanning (deploy-gate + daily)
+- Terraform infrastructure as code (Lightsail, SES, CloudFront, Route53)
+- AWS Lightsail Container Service deployment
+- Security practices (CSRF, SSRF, path traversal, HMAC)
 
 ### Appendix File
 
 Path: 99-appendix.md
 Contents:
+- Permission patterns reference
+- Notification types and triggers
+- SiteSetting keys reference
+- Template filters reference
+- Email templates listing
+- Terraform resource reference
+- Trivy/security commands
+- Model reference table (all 8 models + skipper_crew)
 - Flask routing quick reference
 - SQLAlchemy query patterns
-- Jinja2 template syntax guide
 - Docker Compose command cheat sheet
-- Flask CLI commands reference
 - Common troubleshooting scenarios
-- Security best practices checklist
-- Further reading resources
 
 ## Content Structure (Each Daily Lesson)
 
@@ -121,7 +190,7 @@ Contents:
 2. Concepts Covered (technical topics list)
 3. File Focus (which files to examine)
 4. Code Walkthrough (detailed explanations)
-   - Key snippets included inline
+   - Key snippets included inline (5-20 lines)
    - Longer code sections referenced by file:line
 5. Architecture Diagrams (ASCII art where helpful)
 6. Key Takeaways (summary and connections)
@@ -148,70 +217,89 @@ Contents:
 Use ASCII art for:
 - Application initialization flow (Day 2)
 - Database ER diagram (Day 3)
-- Request/response cycle (Day 5)
-- Container architecture (Day 9)
+- Request/response cycle (Day 6)
+- Container architecture (Day 16)
 - Authentication flow (Day 4)
+- Notification flow (Day 11)
+- CI/CD pipeline (Day 18)
 
 ### Security Notes
 
 Highlight security patterns when encountered:
 - Password hashing (Day 3)
 - CSRF protection (Day 4)
-- File upload security (Day 7)
-- Token-based authentication (Day 8)
+- HMAC unsubscribe tokens (Day 10)
+- SSRF protection (Day 13)
+- Path traversal protection (Day 8)
+- File upload validation (Day 8)
 
 ## Critical Files to Reference
 
 ### Core Application
 
-- race-crew-network/app/__init__.py - App factory
-- race-crew-network/app/config.py - Configuration
-- race-crew-network/app/models.py - All 4 models
-- race-crew-network/app/commands.py - CLI commands
+- app/__init__.py - App factory, context processors, template filters
+- app/config.py - Configuration
+- app/models.py - 8 models + skipper_crew table
+- app/permissions.py - Role-based permission helpers
+- app/commands.py - CLI commands
+- app/storage.py - S3/local storage abstraction
 
 ### Blueprints (Routes)
 
-- race-crew-network/app/auth/routes.py - Authentication
-- race-crew-network/app/regattas/routes.py - CRUD operations
-- race-crew-network/app/calendar/routes.py - iCal feeds
+- app/auth/routes.py - Authentication, user management, crew management
+- app/regattas/routes.py - Event CRUD, RSVP, documents, notifications
+- app/admin/routes.py - Import, settings, document discovery
+- app/calendar/routes.py - iCal feeds, subscribe page
+- app/email/routes.py - Unsubscribe, SES webhooks
+- app/storage_routes.py - Local file serving
+
+### Services
+
+- app/admin/email_service.py - AWS SES email sending
+- app/admin/ai_service.py - Claude API integration
+- app/admin/file_utils.py - File text extraction
+- app/notifications/service.py - Notification logic
 
 ### Templates
 
-- race-crew-network/app/templates/base.html - Base template
-- race-crew-network/app/templates/index.html - Main page
-- race-crew-network/app/templates/regatta_form.html - Form example
+- app/templates/base.html - Base template with navbar
+- app/templates/index.html - Main schedule page
+- app/templates/email/*.html - Email templates
 
 ### Deployment
 
-- race-crew-network/Dockerfile - Container build
-- race-crew-network/docker-compose.yml - Orchestration
-- race-crew-network/nginx.conf - Reverse proxy
-- race-crew-network/gunicorn.conf.py - WSGI config
-- race-crew-network/entrypoint.sh - Startup script
-- race-crew-network/requirements.txt - Dependencies
+- Dockerfile - Container build
+- docker-compose.yml - Local orchestration
+- gunicorn.conf.py - WSGI config
+- entrypoint.sh - Startup script
+- .github/workflows/deploy.yml - CI/CD pipeline
+- .github/workflows/vulnerability-scan.yml - Security scanning
+- .github/workflows/terraform.yml - Infrastructure automation
+- terraform/main.tf - AWS infrastructure
 
-### Database
+### Tests
 
-- race-crew-network/migrations/versions/*.py - Migration examples
+- tests/conftest.py - Test fixtures
+- tests/test_*.py - Test modules
 
 ## Implementation Steps
 
-1. Day 1-3: Foundation (App structure, models, database)
-2. Day 4-6: Core features (Auth, CRUD, relationships)
-3. Day 7-8: Advanced features (Files, calendar)
-4. Day 9-10: Deployment (Docker, production)
-5. Appendix: Quick reference materials
+1. Phase 1: Foundation (Days 1-4) — App structure, models, auth
+2. Phase 2: Core features (Days 5-9) — Roles, CRUD, RSVP, storage, crew
+3. Phase 3: Communication (Days 10-13) — Email, notifications, calendar, AI
+4. Phase 4: Operations (Days 14-18) — UI, settings, Docker, testing, CI/CD
+5. Appendix: Comprehensive reference materials
 
 ## Verification After Creation
 
-1. Index file exists and provides clear navigation
-2. All 10 daily lesson files created (01-10)
-3. Appendix file created (99)
-4. Each lesson follows the structure template
-5. File paths referenced are accurate
-6. ASCII diagrams render correctly in plain text
-7. Lesson progression is logical and builds on previous days
-8. Total word count per lesson is ~1500-2500 words
+1. All 21 files present (00-index, 01-18, 99-appendix, plan)
+2. No old numbered files remain
+3. Each lesson follows the structure template
+4. File paths and line numbers reference actual source code
+5. Cross-references between lessons are consistent
+6. Lesson progression is logical and builds on previous days
+7. Total word count per lesson is ~1500-2500 words
+8. Version metadata updated to v0.61.0 / Training v3.0
 
 ## Success Criteria
 
@@ -219,6 +307,6 @@ The training materials succeed if:
 - Each lesson can be read in 30-60 minutes
 - Code explanations reference actual application files
 - Flask patterns are clearly explained (not just Python)
-- A developer with Python/Docker knowledge can understand the full Flask application architecture after 10 days
+- A developer with Python/Docker knowledge can understand the full application after 18 days
 - Materials are self-contained in text files (no external dependencies)
 - Lessons build progressively from basics to advanced topics


### PR DESCRIPTION
## Summary
- Add comprehensive 18-day training curriculum covering Flask app development through the Race Crew Network codebase
- Four phases: Foundations (Days 1-4), Core Features (Days 5-9), Communication & Integration (Days 10-13), Operations & Advanced (Days 14-18)
- Includes course index, daily lesson plans with code walkthroughs, and quick-reference appendix
- Version bump to 0.62.0

## Test plan
- [x] All 430 tests pass
- [ ] Review training content for accuracy against current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)