### PR TITLE
Update calendar subscription instructions and add event reminders (v0.65.0)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.65.0
+- Update calendar subscription instructions with accurate per-app guidance for Apple Calendar, Google Calendar, and Outlook (web, Windows, Mac)
+- Add "at event start" reminder/notification to all calendar subscription events
+
 ## 0.64.1
 - Fix RSVP reset: selecting "-" (no response) now deletes the RSVP record instead of showing "Invalid RSVP status" error
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.64.1"
+__version__ = "0.65.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/calendar/routes.py
+++ b/app/calendar/routes.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from flask import Response, render_template, url_for
 from flask_login import current_user, login_required
-from icalendar import Calendar, Event
+from icalendar import Alarm, Calendar, Event
 
 from app import db
 from app.calendar import bp
@@ -86,6 +86,13 @@ def ical_feed(token: str):
 
         if lines:
             event.add("description", "\n\n".join(lines))
+
+        # Reminder at event start
+        alarm = Alarm()
+        alarm.add("action", "DISPLAY")
+        alarm.add("description", "Race day")
+        alarm.add("trigger", timedelta(0))
+        event.add_component(alarm)
 
         cal.add_component(event)
 

--- a/app/templates/calendar/subscribe.html
+++ b/app/templates/calendar/subscribe.html
@@ -8,26 +8,36 @@
         <div class="col-md-8">
             <h2>Calendar Subscription</h2>
             <p>Subscribe to keep your calendar in sync with your race schedule. Events you've RSVP'd <strong>Yes</strong> or <strong>Maybe</strong> to will appear automatically, and updates sync whenever your calendar app refreshes.</p>
+            <div class="alert alert-info small mb-4">
+                <strong>Subscribe vs. Import:</strong> All methods on this page create a <strong>live subscription</strong> that stays in sync with your race schedule. If you simply download and open an .ics file, it will only import a one-time snapshot that won't update.
+            </div>
 
             <div class="card mb-4">
                 <div class="card-body">
                     <h5 class="card-title">Quick Subscribe</h5>
-                    <p class="card-text">If you use <strong>Apple Calendar</strong> or <strong>Outlook</strong>, click the button below to subscribe instantly. Your calendar app will open and ask you to confirm the subscription.</p>
+                    <p class="card-text">If you use <strong>Apple Calendar</strong>, click the button below to subscribe instantly.</p>
                     <a href="{{ webcal_url }}" class="btn btn-primary" id="webcal-subscribe">Open in Calendar App</a>
-                    <div class="form-text mt-2">Works with Apple Calendar (iPhone, iPad, Mac) and Outlook (desktop and mobile). For Google Calendar, follow the manual steps below.</div>
+                    <div class="form-text mt-2">Works with Apple Calendar (iPhone, iPad, Mac). Creates a live subscription that stays in sync. For Outlook or Google Calendar, copy the URL below and follow the instructions for your app.</div>
                 </div>
             </div>
 
             <div class="card mb-4">
                 <div class="card-body">
-                    <h5 class="card-title">Subscription URL</h5>
-                    <p class="card-text">If the button above doesn't work for your calendar app, copy this URL and add it manually using the instructions below.</p>
+                    <h5 class="card-title">Subscription URLs</h5>
+                    <p class="card-text">Copy the appropriate URL for your calendar app and follow the instructions below.</p>
+                    <label class="form-label fw-semibold" for="webcal-url">Calendar URL <span class="text-muted fw-normal">(Apple Calendar, Outlook)</span></label>
+                    <div class="input-group mb-3">
+                        <input type="text" class="form-control" id="webcal-url" readonly value="{{ webcal_url }}">
+                        <button class="btn btn-outline-secondary" type="button" id="copy-webcal-url"
+                                onclick="navigator.clipboard.writeText(document.getElementById('webcal-url').value); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy', 2000);">Copy</button>
+                    </div>
+                    <label class="form-label fw-semibold" for="ical-url">HTTPS URL <span class="text-muted fw-normal">(Google Calendar)</span></label>
                     <div class="input-group">
                         <input type="text" class="form-control" id="ical-url" readonly value="{{ feed_url }}">
                         <button class="btn btn-outline-secondary" type="button" id="copy-ical-url"
                                 onclick="navigator.clipboard.writeText(document.getElementById('ical-url').value); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy', 2000);">Copy</button>
                     </div>
