### PR TITLE
Fix calendar URL scheme generating http:// instead of https://

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.63.1
+- Fix calendar and email URLs generating http:// instead of https:// behind reverse proxy (add ProxyFix middleware)
+
 ## 0.63.0
 - Add system-wide email rate limiting (default 50/hour, admin-configurable)
 - Emails exceeding rate limit are queued, not dropped — no emails lost

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,8 +6,9 @@ from flask_wtf.csrf import CSRFProtect
 from markupsafe import Markup, escape
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
+from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.63.0"
+__version__ = "0.63.1"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -40,6 +41,7 @@ def create_app(test_config=None):
     migrate.init_app(app, db)
     login_manager.init_app(app)
     csrf.init_app(app)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 
     from app.admin import bp as admin_bp
     from app.auth import bp as auth_bp

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -90,6 +90,12 @@ class TestAppFactory:
         assert b"/admin/users" in resp.data
         assert b"/admin/settings/analytics" in resp.data
 
+    def test_proxy_fix_applied(self, app):
+        """ProxyFix middleware wraps the WSGI app for reverse proxy support."""
+        from werkzeug.middleware.proxy_fix import ProxyFix
+
+        assert isinstance(app.wsgi_app, ProxyFix)
+
     def test_regatta_days_filter_single_day(self, app):
         with app.app_context():
             fn = app.jinja_env.filters["regatta_days"]


### PR DESCRIPTION
## Summary
- Add Werkzeug `ProxyFix` middleware to `create_app()` so Flask trusts `X-Forwarded-Proto/Host/For/Prefix` headers from the AWS Lightsail reverse proxy
- Fixes all `_external=True` URLs (calendar feeds, email unsubscribe links, invite URLs, notification email links) generating `http://` instead of `https://`
- Bump version to 0.63.1

Fixes #102

## Test plan
- [x] New test verifies `ProxyFix` wraps the WSGI app
- [x] Full test suite passes (454 tests)
- [ ] Deploy to production, verify calendar subscription URL shows `https://`
- [ ] Verify webcal:// link works in Outlook on Mac without "unknown host" error
- [ ] Verify email links use `https://`

🤖 Generated with [Claude Code](https://claude.com/claude-code)