### PR TITLE
Add city/state field to regattas and fix calendar URL scheme (v0.64.0)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.64.0
+- Add City, State field to regattas for displaying venue location details (e.g. "Eustis, FL")
+- City/State input on create/edit event form and AI import preview
+- AI extraction prompt updated to extract city_state as a separate field
+- City/State displayed below location on schedule (desktop and mobile), PDF, iCal, and all email templates
+- Google Maps auto-generated links include city/state for more accurate results
+- Fix calendar subscription URL generating http:// instead of https:// (set PREFERRED_URL_SCHEME default to https)
+
 ## 0.63.1
 - Fix calendar and email URLs generating http:// instead of https:// behind reverse proxy (add ProxyFix middleware)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.63.1"
+__version__ = "0.64.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/ai_service.py
+++ b/app/admin/ai_service.py
@@ -14,7 +14,8 @@ Each object in the array must have these fields:
 - "name": string (event name)
 - "boat_class": string or null (the one-design or racing class, \
 e.g. "Thistle", "J/24")
-- "location": string (city, yacht club, or venue)
+- "location": string (venue or yacht club name, e.g. "Eustis Sailing Club")
+- "city_state": string or null (city and state of the venue, e.g. "Eustis, FL")
 - "location_url": string or null (URL for the venue if mentioned)
 - "start_date": string in "YYYY-MM-DD" format
 - "end_date": string in "YYYY-MM-DD" format or null (if single-day event)

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1273,6 +1273,7 @@ def import_schedule_confirm():
         name = request.form.get(f"name_{idx}", "").strip()
         boat_class = request.form.get(f"boat_class_{idx}", "").strip()
         location = request.form.get(f"location_{idx}", "").strip()
+        city_state = request.form.get(f"city_state_{idx}", "").strip()
         location_url = request.form.get(f"location_url_{idx}", "").strip()
         start_date_str = request.form.get(f"start_date_{idx}", "").strip()
         end_date_str = request.form.get(f"end_date_{idx}", "").strip()
@@ -1301,7 +1302,8 @@ def import_schedule_confirm():
 
         # Auto-generate Google Maps link if no location_url
         if not location_url and location:
-            location_url = f"https://www.google.com/maps/search/{quote_plus(location)}"
+            maps_query = f"{location}, {city_state}" if city_state else location
+            location_url = f"https://www.google.com/maps/search/{quote_plus(maps_query)}"
 
         detail_url = request.form.get(f"detail_url_{idx}", "").strip()
 
@@ -1309,6 +1311,7 @@ def import_schedule_confirm():
             name=name,
             boat_class=boat_class,
             location=location or "TBD",
+            city_state=city_state or None,
             location_url=location_url or None,
             start_date=start_date,
             end_date=end_date,
@@ -1376,6 +1379,7 @@ def import_schedule_discover():
                 "name": request.form.get(f"name_{idx}", "").strip(),
                 "boat_class": request.form.get(f"boat_class_{idx}", "").strip(),
                 "location": request.form.get(f"location_{idx}", "").strip(),
+                "city_state": request.form.get(f"city_state_{idx}", "").strip(),
                 "location_url": request.form.get(f"location_url_{idx}", "").strip(),
                 "start_date": request.form.get(f"start_date_{idx}", "").strip(),
                 "end_date": request.form.get(f"end_date_{idx}", "").strip(),

--- a/app/calendar/routes.py
+++ b/app/calendar/routes.py
@@ -60,7 +60,7 @@ def ical_feed(token: str):
         # End date is exclusive in iCal, so add 1 day
         end = (regatta.end_date or regatta.start_date) + timedelta(days=1)
         event.add("dtend", end)
-        event.add("location", regatta.location)
+        event.add("location", regatta.full_location)
 
         if regatta.location_url:
             event.add("url", regatta.location_url)

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class Config:
         "mysql+pymysql://racecrew:racecrew@localhost:3306/racecrew",
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    PREFERRED_URL_SCHEME = os.environ.get("PREFERRED_URL_SCHEME", "https")
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB max upload
     PROFILE_IMAGE_MAX_BYTES = 10 * 1024 * 1024
     UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "uploads")