-                    <div class="form-text mt-2">This URL is private to you. Don't share it with others.</div>
+                    <div class="form-text mt-2">These URLs are private to you. Don't share them with others.</div>
                 </div>
             </div>
 
@@ -45,7 +55,7 @@
                             <hr>
                             <p><strong>Manual setup:</strong></p>
                             <ol>
-                                <li>Tap the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Copy the <strong>Calendar URL</strong> above.</li>
                                 <li>Open the <strong>Settings</strong> app on your iPhone or iPad.</li>
                                 <li>Scroll down and tap <strong>Calendar</strong> (or <strong>Mail</strong> on older iOS versions).</li>
                                 <li>Tap <strong>Accounts</strong> &gt; <strong>Add Account</strong> &gt; <strong>Other</strong>.</li>
@@ -53,7 +63,7 @@
                                 <li>Paste the URL into the <strong>Server</strong> field and tap <strong>Next</strong>.</li>
                                 <li>Review the settings and tap <strong>Save</strong>.</li>
                             </ol>
-                            <p class="text-muted small mb-0">Your subscribed calendar will appear in the Calendar app. iOS typically refreshes subscribed calendars every few hours.</p>
+                            <p class="text-muted small mb-0">Creates a live subscription that stays in sync. iOS typically refreshes every few hours.</p>
                         </div>
                     </div>
                 </div>
@@ -69,14 +79,14 @@
                             <hr>
                             <p><strong>Manual setup:</strong></p>
                             <ol>
-                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Copy the <strong>Calendar URL</strong> above.</li>
                                 <li>Open the <strong>Calendar</strong> app on your Mac.</li>
                                 <li>From the menu bar, click <strong>File</strong> &gt; <strong>New Calendar Subscription...</strong></li>
                                 <li>Paste the URL into the <strong>Calendar URL</strong> field and click <strong>Subscribe</strong>.</li>
                                 <li>Choose a name, color, and how often to auto-refresh (every hour is recommended).</li>
                                 <li>Click <strong>OK</strong>.</li>
                             </ol>
-                            <p class="text-muted small mb-0">If you use iCloud, the subscription will sync to all your Apple devices automatically.</p>
+                            <p class="text-muted small mb-0">Creates a live subscription that stays in sync. If you use iCloud, it will sync to all your Apple devices automatically.</p>
                         </div>
                     </div>
                 </div>
@@ -88,47 +98,85 @@
                     </h2>
                     <div id="googleInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
                         <div class="accordion-body">
-                            <p class="text-muted">Google Calendar does not support the subscribe button — you'll need to add the URL manually. This must be done from a computer, not the mobile app.</p>
+                            <p class="text-muted">Google Calendar requires the HTTPS URL. This must be done from a computer, not the mobile app.</p>
                             <ol>
-                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
+                                <li>Copy the <strong>HTTPS URL</strong> above.</li>
                                 <li>Open <a href="https://calendar.google.com" target="_blank" rel="noopener">Google Calendar</a> in a web browser on your computer.</li>
                                 <li>In the left sidebar, find <strong>"Other calendars"</strong> and click the <strong>+</strong> icon next to it.</li>
                                 <li>Select <strong>From URL</strong>.</li>
                                 <li>Paste the subscription URL into the <strong>URL of calendar</strong> field.</li>
                                 <li>Click <strong>Add calendar</strong>.</li>
                             </ol>
-                            <p class="text-muted small mb-0">Google Calendar typically refreshes subscribed calendars once every 12–24 hours. There is no way to force a manual refresh.</p>
+                            <p class="text-muted small mb-0">Creates a live subscription that stays in sync. Google Calendar typically refreshes once every 12–24 hours.</p>
                         </div>
                     </div>
                 </div>
                 <div class="accordion-item">
                     <h2 class="accordion-header">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#outlookInstructions">
