### PR TITLE
Fix Email Statistics 500 error (v0.67.1)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.67.1
+- Fix Email Statistics 500 error when Cost Explorer client creation fails (unbound `client` variable in except handler)
+- Fix Cost Explorer query failing on the 1st of the month when Start and End dates are equal
+
 ## 0.67.0
 - Add public Help & Documentation page with usage guides for all user roles
 - Add contact form with honeypot and timestamp spam protection

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.67.0"
+__version__ = "0.67.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/email_stats.py
+++ b/app/admin/email_stats.py
@@ -85,12 +85,18 @@ def get_ses_cost(months: int = 1) -> dict | None:
     """
     try:
         client = _get_ce_client()
+    except Exception:
+        logger.exception("Failed to create Cost Explorer client")
+        return None
+
+    try:
         today = date.today()
-        current_start = today.replace(day=1).isoformat()
-        current_end = today.isoformat()
+        current_start = today.replace(day=1)
+        # Cost Explorer requires Start < End; on the 1st, use tomorrow
+        current_end = today if today > current_start else today + timedelta(days=1)
 
         # Last month
-        last_month_end = today.replace(day=1)
+        last_month_end = current_start
         if last_month_end.month == 1:
             last_month_start = last_month_end.replace(
                 year=last_month_end.year - 1, month=12
@@ -102,7 +108,10 @@ def get_ses_cost(months: int = 1) -> dict | None:
 
         # Current month
         resp = client.get_cost_and_usage(
-            TimePeriod={"Start": current_start, "End": current_end},
+            TimePeriod={
+                "Start": current_start.isoformat(),
+                "End": current_end.isoformat(),
+            },
             Granularity="MONTHLY",
             Metrics=["UnblendedCost"],
             Filter={


### PR DESCRIPTION
## Summary
- Fix `UnboundLocalError` crash when Cost Explorer client creation fails — `client` was referenced in an `except` handler before being assigned
- Fix invalid Cost Explorer query on the 1st of the month when Start and End dates are equal

## Test plan
- [x] `pytest` — all 486 tests pass
- [ ] Visit Email Statistics page on production — no more 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)