### PR TITLE
Fix RSVP reset to '-' (v0.64.1)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.64.1
+- Fix RSVP reset: selecting "-" (no response) now deletes the RSVP record instead of showing "Invalid RSVP status" error
+
 ## 0.64.0
 - Add City, State field to regattas for displaying venue location details (e.g. "Eustis, FL")
 - City/State input on create/edit event form and AI import preview

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.64.0"
+__version__ = "0.64.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -116,8 +116,7 @@ def pdf():
 
     # Determine title and whether to show skipper column
     show_skipper = skipper_id == 0 or (
-        skipper_id is None
-        and not current_user.is_skipper
+        skipper_id is None and not current_user.is_skipper
     )
     if skipper_id and skipper_id != 0:
         skipper = db.session.get(User, skipper_id)
@@ -283,14 +282,34 @@ def notify_crew_action():
 @login_required
 def rsvp(regatta_id: int):
     status = request.form.get("status", "").lower()
+
+    # Build redirect args early — used by all exit paths
+    redirect_args = {}
+    redirect_skipper = request.form.get("redirect_skipper")
+    if redirect_skipper is not None and redirect_skipper != "":
+        redirect_args["skipper"] = redirect_skipper
+    redirect_rsvp = request.form.getlist("redirect_rsvp")
+    if redirect_rsvp:
+        redirect_args["rsvp"] = redirect_rsvp
+
+    if not status:
+        # User selected "-" — clear their RSVP
+        existing = RSVP.query.filter_by(
+            regatta_id=regatta_id, user_id=current_user.id
+        ).first()
+        if existing:
+            db.session.delete(existing)
+            db.session.commit()
+        return redirect(url_for("regattas.index", **redirect_args))
+
     if status not in ("yes", "no", "maybe"):
         flash("Invalid RSVP status.", "error")
-        return redirect(url_for("regattas.index"))
+        return redirect(url_for("regattas.index", **redirect_args))
 
     regatta = db.session.get(Regatta, regatta_id)
     if not regatta or not can_rsvp_to_regatta(current_user, regatta):
         flash("Access denied.", "error")
-        return redirect(url_for("regattas.index"))
+        return redirect(url_for("regattas.index", **redirect_args))
 
     existing = RSVP.query.filter_by(
         regatta_id=regatta_id, user_id=current_user.id
@@ -310,14 +329,6 @@ def rsvp(regatta_id: int):
     except Exception:
         logger.exception("Failed to send RSVP notification for regatta %s", regatta.id)
 
-    # Preserve filter state in redirect
-    redirect_args = {}
-    redirect_skipper = request.form.get("redirect_skipper")
-    if redirect_skipper is not None and redirect_skipper != "":
-        redirect_args["skipper"] = redirect_skipper
-    redirect_rsvp = request.form.getlist("redirect_rsvp")
-    if redirect_rsvp:
-        redirect_args["rsvp"] = redirect_rsvp
     return redirect(url_for("regattas.index", **redirect_args))
 
 

--- a/tests/test_schedule_filters.py
+++ b/tests/test_schedule_filters.py
@@ -387,6 +387,61 @@ class TestRSVPFilterStatePreservation:
         assert "rsvp=yes" in location
 
 
+class TestRSVPReset:
+    """Submitting empty status (the '-' option) deletes the RSVP record."""
+
+    def test_empty_status_deletes_existing_rsvp(
+        self, app, db, logged_in_client, admin_user
+    ):
+        r = _create_regatta(db, "Test Regatta", admin_user.id)
+        db.session.add(RSVP(regatta_id=r.id, user_id=admin_user.id, status="yes"))
+        db.session.commit()
+
+        assert RSVP.query.filter_by(regatta_id=r.id, user_id=admin_user.id).first()
+
+        resp = logged_in_client.post(
+            f"/regattas/{r.id}/rsvp",
+            data={"status": ""},
+        )
+        assert resp.status_code == 302
+        assert (
+            RSVP.query.filter_by(regatta_id=r.id, user_id=admin_user.id).first() is None
+        )
+
+    def test_empty_status_no_existing_rsvp_does_not_error(
+        self, app, db, logged_in_client, admin_user
+    ):
+        r = _create_regatta(db, "Test Regatta", admin_user.id)
+
+        resp = logged_in_client.post(
+            f"/regattas/{r.id}/rsvp",
+            data={"status": ""},
+        )
+        assert resp.status_code == 302
+        assert (
+            RSVP.query.filter_by(regatta_id=r.id, user_id=admin_user.id).first() is None
+        )
+
+    def test_empty_status_preserves_filter_params(
+        self, app, db, logged_in_client, admin_user
+    ):
+        r = _create_regatta(db, "Test Regatta", admin_user.id)
+
+        resp = logged_in_client.post(
+            f"/regattas/{r.id}/rsvp",
+            data={
+                "status": "",
+                "redirect_skipper": str(admin_user.id),
+                "redirect_rsvp": ["yes", "maybe"],
+            },
+        )
+        assert resp.status_code == 302
+        location = resp.headers["Location"]
+        assert f"skipper={admin_user.id}" in location
+        assert "rsvp=yes" in location
+        assert "rsvp=maybe" in location
+
+
 class TestMonthDividerLabels:
     """Month divider labels render once per month group per view."""
 


### PR DESCRIPTION
## Summary
- Fix: selecting "-" (no response) in the RSVP dropdown now deletes the RSVP record instead of showing "Invalid RSVP status" error
- Empty status is handled before validation, preserving filter state in redirect
- Version bumped to 0.64.1

## Test plan
- [x] New test: empty status deletes existing RSVP record
- [x] New test: empty status with no existing RSVP does not error
- [x] New test: empty status preserves filter params in redirect
- [x] Full test suite passes (466 tests)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)