-                            Outlook
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#outlookWebInstructions">
+                            Outlook on the Web (Recommended for Outlook Users)
                         </button>
                     </h2>
-                    <div id="outlookInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
+                    <div id="outlookWebInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
                         <div class="accordion-body">
-                            <p><strong>Easiest way:</strong> Click the <strong>"Open in Calendar App"</strong> button above. Outlook will open and ask you to confirm the subscription.</p>
-                            <hr>
-                            <p><strong>Outlook on the web (outlook.com):</strong></p>
+                            <p class="text-muted">This is the easiest way to subscribe with Outlook. The calendar will sync to all your Outlook apps (desktop, mobile, and web) automatically.</p>
                             <ol>
-                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
-                                <li>Open <a href="https://outlook.live.com/calendar" target="_blank" rel="noopener">Outlook Calendar</a> in your browser.</li>
+                                <li>Copy the <strong>Calendar URL</strong> above.</li>
+                                <li>Open <a href="https://outlook.live.com/calendar" target="_blank" rel="noopener">Outlook Calendar</a> in your browser (or <a href="https://outlook.office.com/calendar" target="_blank" rel="noopener">Office 365 Calendar</a> if you use a work account).</li>
+                                <li>Click <strong>Add calendar</strong> in the left sidebar.</li>
+                                <li>Select <strong>Subscribe from web</strong>.</li>
+                                <li>Paste the URL, give the calendar a name, and click <strong>Import</strong>.</li>
+                            </ol>
+                            <p class="text-muted small mb-0">Creates a live subscription that stays in sync. Outlook typically refreshes every 3 hours. The subscription will appear on all your devices signed into the same Microsoft account.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#outlookWindowsInstructions">
+                            Outlook Desktop (Windows)
+                        </button>
+                    </h2>
+                    <div id="outlookWindowsInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
+                        <div class="accordion-body">
+                            <p><strong>New Outlook:</strong></p>
+                            <ol>
+                                <li>Copy the <strong>Calendar URL</strong> above.</li>
+                                <li>Open Outlook and switch to the <strong>Calendar</strong> view.</li>
                                 <li>Click <strong>Add calendar</strong> in the left sidebar.</li>
                                 <li>Select <strong>Subscribe from web</strong>.</li>
                                 <li>Paste the URL, give the calendar a name, and click <strong>Import</strong>.</li>
                             </ol>
                             <hr>
-                            <p><strong>Outlook desktop app (Windows/Mac):</strong></p>
+                            <p><strong>Classic Outlook:</strong></p>
                             <ol>
-                                <li>Click the <strong>Copy</strong> button above to copy the subscription URL.</li>
-                                <li>Open Outlook and switch to the <strong>Calendar</strong> view.</li>
-                                <li>Click <strong>Add calendar</strong> (or <strong>Open Calendar</strong> on older versions).</li>
-                                <li>Select <strong>From Internet...</strong> or <strong>Subscribe from web</strong>.</li>
-                                <li>Paste the URL and click <strong>OK</strong>.</li>
+                                <li>Copy the <strong>Calendar URL</strong> above.</li>
+                                <li>Go to <strong>File</strong> &gt; <strong>Account Settings</strong> &gt; <strong>Account Settings</strong>.</li>
+                                <li>Click the <strong>Internet Calendars</strong> tab.</li>
+                                <li>Click <strong>New...</strong> and paste the URL.</li>
+                                <li>Click <strong>Add</strong>, optionally rename the calendar, then click <strong>OK</strong>.</li>
                             </ol>