--- a/app/models.py
+++ b/app/models.py
@@ -148,6 +148,7 @@ class Regatta(db.Model):
     name = db.Column(db.String(200), nullable=False)
     boat_class = db.Column(db.String(100), nullable=False, default="")
     location = db.Column(db.String(200), nullable=False)
+    city_state = db.Column(db.String(100), nullable=True)
     location_url = db.Column(db.String(500), nullable=True)
     start_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date, nullable=True)
@@ -173,6 +174,12 @@ class Regatta(db.Model):
     creator = db.relationship(
         "User", backref="created_regattas", foreign_keys=[created_by]
     )
+
+    @property
+    def full_location(self) -> str:
+        if self.city_state:
+            return f"{self.location}, {self.city_state}"
+        return self.location
 
 
 class Document(db.Model):

--- a/app/notifications/service.py
+++ b/app/notifications/service.py
@@ -141,7 +141,7 @@ def notify_rsvp_to_skipper(rsvp) -> None:
         regatta_name=rsvp.regatta.name,
         regatta_date=rsvp.regatta.start_date,
         regatta_end_date=rsvp.regatta.end_date,
-        regatta_location=rsvp.regatta.location,
+        regatta_location=rsvp.regatta.full_location,
         schedule_url=schedule_url,
         profile_url=profile_url,
     )
@@ -152,7 +152,7 @@ def notify_rsvp_to_skipper(rsvp) -> None:
         regatta_name=rsvp.regatta.name,
         regatta_date=rsvp.regatta.start_date,
         regatta_end_date=rsvp.regatta.end_date,
-        regatta_location=rsvp.regatta.location,
+        regatta_location=rsvp.regatta.full_location,
         schedule_url=schedule_url,
         profile_url=profile_url,
     )

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -414,6 +414,7 @@ def _save_regatta(regatta: Regatta | None):
     name = request.form.get("name", "").strip()
     boat_class = request.form.get("boat_class", "").strip()
     location = request.form.get("location", "").strip()
+    city_state = request.form.get("city_state", "").strip()
     location_url = request.form.get("location_url", "").strip()
     start_date_str = request.form.get("start_date", "")
     end_date_str = request.form.get("end_date", "")
@@ -438,12 +439,14 @@ def _save_regatta(regatta: Regatta | None):
     regatta.name = name
     regatta.boat_class = boat_class
     regatta.location = location
+    regatta.city_state = city_state or None
     if location_url:
         regatta.location_url = location_url
     else:
-        # Auto-generate Google Maps search link from location text
+        # Auto-generate Google Maps search link from full location text
+        maps_query = f"{location}, {city_state}" if city_state else location
         regatta.location_url = (
-            f"https://www.google.com/maps/search/{quote_plus(location)}"
+            f"https://www.google.com/maps/search/{quote_plus(maps_query)}"
         )
     regatta.start_date = start_date
     regatta.end_date = end_date

--- a/app/templates/admin/_preview_table.html
+++ b/app/templates/admin/_preview_table.html
@@ -39,6 +39,7 @@
                     </td>
                     <td>
                         <input type="text" class="form-control form-control-sm" name="location_{{ loop.index0 }}" value="{{ r.location or '' }}">
+                        <input type="text" class="form-control form-control-sm mt-1" name="city_state_{{ loop.index0 }}" value="{{ r.city_state or '' }}" placeholder="City, State">
                         <input type="hidden" name="location_url_{{ loop.index0 }}" value="{{ r.location_url or '' }}">
                     </td>
                     <td>

--- a/app/templates/admin/import_schedule_documents.html
+++ b/app/templates/admin/import_schedule_documents.html
@@ -15,6 +15,7 @@
             <input type="hidden" name="name_{{ r_idx }}" value="{{ r.name }}">
             <input type="hidden" name="boat_class_{{ r_idx }}" value="{{ r.boat_class }}">
             <input type="hidden" name="location_{{ r_idx }}" value="{{ r.location }}">
