### PR TITLE
Add help page & contact form (v0.67.0)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.67.0
+- Add public Help & Documentation page with usage guides for all user roles
+- Add contact form with honeypot and timestamp spam protection
+- Help link visible in navbar for all users, including anonymous visitors
+
 ## 0.66.0
 - Add Race Crew Network logo header to all HTML emails
 - Wrap all email subject lines with sailboat emoji (⛵)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.66.0"
+__version__ = "0.67.0"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -47,6 +47,7 @@ def create_app(test_config=None):
     from app.auth import bp as auth_bp
     from app.calendar import bp as calendar_bp
     from app.email import bp as email_bp
+    from app.help import bp as help_bp
     from app.regattas import bp as regattas_bp
     from app.storage_routes import bp as storage_bp
 
@@ -54,6 +55,7 @@ def create_app(test_config=None):
     app.register_blueprint(auth_bp)
     app.register_blueprint(calendar_bp)
     app.register_blueprint(email_bp)
+    app.register_blueprint(help_bp)
     app.register_blueprint(regattas_bp)
     app.register_blueprint(storage_bp)
 

--- a/app/admin/email_service.py
+++ b/app/admin/email_service.py
@@ -88,6 +88,7 @@ def _send_via_ses(
     subject: str,
     body_text: str,
     body_html: str | None = None,
+    reply_to: str | None = None,
 ) -> None:
     """Build MIME message and send via AWS SES.
 
@@ -113,6 +114,9 @@ def _send_via_ses(
     msg["Subject"] = subject
     msg["From"] = f"Race Crew Network <{sender}>"
     msg["To"] = to
+
+    if reply_to:
+        msg["Reply-To"] = reply_to
 
     # Add unsubscribe headers (RFC 8058)
     unsubscribe_url = generate_unsubscribe_url(to)

--- a/app/help/__init__.py
+++ b/app/help/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("help", __name__)
+
+from app.help import routes  # noqa: E402, F401

--- a/app/help/routes.py
+++ b/app/help/routes.py
@@ -1,0 +1,63 @@
+import time
+
+from flask import current_app, redirect, render_template, request, url_for
+
+from app.help import bp
+
+
+@bp.route("/help")
+def index():
+    """Render the public help page."""
+    contact_status = request.args.get("contact")
+    return render_template(
+        "help/index.html",
+        form_timestamp=int(time.time()),
+        contact_status=contact_status,
+    )
+
+
+@bp.route("/help/contact", methods=["POST"])
+def contact():
+    """Handle contact form submission with spam protection."""
+    # Honeypot check — bots fill the hidden field; humans never see it
+    if request.form.get("website"):
+        return redirect(url_for("help.index", contact="sent", _anchor="contact"))
+
+    # Timestamp check — reject submissions faster than 3 seconds
+    try:
+        form_ts = int(request.form.get("form_timestamp", 0))
+        if time.time() - form_ts < 3:
+            return redirect(url_for("help.index", contact="sent", _anchor="contact"))
+    except (ValueError, TypeError):
+        pass
+
+    name = request.form.get("name", "").strip()
+    email = request.form.get("email", "").strip()
+    message = request.form.get("message", "").strip()
+
+    if not name or not email or not message:
+        return redirect(url_for("help.index", contact="missing", _anchor="contact"))
+
+    # Send via SES to admin
+    try:
+        from app.admin.email_service import _send_via_ses, load_email_settings
+
+        settings = load_email_settings()
+        recipient = settings["ses_sender_to"] or settings["ses_sender"]
+        if not recipient:
+            raise ValueError("No admin email configured.")
+
+        subject = f"[Contact Form] Message from {name}"
+        body_text = f"Name: {name}\nEmail: {email}\n\nMessage:\n{message}"
+        body_html = (
+            f"<p><strong>Name:</strong> {name}</p>"
+            f"<p><strong>Email:</strong> {email}</p>"
+            f"<hr><p>{message}</p>"
+        )
+
+        _send_via_ses(recipient, subject, body_text, body_html, reply_to=email)
+
+        return redirect(url_for("help.index", contact="sent", _anchor="contact"))
+    except Exception:
+        current_app.logger.exception("Contact form email failed")
+        return redirect(url_for("help.index", contact="error", _anchor="contact"))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,17 +26,20 @@
             <a class="navbar-brand" href="{{ url_for('regattas.index') }}">
                 <img src="{{ url_for('static', filename='img/race-crew-network-1536x1024.png') }}" alt="Race Crew Network" class="navbar-logo">
             </a>
-            {% if current_user.is_authenticated %}
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu" aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navMenu">
                 <div class="navbar-nav ms-auto align-items-center gap-2">
+                    {% if current_user.is_authenticated %}
                     <a class="nav-link nav-pill-link" href="{{ url_for('regattas.index') }}">Home</a>
                     <a class="nav-link nav-pill-link" href="{{ url_for('calendar.subscribe') }}">Calendar</a>
                     {% if current_user.is_admin or current_user.is_skipper %}
                     <a class="nav-link nav-pill-link" href="{{ url_for('auth.my_crew') }}">My Crew</a>
                     {% endif %}
+                    {% endif %}
+                    <a class="nav-link nav-pill-link" href="{{ url_for('help.index') }}">Help</a>
+                    {% if current_user.is_authenticated %}
                     {% if current_user.is_admin %}
                     <li class="nav-item dropdown">
                         <a class="nav-link nav-pill-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Admin</a>
@@ -64,9 +67,9 @@
                             <li><a class="dropdown-item" href="{{ url_for('auth.logout') }}">Logout</a></li>
                         </ul>
                     </li>
+                    {% endif %}
                 </div>
             </div>
-            {% endif %}
         </div>
     </nav>
 

--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -1,0 +1,218 @@
+{% extends "base.html" %}
+
+{% block title %}Help — Race Crew Network{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2 class="mb-4">Help &amp; Documentation</h2>
+
+    <div class="row">
+        {# -- Mobile TOC (collapsible, visible below md) -- #}
+        <div class="col-12 d-md-none mb-3">
+            <button class="btn btn-outline-secondary w-100" type="button" data-bs-toggle="collapse" data-bs-target="#tocMobile" aria-expanded="false" aria-controls="tocMobile">
+                Table of Contents
+            </button>
+            <div class="collapse mt-2" id="tocMobile">
+                <div class="list-group list-group-flush">
+                    <a href="#getting-started" class="list-group-item list-group-item-action">Getting Started</a>
+                    <a href="#request-access" class="list-group-item list-group-item-action">How to Request Access</a>
+                    <a href="#schedule-rsvps" class="list-group-item list-group-item-action">Viewing the Schedule &amp; RSVPs</a>
+                    <a href="#calendar" class="list-group-item list-group-item-action">Calendar Subscription</a>
+                    <a href="#documents" class="list-group-item list-group-item-action">Documents</a>
+                    <a href="#profile-notifications" class="list-group-item list-group-item-action">Profile &amp; Notifications</a>
+                    <a href="#skippers" class="list-group-item list-group-item-action">For Skippers: Crew &amp; Events</a>
+                    <a href="#developers" class="list-group-item list-group-item-action">For Developers</a>
+                    <a href="#contact" class="list-group-item list-group-item-action">Contact Support</a>
+                </div>
+            </div>
+        </div>
+
+        {# -- Desktop TOC sidebar (sticky, visible md+) -- #}
+        <div class="col-md-3 d-none d-md-block">
+            <div class="position-sticky" style="top: 80px;">
+                <h6 class="text-muted text-uppercase small mb-3">Contents</h6>
+                <nav class="nav flex-column">
+                    <a class="nav-link px-0 py-1" href="#getting-started">Getting Started</a>
+                    <a class="nav-link px-0 py-1" href="#request-access">How to Request Access</a>
+                    <a class="nav-link px-0 py-1" href="#schedule-rsvps">Schedule &amp; RSVPs</a>
+                    <a class="nav-link px-0 py-1" href="#calendar">Calendar Subscription</a>
+                    <a class="nav-link px-0 py-1" href="#documents">Documents</a>
+                    <a class="nav-link px-0 py-1" href="#profile-notifications">Profile &amp; Notifications</a>
+                    <a class="nav-link px-0 py-1" href="#skippers">For Skippers</a>
+                    <a class="nav-link px-0 py-1" href="#developers">For Developers</a>
+                    <a class="nav-link px-0 py-1" href="#contact">Contact Support</a>
+                </nav>
+            </div>
+        </div>
+
+        {# -- Main content -- #}
+        <div class="col-md-9">
+
+            {# 1. Getting Started #}
+            <section id="getting-started" class="mb-5">
+                <h3>Getting Started</h3>
+                <p>Race Crew Network (RCN) is a private scheduling and communication tool for sailing race crews. It helps skippers organize their race calendar and crew members stay on top of upcoming events.</p>
+                <p>After your first login, set up your profile by navigating to <strong>Profile Settings</strong> from the avatar dropdown in the top-right corner. From there you can:</p>
+                <ul>
+                    <li>Set your <strong>display name</strong> and <strong>initials</strong></li>
+                    <li>Upload a <strong>profile picture</strong> or use the auto-generated avatar</li>
+                    <li>Update your email address and password</li>
+                </ul>
+            </section>
+
+            {# 2. How to Request Access #}
+            <section id="request-access" class="mb-5">
+                <h3>How to Request Access</h3>
+                <p>RCN is <strong>invite-only</strong>. To get access:</p>
+                <ol>
+                    <li>Ask your skipper or team admin if they have a Race Crew Network account</li>
+                    <li>They can invite you by sharing a <strong>registration link</strong> or sending you an email invitation from the <strong>My Crew</strong> page</li>
+                    <li>Click the link, create your account, and you'll automatically be connected to your skipper's crew</li>
+                </ol>
+                <p>If you're a skipper looking to set up your own crew, contact us using the form below.</p>
+            </section>
+
+            {# 3. Viewing the Schedule & RSVPs #}
+            <section id="schedule-rsvps" class="mb-5">
+                <h3>Viewing the Schedule &amp; RSVPs</h3>
+                <p>The <strong>Home</strong> page shows your upcoming race schedule. Events are listed chronologically with key details like date, location, and event type.</p>
+                <ul>
+                    <li><strong>RSVP</strong> to each event with <strong>Yes</strong>, <strong>No</strong>, or <strong>Maybe</strong> so your skipper knows who's available</li>
+                    <li>On <strong>desktop</strong>, you'll see a full table view with crew RSVP status at a glance</li>
+                    <li>On <strong>mobile</strong>, events are shown as cards optimized for smaller screens</li>
+                    <li>Use the tabs to switch between <strong>Upcoming</strong> and <strong>Past</strong> events</li>
+                </ul>
+            </section>
+
+            {# 4. Calendar Subscription #}
+            <section id="calendar" class="mb-5">
+                <h3>Calendar Subscription</h3>
+                <p>Subscribe to your race schedule so events automatically appear in your personal calendar. Events you've RSVP'd <strong>Yes</strong> or <strong>Maybe</strong> to will sync automatically.</p>
+                <p>Click <strong>Calendar</strong> in the navbar to get your subscription URL, then add it to your preferred app:</p>
+                <ul>
+                    <li><strong>Apple Calendar</strong> — Click the "Open in Calendar App" button for instant setup</li>
+                    <li><strong>Google Calendar</strong> — Copy the HTTPS URL and add it under "Other calendars &rarr; From URL"</li>
+                    <li><strong>Outlook</strong> — Copy the calendar URL and subscribe via "Add calendar &rarr; From internet"</li>
+                </ul>
+                <p class="text-muted small">Your subscription URL is private. Don't share it with others.</p>
+            </section>
+
+            {# 5. Documents #}
+            <section id="documents" class="mb-5">
+                <h3>Documents</h3>
+                <p>Skippers and admins can attach documents to events — typically <strong>Notice of Race (NOR)</strong>, <strong>Sailing Instructions (SI)</strong>, and other race documents.</p>
+                <ul>
+                    <li>View attached documents from the event detail page</li>
+                    <li>Documents open in a new tab for easy reading</li>
+                    <li>Supported formats include PDF and common document types</li>
+                </ul>
+            </section>
+
+            {# 6. Profile & Notifications #}
+            <section id="profile-notifications" class="mb-5">
+                <h3>Profile &amp; Notifications</h3>
+                <p>Manage your account from <strong>Profile Settings</strong> (avatar dropdown &rarr; Profile Settings):</p>
+                <ul>
+                    <li><strong>Display name &amp; initials</strong> — How you appear to your crew</li>
+                    <li><strong>Email</strong> — Used for login and notifications</li>
+                    <li><strong>Password</strong> — Change your password at any time</li>
+                    <li><strong>Profile picture</strong> — Upload a photo or keep the auto-generated avatar</li>
+                    <li><strong>Email preferences</strong> — Choose to receive email notifications or opt out entirely. You can also choose between <strong>immediate</strong> delivery or a <strong>digest</strong> summary</li>
+                </ul>
+            </section>
+
+            {# 7. For Skippers: Crew & Events #}
+            <section id="skippers" class="mb-5">
+                <h3>For Skippers: Crew &amp; Events</h3>
+                <p>As a skipper, you have additional tools to manage your crew and race schedule.</p>
+
+                <h5 class="mt-3">Inviting Crew</h5>
+                <ul>
+                    <li>Go to <strong>My Crew</strong> to see your current crew roster</li>
+                    <li>Share the <strong>registration link</strong> or send <strong>email invitations</strong> directly</li>
+                    <li>New members are automatically linked to your crew when they register</li>
+                </ul>
+
+                <h5 class="mt-3">Managing Events</h5>
+                <ul>
+                    <li><strong>Add</strong> events manually with date, location, and details</li>
+                    <li><strong>Edit</strong> or <strong>delete</strong> events from the event detail page</li>
+                    <li><strong>Import schedules</strong> — paste a URL, upload a file, or paste text from a regatta schedule. The AI-powered importer will extract event details automatically</li>
+                </ul>
+
+                <h5 class="mt-3">Notifying Crew</h5>
+                <ul>
+                    <li>After adding or updating events, use <strong>Notify Crew</strong> to send email updates to your team</li>
+                    <li>Notifications respect each crew member's email preferences</li>
+                </ul>
+            </section>
+
+            {# 8. For Developers #}
+            <section id="developers" class="mb-5">
+                <h3>For Developers</h3>
+                <p>Race Crew Network is open source and built with Flask, SQLAlchemy, and Bootstrap. If you're interested in contributing or learning how it's built:</p>
+                <ul>
+                    <li>Check out the <a href="https://github.com/chris-edwards-pub/race-crew-network/tree/master/training" target="_blank" rel="noopener">training directory</a> — an 18-day Flask curriculum that walks through building a web app from scratch</li>
+                    <li>The full source code is available on <a href="https://github.com/chris-edwards-pub/race-crew-network" target="_blank" rel="noopener">GitHub</a></li>
+                </ul>
+            </section>
+
+            {# 9. Contact Support #}
+            <section id="contact" class="mb-5">
+                <h3>Contact Support</h3>
+                <p>Have a question, found a bug, or need help? Send us a message and we'll get back to you.</p>
+
+                {% if contact_status == "sent" %}
+                <div class="alert alert-success alert-dismissible fade show" role="alert">
+                    Your message has been sent. We'll get back to you soon!
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                </div>
+                {% elif contact_status == "missing" %}
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    Please fill in all required fields.
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                </div>
+                {% elif contact_status == "error" %}
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    Sorry, we couldn't send your message right now. Please try again later.
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                </div>
+                {% endif %}
+
+                <div class="card">
+                    <div class="card-body">
+                        <form method="POST" action="{{ url_for('help.contact') }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <input type="hidden" name="form_timestamp" value="{{ form_timestamp }}">
+
+                            {# Honeypot field — hidden from humans, bots auto-fill it #}
+                            <div style="display:none;" aria-hidden="true">
+                                <label for="website">Website</label>
+                                <input type="text" name="website" id="website" tabindex="-1" autocomplete="off">
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="contact-name" class="form-label">Name <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control" id="contact-name" name="name" required>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="contact-email" class="form-label">Email <span class="text-danger">*</span></label>
+                                <input type="email" class="form-control" id="contact-email" name="email" required>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="contact-message" class="form-label">Message <span class="text-danger">*</span></label>
+                                <textarea class="form-control" id="contact-message" name="message" rows="5" required></textarea>
+                            </div>
+
+                            <button type="submit" class="btn btn-primary">Send Message</button>
+                        </form>
+                    </div>
+                </div>
+            </section>
+
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -6,8 +6,8 @@ import anthropic
 import pytest
 
 from app.admin.ai_service import (EXTRACTION_PROMPT, _parse_json_response,
-                                  discover_documents,
-                                  discover_documents_deep, extract_regattas)
+                                  discover_documents, discover_documents_deep,
+                                  extract_regattas)
 
 # --- _parse_json_response ---
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,160 @@
+"""Tests for the help page and contact form."""
+
+import time
+from unittest.mock import patch
+
+from app.models import SiteSetting
+
+
+class TestHelpPage:
+    def test_help_page_accessible_anonymous(self, client):
+        resp = client.get("/help")
+        assert resp.status_code == 200
+        assert b"Help" in resp.data
+
+    def test_help_page_accessible_logged_in(self, logged_in_client):
+        resp = logged_in_client.get("/help")
+        assert resp.status_code == 200
+        assert b"Help" in resp.data
+
+    def test_help_page_contains_sections(self, client):
+        resp = client.get("/help")
+        html = resp.data.decode()
+        assert "Getting Started" in html
+        assert "How to Request Access" in html
+        assert "Viewing the Schedule" in html
+        assert "Calendar Subscription" in html
+        assert "Documents" in html
+        assert "Profile &amp; Notifications" in html
+        assert "For Skippers" in html
+        assert "For Developers" in html
+        assert "Contact Support" in html
+
+    def test_navbar_help_link_anonymous(self, client):
+        resp = client.get("/help")
+        html = resp.data.decode()
+        assert 'href="/help"' in html
+
+    def test_navbar_help_link_logged_in(self, logged_in_client):
+        resp = logged_in_client.get("/help")
+        html = resp.data.decode()
+        assert 'href="/help"' in html
+
+
+class TestContactForm:
+    @patch("app.admin.email_service._send_via_ses")
+    def test_contact_form_sends_email(self, mock_ses, client, db):
+        # Configure SES sender
+        db.session.add(SiteSetting(key="ses_sender", value="noreply@example.com"))
+        db.session.add(SiteSetting(key="ses_sender_to", value="admin@example.com"))
+        db.session.commit()
+
+        ts = str(int(time.time()) - 5)  # 5 seconds ago
+        resp = client.post(
+            "/help/contact",
+            data={
+                "name": "Test User",
+                "email": "test@example.com",
+                "message": "Hello, need help!",
+                "form_timestamp": ts,
+            },
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert b"Your message has been sent" in resp.data
+        mock_ses.assert_called_once()
+        call_args = mock_ses.call_args
+        assert call_args[0][0] == "admin@example.com"
+        assert "[Contact Form]" in call_args[0][1]
+        assert "Test User" in call_args[0][1]
+        assert call_args[1]["reply_to"] == "test@example.com"
+
+    @patch("app.admin.email_service._send_via_ses")
+    def test_contact_form_honeypot_rejects(self, mock_ses, client):
+        ts = str(int(time.time()) - 5)
+        resp = client.post(
+            "/help/contact",
+            data={
+                "name": "Bot",
+                "email": "bot@spam.com",
+                "message": "Buy stuff",
+                "form_timestamp": ts,
+                "website": "http://spam.com",  # honeypot filled
+            },
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        mock_ses.assert_not_called()
+
+    @patch("app.admin.email_service._send_via_ses")
+    def test_contact_form_timestamp_rejects(self, mock_ses, client):
+        ts = str(int(time.time()))  # submitted "right now" = too fast
+        resp = client.post(
+            "/help/contact",
+            data={
+                "name": "Bot",
+                "email": "bot@spam.com",
+                "message": "Spam",
+                "form_timestamp": ts,
+            },
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        mock_ses.assert_not_called()
+
+    def test_contact_form_missing_fields(self, client):
+        ts = str(int(time.time()) - 5)
+        resp = client.post(
+            "/help/contact",
+            data={
+                "name": "",
+                "email": "test@example.com",
+                "message": "Hello",
+                "form_timestamp": ts,
+            },
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert b"Please fill in all required fields" in resp.data
+
+    def test_contact_form_no_email_configured(self, client):
+        # No SiteSetting records → no sender configured → ValueError caught
+        ts = str(int(time.time()) - 5)
+        resp = client.post(
+            "/help/contact",
+            data={
+                "name": "Test",
+                "email": "test@example.com",
+                "message": "Help!",
+                "form_timestamp": ts,
+            },
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert b"try again later" in resp.data
+
+    @patch("app.admin.email_service._send_via_ses")
+    def test_contact_form_falls_back_to_ses_sender(self, mock_ses, client, db):
+        # Only ses_sender configured, no ses_sender_to
+        db.session.add(SiteSetting(key="ses_sender", value="fallback@example.com"))
+        db.session.commit()
+
+        ts = str(int(time.time()) - 5)
+        client.post(
+            "/help/contact",
+            data={
+                "name": "Test",
+                "email": "test@example.com",
+                "message": "Hello",
+                "form_timestamp": ts,
+            },
+            follow_redirects=True,
+        )
+
+        mock_ses.assert_called_once()
+        assert mock_ses.call_args[0][0] == "fallback@example.com"

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -65,7 +65,8 @@ class TestEmailRateLimit:
         _set_rate_limit(db, 50)
 
         with app.app_context():
-            from app.notifications.rate_limits import is_within_email_rate_limit
+            from app.notifications.rate_limits import \
+                is_within_email_rate_limit
 
             assert is_within_email_rate_limit() is True
 
@@ -77,9 +78,7 @@ class TestEmailRateLimit:
 
         with app.app_context():
             from app.notifications.rate_limits import (
-                is_within_email_rate_limit,
-                queue_email,
-            )
+                is_within_email_rate_limit, queue_email)
 
             assert is_within_email_rate_limit() is False
 
@@ -128,9 +127,7 @@ class TestEmailRateLimit:
 
         with app.app_context():
             from app.notifications.rate_limits import (
-                is_within_email_rate_limit,
-                send_rate_limit_alert,
-            )
+                is_within_email_rate_limit, send_rate_limit_alert)
 
             assert is_within_email_rate_limit() is False
             send_rate_limit_alert()
@@ -189,7 +186,8 @@ class TestEmailQueue:
         _create_admin(db)
 
         with app.app_context():
-            from app.notifications.rate_limits import process_email_queue, queue_email
+            from app.notifications.rate_limits import (process_email_queue,
+                                                       queue_email)
 
             queue_email("a@test.com", "Sub A", "Body A")
             queue_email("b@test.com", "Sub B", "Body B")
@@ -209,7 +207,8 @@ class TestEmailQueue:
         _create_notification_logs(db, admin.id, 1)
 
         with app.app_context():
-            from app.notifications.rate_limits import process_email_queue, queue_email
+            from app.notifications.rate_limits import (process_email_queue,
+                                                       queue_email)
 
             queue_email("a@test.com", "Sub A", "Body A")
             queue_email("b@test.com", "Sub B", "Body B")
@@ -227,7 +226,8 @@ class TestEmailQueue:
         mock_send.side_effect = Exception("SES error")
 
         with app.app_context():
-            from app.notifications.rate_limits import process_email_queue, queue_email
+            from app.notifications.rate_limits import (process_email_queue,
+                                                       queue_email)
 
             queue_email("fail@test.com", "Sub", "Body")
             result = process_email_queue()


### PR DESCRIPTION
## Summary
- Add public Help & Documentation page with 9 sections covering all user roles (Getting Started, Request Access, Schedule & RSVPs, Calendar, Documents, Profile & Notifications, Skippers, Developers, Contact Support)
- Add contact form with 3-layer spam protection (honeypot, timestamp check, CSRF) that emails the site admin via SES with Reply-To support
- Help link visible in navbar for all users including anonymous visitors
- Inline contact form feedback (success/error alerts near the form, not at page top)
- 11 new tests covering page access, sections, navbar links, email sending, spam rejection, missing fields, and fallback behavior

## Test plan
- [x] `black . && isort . && flake8` — clean
- [x] `pytest` — all 486 tests pass
- [ ] Visit `/help` while logged out — page loads, Help link in navbar
- [ ] Visit `/help` while logged in — page loads, Help link alongside other nav items
- [ ] Click TOC links — scroll to correct sections
- [ ] Test on mobile width — responsive layout, TOC collapses
- [ ] Submit contact form — success alert shown inline near form
- [ ] Submit with honeypot filled — no email sent, fake success shown
- [ ] Submit instantly (< 3s) — no email sent, fake success shown

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)