-                            <p class="text-muted small mb-0">Outlook typically refreshes subscribed calendars every 3 hours.</p>
+                            <p class="text-muted small mb-0">Creates a live subscription that stays in sync. Outlook typically refreshes every 3 hours.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#outlookMacInstructions">
+                            Outlook Desktop (Mac)
+                        </button>
+                    </h2>
+                    <div id="outlookMacInstructions" class="accordion-collapse collapse" data-bs-parent="#calendarInstructions">
+                        <div class="accordion-body">
+                            <p class="text-muted">Outlook for Mac does not support calendar subscriptions directly. Use <strong>Outlook on the Web</strong> instead — the subscription will sync to your Mac automatically.</p>
+                            <ol>
+                                <li>Copy the <strong>Calendar URL</strong> above.</li>
+                                <li>Open <a href="https://outlook.live.com/calendar" target="_blank" rel="noopener">Outlook Calendar</a> in your browser (or <a href="https://outlook.office.com/calendar" target="_blank" rel="noopener">Office 365 Calendar</a> for work accounts).</li>
+                                <li>Click <strong>Add calendar</strong> in the left sidebar.</li>
+                                <li>Select <strong>Subscribe from web</strong>.</li>
+                                <li>Paste the URL, give the calendar a name, and click <strong>Import</strong>.</li>
+                            </ol>
+                            <p class="text-muted small mb-0">Creates a live subscription that stays in sync. The subscription will appear in your Outlook for Mac app once it syncs with your Microsoft account.</p>
                         </div>
                     </div>
                 </div>

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -131,6 +131,17 @@ class TestIcalFeedFiltering:
         assert resp.status_code == 200
         assert "text/calendar" in resp.content_type
 
+    def test_events_include_alarm_at_start(self, db, logged_in_client, admin_user):
+        r = _create_regatta(db, admin_user)
+        _rsvp(db, admin_user, r, "yes")
+        _subscribe(logged_in_client)
+        db.session.refresh(admin_user)
+
+        resp = logged_in_client.get(f"/calendar/{admin_user.calendar_token}.ics")
+        assert resp.status_code == 200
+        assert b"VALARM" in resp.data
+        assert b"TRIGGER" in resp.data
+
     def test_invalid_token_returns_404(self, client):
         resp = client.get("/calendar/invalid-token-12345.ics")
         assert resp.status_code == 404
@@ -172,6 +183,14 @@ class TestSubscribePage:
         assert b"webcal://" in resp.data
         assert admin_user.calendar_token.encode() in resp.data
 
+    def test_shows_webcal_url_copyable(self, db, logged_in_client, admin_user):
+        resp = logged_in_client.get("/calendar/subscribe")
+        db.session.refresh(admin_user)
+        html = resp.data.decode()
+        assert 'id="webcal-url"' in html
+        assert f"webcal://" in html
+        assert 'id="copy-webcal-url"' in html
+
     def test_shows_apple_instructions(self, db, logged_in_client):
         resp = logged_in_client.get("/calendar/subscribe")
         assert b"Apple Calendar (iPhone / iPad)" in resp.data
@@ -184,7 +203,9 @@ class TestSubscribePage:
 
     def test_shows_outlook_instructions(self, db, logged_in_client):
         resp = logged_in_client.get("/calendar/subscribe")
-        assert b"Outlook" in resp.data
+        assert b"Outlook on the Web" in resp.data
+        assert b"Outlook Desktop (Windows)" in resp.data
+        assert b"Outlook Desktop (Mac)" in resp.data
         assert b"outlook.live.com" in resp.data
 
     def test_preserves_existing_token(self, db, logged_in_client, admin_user):


### PR DESCRIPTION
## Summary
- Rewrite calendar subscribe page with accurate per-app instructions for Apple Calendar, Google Calendar, and Outlook (web, Windows desktop, Mac)
- Add copyable webcal:// URL field for Apple Calendar and Outlook subscribers (separate from HTTPS URL for Google Calendar)
- Add "Subscribe vs. Import" info banner and per-section sync notes clarifying all methods create live subscriptions
- Add VALARM reminder (at event start) to all calendar feed events

## Test plan
- [x] New test: calendar feed events include VALARM alarm
- [x] New test: subscribe page shows copyable webcal URL
- [x] Updated test: Outlook instructions reflect new section layout
- [x] Full test suite passes (468 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)