+            <input type="hidden" name="city_state_{{ r_idx }}" value="{{ r.city_state or '' }}">
             <input type="hidden" name="location_url_{{ r_idx }}" value="{{ r.location_url }}">
             <input type="hidden" name="start_date_{{ r_idx }}" value="{{ r.start_date }}">
             <input type="hidden" name="end_date_{{ r_idx }}" value="{{ r.end_date }}">

--- a/app/templates/admin/import_single_preview.html
+++ b/app/templates/admin/import_single_preview.html
@@ -39,6 +39,10 @@
             <div class="mb-3">
                 <label for="location_0" class="form-label">Location</label>
                 <input type="text" class="form-control" id="location_0" name="location_0" value="{{ regatta.location or '' }}">
+            </div>
+            <div class="mb-3">
+                <label for="city_state_0" class="form-label">City, State</label>
+                <input type="text" class="form-control" id="city_state_0" name="city_state_0" value="{{ regatta.city_state or '' }}" placeholder="e.g. Eustis, FL">
                 <input type="hidden" name="location_url_0" value="{{ regatta.location_url or '' }}">
             </div>
             <div class="mb-3">
@@ -108,7 +112,7 @@ document.getElementById('btn-no-docs').addEventListener('click', function() {
 
     confirmForm.innerHTML = '<input type="hidden" name="csrf_token" value="' + importForm.querySelector('[name=csrf_token]').value + '">';
 
-    var fields = ['selected', 'name_0', 'boat_class_0', 'start_date_0', 'end_date_0', 'location_0', 'location_url_0', 'notes_0', 'detail_url_0'];
+    var fields = ['selected', 'name_0', 'boat_class_0', 'start_date_0', 'end_date_0', 'location_0', 'city_state_0', 'location_url_0', 'notes_0', 'detail_url_0'];
     fields.forEach(function(name) {
         var input = importForm.querySelector('[name="' + name + '"]');
         if (input) {

--- a/app/templates/email/coming_up_reminder.html
+++ b/app/templates/email/coming_up_reminder.html
@@ -8,7 +8,7 @@
     </tr>
     <tr>
         <td style="border:1px solid #dee2e6;background-color:#f8f9fa;font-weight:bold;">Location</td>
-        <td style="border:1px solid #dee2e6;">{{ regatta.location }}</td>
+        <td style="border:1px solid #dee2e6;">{{ regatta.full_location }}</td>
     </tr>
 </table>
 <p><a href="{{ schedule_url }}">View your schedule</a></p>

--- a/app/templates/email/coming_up_reminder.txt
+++ b/app/templates/email/coming_up_reminder.txt
@@ -3,7 +3,7 @@ Hi {{ crew_name }},
 Just a reminder — {{ regatta.name }} is in {{ days }} days!
 
 Date: {{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}
-Location: {{ regatta.location }}
+Location: {{ regatta.full_location }}
 
 View your schedule: {{ schedule_url }}
 

--- a/app/templates/email/crew_digest.html
+++ b/app/templates/email/crew_digest.html
@@ -5,7 +5,7 @@
 <h3>RSVP Needed</h3>
 <ul>
 {% for regatta in rsvp_needed %}
-    <li><strong>{{ regatta.name }}</strong> ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.location }}) — please RSVP</li>
+    <li><strong>{{ regatta.name }}</strong> ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.full_location }}) — please RSVP</li>
 {% endfor %}
 </ul>
 {% endif %}
@@ -13,7 +13,7 @@
 <h3>Coming Up</h3>
 <ul>
 {% for regatta in coming_up %}
-    <li><strong>{{ regatta.name }}</strong> ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.location }})</li>
+    <li><strong>{{ regatta.name }}</strong> ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.full_location }})</li>
 {% endfor %}
 </ul>
 {% endif %}

