### PR TITLE
Clear import cache after 30 days (v0.65.1)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.65.1
+- Auto-delete ImportCache entries older than 30 days to prevent stale data accumulation
+
 ## 0.65.0
 - Update calendar subscription instructions with accurate per-app guidance for Apple Calendar, Google Calendar, and Outlook (web, Windows, Mac)
 - Add "at event start" reminder/notification to all calendar subscription events

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.65.0"
+__version__ = "0.65.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -66,6 +66,13 @@ def _cleanup_stale_task_results() -> None:
     db.session.commit()
 
 
+def _cleanup_stale_import_cache(max_age_days: int = 30) -> None:
+    """Delete ImportCache entries older than max_age_days."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+    ImportCache.query.filter(ImportCache.extracted_at < cutoff).delete()
+    db.session.commit()
+
+
 def _require_admin():
     """Return a redirect response if the user is not an admin, else None."""
     if not current_user.is_admin:
@@ -682,6 +689,7 @@ def import_schedule_extract():
 
     def generate():
         _cleanup_stale_task_results()
+        _cleanup_stale_import_cache()
         content = schedule_text
         from_cache = False
 
@@ -876,6 +884,7 @@ def import_schedule_extract_file():
 
     def generate():
         _cleanup_stale_task_results()
+        _cleanup_stale_import_cache()
         if file_bytes is None or not file_name:
             yield _sse({"type": "error", "message": "No file uploaded."})
             yield _sse({"type": "failed"})
@@ -1060,6 +1069,7 @@ def import_schedule_extract_single():
 
     def generate():
         _cleanup_stale_task_results()
+        _cleanup_stale_import_cache()
         if not schedule_url:
             yield _sse({"type": "error", "message": "Provide a regatta URL."})
             yield _sse({"type": "failed"})
@@ -1303,7 +1313,9 @@ def import_schedule_confirm():
         # Auto-generate Google Maps link if no location_url
         if not location_url and location:
             maps_query = f"{location}, {city_state}" if city_state else location
-            location_url = f"https://www.google.com/maps/search/{quote_plus(maps_query)}"
+            location_url = (
+                f"https://www.google.com/maps/search/{quote_plus(maps_query)}"
+            )
 
         detail_url = request.form.get(f"detail_url_{idx}", "").strip()
 
@@ -1405,6 +1417,7 @@ def import_schedule_discover():
 
     def generate():
         _cleanup_stale_task_results()
+        _cleanup_stale_import_cache()
         total_docs = 0
 
         if not has_detail_urls:
@@ -1615,6 +1628,7 @@ def discover_documents_for_regatta(regatta_id: int):
 
     def generate():
         _cleanup_stale_task_results()
+        _cleanup_stale_import_cache()
         total_docs = 0
         documents = []
 

--- a/tests/test_admin_helpers.py
+++ b/tests/test_admin_helpers.py
@@ -1,10 +1,12 @@
 """Tests for helper functions in app.admin.routes."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from bs4 import BeautifulSoup
 
-from app.admin.routes import (_extract_data_attributes, _extract_jsonld_events,
+from app.admin.routes import (_cleanup_stale_import_cache,
+                              _extract_data_attributes, _extract_jsonld_events,
                               _fetch_clubspot_documents, _is_private_ip,
                               _parse_clubspot_regatta_id)
 
@@ -292,3 +294,53 @@ class TestFetchClubspotDocuments:
         call_kwargs = mock_get.call_args
         headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
         assert headers["X-Parse-Application-Id"] == "myclubspot2017"
+
+
+# --- _cleanup_stale_import_cache ---
+
+
+class TestCleanupStaleImportCache:
+    def test_deletes_entries_older_than_30_days(self, app, db):
+        from app.models import ImportCache
+
+        old_entry = ImportCache(
+            url="https://example.com/old",
+            year=2025,
+            results_json="[]",
+            regatta_count=0,
+            extracted_at=datetime.now(timezone.utc) - timedelta(days=31),
+        )
+        db.session.add(old_entry)
+        db.session.commit()
+
+        with app.app_context():
+            _cleanup_stale_import_cache()
+
+        assert (
+            ImportCache.query.filter_by(url="https://example.com/old").first() is None
+        )
+
+    def test_preserves_entries_newer_than_30_days(self, app, db):
+        from app.models import ImportCache
+
+        recent_entry = ImportCache(
+            url="https://example.com/recent",
+            year=2025,
+            results_json="[]",
+            regatta_count=0,
+            extracted_at=datetime.now(timezone.utc) - timedelta(days=29),
+        )
+        db.session.add(recent_entry)
+        db.session.commit()
+
+        with app.app_context():
+            _cleanup_stale_import_cache()
+
+        assert (
+            ImportCache.query.filter_by(url="https://example.com/recent").first()
+            is not None
+        )
+
+    def test_no_entries_does_not_error(self, app, db):
+        with app.app_context():
+            _cleanup_stale_import_cache()


### PR DESCRIPTION
## Summary
- Add `_cleanup_stale_import_cache()` to auto-delete `ImportCache` entries older than 30 days
- Called alongside existing `_cleanup_stale_task_results()` in all 5 extraction routes
- Includes 3 tests for cache cleanup (old entries deleted, recent preserved, empty table safe)
- Bump version to 0.65.1

Closes #78

## Test plan
- [x] All 471 tests pass
- [x] `black . && isort . && flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)