### PR TITLE
Add logo & sailboat emoji to all emails (v0.66.0)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.66.0
+- Add Race Crew Network logo header to all HTML emails
+- Wrap all email subject lines with sailboat emoji (⛵)
+- Branding applied centrally in `_send_via_ses()` so all current and future emails are covered
+
 ## 0.65.1
 - Auto-delete ImportCache entries older than 30 days to prevent stale data accumulation
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.65.1"
+__version__ = "0.66.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/email_service.py
+++ b/app/admin/email_service.py
@@ -105,6 +105,9 @@ def _send_via_ses(
     region = settings["ses_region"]
     client = _get_ses_client(region)
 
+    # Wrap subject with sailboat emoji
+    subject = f"⛵ {subject} ⛵"
+
     # Build MIME message for custom headers
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
@@ -119,15 +122,26 @@ def _send_via_ses(
     # Attach text part
     msg.attach(MIMEText(body_text, "plain", "utf-8"))
 
-    # Attach HTML part with unsubscribe footer
+    # Attach HTML part with logo header and unsubscribe footer
     if body_html:
+        logo_url = url_for(
+            "static",
+            filename="img/race-crew-network-1536x1024.png",
+            _external=True,
+        )
+        header = (
+            '<div style="text-align:center;margin-bottom:20px;">'
+            f'<img src="{logo_url}" alt="Race Crew Network" '
+            'style="max-width:350px;width:100%;height:auto;" />'
+            "</div>"
+        )
         footer = (
             '<hr style="margin-top:20px;border:none;border-top:1px solid #ddd;">'
             '<p style="font-size:12px;color:#888;">'
             f'<a href="{unsubscribe_url}">Unsubscribe</a> from Race Crew Network emails.'
             "</p>"
         )
-        body_html_with_footer = body_html + footer
+        body_html_with_footer = header + body_html + footer
         msg.attach(MIMEText(body_html_with_footer, "html", "utf-8"))
 
     client.send_raw_email(

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,5 +1,7 @@
 """Tests for email service (SES integration)."""
 
+from email import message_from_string
+from email.header import decode_header
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +12,26 @@ from app.admin.email_service import (generate_unsubscribe_token,
                                      is_email_configured, load_email_settings,
                                      send_email, verify_unsubscribe_token)
 from app.models import SiteSetting, User
+
+
+def _decode_subject(raw_data: str) -> str:
+    """Parse a raw MIME message and return the decoded Subject string."""
+    msg = message_from_string(raw_data)
+    parts = decode_header(msg["Subject"])
+    return "".join(
+        part.decode(enc or "utf-8") if isinstance(part, bytes) else part
+        for part, enc in parts
+    )
+
+
+def _decode_html_body(raw_data: str) -> str:
+    """Extract and decode the HTML part from a raw MIME message."""
+    msg = message_from_string(raw_data)
+    for part in msg.walk():
+        if part.get_content_type() == "text/html":
+            payload = part.get_payload(decode=True)
+            return payload.decode("utf-8")
+    return ""
 
 
 class TestLoadEmailSettings:
@@ -102,12 +124,11 @@ class TestSendEmail:
         raw_data = call_kwargs["RawMessage"]["Data"]
         assert "List-Unsubscribe:" in raw_data
         assert "List-Unsubscribe-Post:" in raw_data
-        assert "Test Subject" in raw_data
+        decoded_subject = _decode_subject(raw_data)
+        assert "Test Subject" in decoded_subject
 
     @patch("app.admin.email_service._get_ses_client")
     def test_sends_html_with_footer(self, mock_get_client, app, db):
-        import base64
-
         db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
         db.session.commit()
 
@@ -119,12 +140,7 @@ class TestSendEmail:
         call_kwargs = mock_client.send_raw_email.call_args[1]
         assert call_kwargs["Source"] == "Race Crew Network <from@example.com>"
         raw_data = call_kwargs["RawMessage"]["Data"]
-        # HTML body is base64-encoded in the MIME message; decode to verify
-        assert "text/html" in raw_data
-        # Extract and decode the base64 HTML part
-        parts = raw_data.split("text/html")
-        b64_content = parts[1].split("\n\n", 1)[1].split("\n--")[0].strip()
-        decoded_html = base64.b64decode(b64_content).decode("utf-8")
+        decoded_html = _decode_html_body(raw_data)
         assert "<p>HTML</p>" in decoded_html
         assert "Unsubscribe" in decoded_html
 
@@ -197,3 +213,65 @@ class TestSendEmail:
         send_email("optin@example.com", "Subject", "Body")
 
         mock_client.send_raw_email.assert_called_once()
+
+
+class TestEmailBranding:
+    @patch("app.admin.email_service._get_ses_client")
+    def test_subject_wrapped_with_sailboat_emoji(self, mock_get_client, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("to@example.com", "Test Subject", "Body")
+
+        raw_data = mock_client.send_raw_email.call_args[1]["RawMessage"]["Data"]
+        decoded_subject = _decode_subject(raw_data)
+        assert decoded_subject == "⛵ Test Subject ⛵"
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_html_email_includes_logo(self, mock_get_client, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("to@example.com", "Subject", "Text", body_html="<p>HTML</p>")
+
+        raw_data = mock_client.send_raw_email.call_args[1]["RawMessage"]["Data"]
+        decoded_html = _decode_html_body(raw_data)
+        assert "race-crew-network-1536x1024.png" in decoded_html
+        assert 'alt="Race Crew Network"' in decoded_html
+        assert "max-width:350px" in decoded_html
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_logo_before_body_before_footer(self, mock_get_client, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("to@example.com", "Subject", "Text", body_html="<p>Body</p>")
+
+        raw_data = mock_client.send_raw_email.call_args[1]["RawMessage"]["Data"]
+        decoded_html = _decode_html_body(raw_data)
+        logo_pos = decoded_html.index("race-crew-network-1536x1024.png")
+        body_pos = decoded_html.index("<p>Body</p>")
+        footer_pos = decoded_html.index("Unsubscribe")
+        assert logo_pos < body_pos < footer_pos
+
+    @patch("app.admin.email_service._get_ses_client")
+    def test_text_only_email_no_logo(self, mock_get_client, app, db):
+        db.session.add(SiteSetting(key="ses_sender", value="from@example.com"))
+        db.session.commit()
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        send_email("to@example.com", "Subject", "Text only body")
+
+        raw_data = mock_client.send_raw_email.call_args[1]["RawMessage"]["Data"]
+        assert "race-crew-network-1536x1024.png" not in raw_data


### PR DESCRIPTION
## Summary
- Prepend Race Crew Network logo header to all HTML emails
- Wrap all email subject lines with ⛵ sailboat emoji
- Branding applied centrally in `_send_via_ses()` — automatically covers all current and future emails

Closes #110

## Test plan
- [x] All 475 existing + new tests pass
- [ ] Local Docker test: send test email from admin panel, verify logo renders and subject has emoji
- [ ] Verify text-only emails do not include logo markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)