--- a/app/templates/email/crew_digest.txt
+++ b/app/templates/email/crew_digest.txt
@@ -3,10 +3,10 @@ Hi {{ crew_name }},
 Here's what's happening with your schedule:
 
 {% if rsvp_needed %}RSVP Needed:
-{% for regatta in rsvp_needed %}  - {{ regatta.name }} ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.location }}) — please RSVP
+{% for regatta in rsvp_needed %}  - {{ regatta.name }} ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.full_location }}) — please RSVP
 {% endfor %}
 {% endif %}{% if coming_up %}Coming Up:
-{% for regatta in coming_up %}  - {{ regatta.name }} ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.location }})
+{% for regatta in coming_up %}  - {{ regatta.name }} ({{ regatta.start_date.strftime('%b %d') }}{% if regatta.end_date %} – {{ regatta.end_date.strftime('%b %d') }}{% endif %}, {{ regatta.start_date.strftime('%Y') }}, {{ regatta.full_location }})
 {% endfor %}
 {% endif %}
 View your schedule: {{ schedule_url }}

--- a/app/templates/email/notify_crew.html
+++ b/app/templates/email/notify_crew.html
@@ -19,7 +19,7 @@
             <td style="border:1px solid #dee2e6;white-space:nowrap;">{{ r.start_date.strftime('%b %d') }}{% if r.end_date %} – {{ r.end_date.strftime('%b %d') }}{% endif %}, {{ r.start_date.strftime('%Y') }}</td>
             <td style="border:1px solid #dee2e6;">{{ r.boat_class }}</td>
             <td style="border:1px solid #dee2e6;">{{ r.name }}</td>
