### PR TITLE
Add custom scrollbar styling to terminal modal

### DIFF
--- a/app/templates/admin/_terminal_modal.html
+++ b/app/templates/admin/_terminal_modal.html
@@ -1,4 +1,21 @@
 <style>
+#terminal-output {
+    scrollbar-width: thin;
+    scrollbar-color: #555 #1e1e1e;
+}
+#terminal-output::-webkit-scrollbar {
+    width: 8px;
+}
+#terminal-output::-webkit-scrollbar-track {
+    background: #1e1e1e;
+}
+#terminal-output::-webkit-scrollbar-thumb {
+    background: #555;
+    border-radius: 4px;
+}
+#terminal-output::-webkit-scrollbar-thumb:hover {
+    background: #777;
+}
 .terminal-cursor {
     color: #569cd6;
     display: inline;


### PR DESCRIPTION
## Summary
- Add thin, dark-themed scrollbar styling to the terminal output modal for a cleaner look
- Supports both Firefox (`scrollbar-width`/`scrollbar-color`) and WebKit browsers (`::-webkit-scrollbar`)

## Test plan
- [x] Visual change only — no logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)