-            <td style="border:1px solid #dee2e6;">{{ r.location }}</td>
+            <td style="border:1px solid #dee2e6;">{{ r.full_location }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/app/templates/email/notify_crew.txt
+++ b/app/templates/email/notify_crew.txt
@@ -5,7 +5,7 @@ Hi {{ crew_name }},
 {% endif %}{{ skipper_name }} wants you to know about the following event(s):
 
 {% for r in regattas %}
-- {{ r.start_date.strftime('%b %d') }}{% if r.end_date %} – {{ r.end_date.strftime('%b %d') }}{% endif %}, {{ r.start_date.strftime('%Y') }} | {{ r.boat_class }} | {{ r.name }} | {{ r.location }}
+- {{ r.start_date.strftime('%b %d') }}{% if r.end_date %} – {{ r.end_date.strftime('%b %d') }}{% endif %}, {{ r.start_date.strftime('%Y') }} | {{ r.boat_class }} | {{ r.name }} | {{ r.full_location }}
 {% endfor %}
 
 View your schedule and RSVP: {{ schedule_url }}

--- a/app/templates/email/rsvp_digest.html
+++ b/app/templates/email/rsvp_digest.html
@@ -3,7 +3,7 @@
 <p>Here's your RSVP summary for today:</p>
 {% for summary in regatta_summaries %}
 <h3 style="margin-bottom:4px;">{{ summary.regatta.name }}</h3>
-<p style="margin-top:0;color:#666;">{{ summary.regatta.start_date.strftime('%b %d') }}{% if summary.regatta.end_date %} – {{ summary.regatta.end_date.strftime('%b %d') }}{% endif %}, {{ summary.regatta.start_date.strftime('%Y') }} — {{ summary.regatta.location }}</p>
+<p style="margin-top:0;color:#666;">{{ summary.regatta.start_date.strftime('%b %d') }}{% if summary.regatta.end_date %} – {{ summary.regatta.end_date.strftime('%b %d') }}{% endif %}, {{ summary.regatta.start_date.strftime('%Y') }} — {{ summary.regatta.full_location }}</p>
 <ul style="margin-top:0;">
 {% for rsvp in summary.rsvps %}
     <li>{{ rsvp.user.display_name }} — {{ rsvp.status }}</li>

--- a/app/templates/email/rsvp_digest.txt
+++ b/app/templates/email/rsvp_digest.txt
@@ -3,7 +3,7 @@ Hi {{ skipper_name }},
 Here's your RSVP summary for today:
 
 {% for summary in regatta_summaries %}
-{{ summary.regatta.name }} ({{ summary.regatta.start_date.strftime('%b %d') }}{% if summary.regatta.end_date %} – {{ summary.regatta.end_date.strftime('%b %d') }}{% endif %}, {{ summary.regatta.start_date.strftime('%Y') }}, {{ summary.regatta.location }})
+{{ summary.regatta.name }} ({{ summary.regatta.start_date.strftime('%b %d') }}{% if summary.regatta.end_date %} – {{ summary.regatta.end_date.strftime('%b %d') }}{% endif %}, {{ summary.regatta.start_date.strftime('%Y') }}, {{ summary.regatta.full_location }})
 {% for rsvp in summary.rsvps %}  - {{ rsvp.user.display_name }} — {{ rsvp.status }}
 {% endfor %}
 {% endfor %}

--- a/app/templates/email/rsvp_reminder.html
+++ b/app/templates/email/rsvp_reminder.html
@@ -1,6 +1,6 @@
 <h2>RSVP Reminder</h2>
 <p>Hi {{ crew_name }},</p>
-<p><strong>{{ regatta.name }}</strong> is coming up on {{ regatta.start_date.strftime('%b %d, %Y') }} at {{ regatta.location }}.</p>
+<p><strong>{{ regatta.name }}</strong> is coming up on {{ regatta.start_date.strftime('%b %d, %Y') }} at {{ regatta.full_location }}.</p>
 <p>{{ skipper_name }} would like to know if you can make it.</p>
 <p><a href="{{ schedule_url }}" style="display:inline-block;padding:10px 20px;background-color:#0d6efd;color:#fff;text-decoration:none;border-radius:4px;">RSVP Now</a></p>
 <p style="font-size:13px;color:#666;"><a href="{{ subscribe_url }}">Add races to your calendar</a> | Manage your notification preferences: <a href="{{ profile_url }}">{{ profile_url }}</a></p>

--- a/app/templates/email/rsvp_reminder.txt
+++ b/app/templates/email/rsvp_reminder.txt
@@ -1,6 +1,6 @@
 Hi {{ crew_name }},
 
-{{ regatta.name }} is coming up on {{ regatta.start_date.strftime('%b %d, %Y') }} at {{ regatta.location }}.
+{{ regatta.name }} is coming up on {{ regatta.start_date.strftime('%b %d, %Y') }} at {{ regatta.full_location }}.
 
 {{ skipper_name }} would like to know if you can make it.
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -135,6 +135,9 @@
                     {% else %}
                     {{ regatta.location }}
                     {% endif %}
+                    {% if regatta.city_state %}
+                    <br><small class="text-muted">{{ regatta.city_state }}</small>
+                    {% endif %}
                 </td>
                 <td class="text-nowrap">
                     {% for doc in regatta.documents|sort(attribute='doc_type') %}
@@ -225,6 +228,7 @@
                 {% else %}
                 {{ regatta.location }}
                 {% endif %}
+                {% if regatta.city_state %}, {{ regatta.city_state }}{% endif %}
                 {% endif %}
             </small>
             {% if regatta.notes %}

--- a/app/templates/pdf_schedule.html
+++ b/app/templates/pdf_schedule.html
@@ -96,7 +96,7 @@
             <br><span class="notes">{{ regatta.notes }}</span>
             {% endif %}
         </td>
-        <td>{{ regatta.location }}</td>
+        <td>{{ regatta.location }}{% if regatta.city_state %}<br><span class="notes">{{ regatta.city_state }}</span>{% endif %}</td>
         <td>
             {% for doc in regatta.documents %}
             <span class="doc-badge">{{ doc.doc_type }}</span>

--- a/app/templates/regatta_form.html
+++ b/app/templates/regatta_form.html
@@ -16,7 +16,11 @@
             </div>
             <div class="mb-3">
                 <label for="location" class="form-label">Location</label>
-                <input type="text" class="form-control" id="location" name="location" required value="{{ regatta.location if regatta else '' }}" placeholder="e.g. Lake Eustis, FL">
+                <input type="text" class="form-control" id="location" name="location" required value="{{ regatta.location if regatta else '' }}" placeholder="e.g. Eustis Sailing Club">
+            </div>
+            <div class="mb-3">
+                <label for="city_state" class="form-label">City, State (optional)</label>
+                <input type="text" class="form-control" id="city_state" name="city_state" value="{{ regatta.city_state if regatta and regatta.city_state else '' }}" placeholder="e.g. Eustis, FL">
             </div>
             <div class="mb-3">
                 <label for="location_url" class="form-label">Google Maps Link (optional — auto-generated from location if blank)</label>

--- a/migrations/versions/k1a2b3c4d5e6_add_city_state_to_regattas.py
+++ b/migrations/versions/k1a2b3c4d5e6_add_city_state_to_regattas.py
@@ -1,0 +1,22 @@
+"""Add city_state column to regattas table
+
+Revision ID: k1a2b3c4d5e6
+Revises: j0f1a2b3c4d5
+Create Date: 2026-03-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "k1a2b3c4d5e6"
+down_revision = "j0f1a2b3c4d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("regattas", sa.Column("city_state", sa.String(100), nullable=True))
+
+
+def downgrade():
+    op.drop_column("regattas", "city_state")

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -737,6 +737,77 @@ class TestImportConfirmSourceUrl:
         assert regatta.source_url is None
 
 
+class TestImportConfirmCityState:
+    """Tests that city_state is persisted during import confirm."""
+
+    def test_imports_regatta_with_city_state(self, app, logged_in_client, db):
+        resp = logged_in_client.post(
+            "/admin/import-schedule/confirm",
+            data={
+                "selected": "0",
+                "name_0": "City State Regatta",
+                "location_0": "Eustis Sailing Club",
+                "city_state_0": "Eustis, FL",
+                "start_date_0": "2026-09-20",
+                "end_date_0": "",
+                "notes_0": "",
+                "location_url_0": "",
+                "doc_count_0": "0",
+            },
+            follow_redirects=True,
+        )
+        assert b"Successfully imported 1 event" in resp.data
+
+        regatta = Regatta.query.filter_by(name="City State Regatta").first()
+        assert regatta is not None
+        assert regatta.city_state == "Eustis, FL"
+        assert regatta.full_location == "Eustis Sailing Club, Eustis, FL"
+
+    def test_imports_regatta_without_city_state(self, app, logged_in_client, db):
+        resp = logged_in_client.post(
+            "/admin/import-schedule/confirm",
+            data={
+                "selected": "0",
+                "name_0": "No City Regatta",
+                "location_0": "Test YC",
+                "start_date_0": "2026-09-21",
+                "end_date_0": "",
+                "notes_0": "",
+                "location_url_0": "",
+                "doc_count_0": "0",
+            },
+            follow_redirects=True,
+        )
+        assert b"Successfully imported 1 event" in resp.data
+
+        regatta = Regatta.query.filter_by(name="No City Regatta").first()
+        assert regatta is not None
+        assert regatta.city_state is None
+        assert regatta.full_location == "Test YC"
+
+    def test_city_state_included_in_auto_maps_url(self, app, logged_in_client, db):
+        logged_in_client.post(
+            "/admin/import-schedule/confirm",
+            data={
+                "selected": "0",
+                "name_0": "Maps URL Regatta",
+                "location_0": "Eustis Sailing Club",
+                "city_state_0": "Eustis, FL",
+                "start_date_0": "2026-09-22",
+                "end_date_0": "",
+                "notes_0": "",
+                "location_url_0": "",
+                "doc_count_0": "0",
+            },
+            follow_redirects=True,
+        )
+        regatta = Regatta.query.filter_by(name="Maps URL Regatta").first()
+        assert regatta is not None
+        assert "Eustis+Sailing+Club" in regatta.location_url
+        assert "Eustis" in regatta.location_url
+        assert "FL" in regatta.location_url
+
+
 class TestDiscoverDocumentsForRegatta:
     """Tests for the discover-documents SSE endpoint."""
 

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, patch
 import anthropic
 import pytest
 
-from app.admin.ai_service import (_parse_json_response, discover_documents,
+from app.admin.ai_service import (EXTRACTION_PROMPT, _parse_json_response,
+                                  discover_documents,
                                   discover_documents_deep, extract_regattas)
 
 # --- _parse_json_response ---
@@ -107,6 +108,15 @@ class TestExtractRegattas:
             extract_regattas("content", 2026)
             _, kwargs = mock_client.messages.create.call_args
             assert kwargs["timeout"] == 30.0
+
+
+class TestExtractionPrompt:
+    def test_prompt_includes_city_state_field(self):
+        assert '"city_state"' in EXTRACTION_PROMPT
+
+    def test_prompt_city_state_is_separate_from_location(self):
+        assert '"location"' in EXTRACTION_PROMPT
+        assert '"city_state"' in EXTRACTION_PROMPT
 
 
 # --- discover_documents ---

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -192,6 +192,56 @@ class TestRegattaModel:
 
         assert regatta.source_url == "https://example.com/regatta/123"
 
+    def test_city_state_nullable(self, app, db, admin_user):
+        regatta = Regatta(
+            name="No City State",
+            location="Test YC",
+            start_date=date(2026, 6, 24),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        assert regatta.city_state is None
+
+    def test_city_state_explicit_value(self, app, db, admin_user):
+        regatta = Regatta(
+            name="With City State",
+            location="Eustis Sailing Club",
+            city_state="Eustis, FL",
+            start_date=date(2026, 6, 25),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        assert regatta.city_state == "Eustis, FL"
+
+    def test_full_location_with_city_state(self, app, db, admin_user):
+        regatta = Regatta(
+            name="Full Location Test",
+            location="Eustis Sailing Club",
+            city_state="Eustis, FL",
+            start_date=date(2026, 6, 26),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        assert regatta.full_location == "Eustis Sailing Club, Eustis, FL"
+
+    def test_full_location_without_city_state(self, app, db, admin_user):
+        regatta = Regatta(
+            name="No City State Location",
+            location="Some Yacht Club",
+            start_date=date(2026, 6, 27),
+            created_by=admin_user.id,
+        )
+        db.session.add(regatta)
+        db.session.commit()
+
+        assert regatta.full_location == "Some Yacht Club"
+
     def test_regatta_cascade_delete_documents(self, app, db, admin_user):
         regatta = Regatta(
             name="Cascade Test",


### PR DESCRIPTION
## Summary
- Add `city_state` field to Regatta model (new DB column + migration) with `full_location` property that combines location + city/state
- City/State input on create/edit form, AI import preview, and single-regatta import preview
- AI extraction prompt updated to extract `city_state` as a separate field
- City/State displayed below location on schedule (desktop table + mobile cards), PDF, iCal feed, and all email templates (HTML + text)
- Google Maps auto-generated links include city/state for more accurate search results
- Fix calendar subscription URL generating `http://` instead of `https://` by setting `PREFERRED_URL_SCHEME` default to `https` in config

## Test plan
- [x] All 463 existing tests pass
- [x] New model tests: `city_state` nullable, explicit value, `full_location` with/without city_state
- [x] New AI service test: prompt includes `city_state` field
- [x] New admin route tests: import with/without city_state, maps URL includes city/state
- [ ] Manual: create event with city/state, verify display on schedule, PDF, iCal
- [ ] Manual: AI import from URL, verify city_state extracted and shown in preview
- [ ] Manual: verify calendar subscribe URL is https:// in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)