### PR TITLE
Fix month divider hover and AI city/state inference (v0.67.2)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.67.2
+- Fix month divider rows highlighting grey on hover in schedule table
+- Update AI extraction prompt to infer city/state from venue name when not explicitly stated (#115)
+
 ## 0.67.1
 - Fix Email Statistics 500 error when Cost Explorer client creation fails (unbound `client` variable in except handler)
 - Fix Cost Explorer query failing on the 1st of the month when Start and End dates are equal

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.67.1"
+__version__ = "0.67.2"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/ai_service.py
+++ b/app/admin/ai_service.py
@@ -33,6 +33,10 @@ to the 16th.
 - If the text contains a link to an individual regatta's event page or \
 information page, include it as detail_url. This is NOT the venue/location URL.
 - Return ONLY the JSON array, no markdown fences, no explanation.
+- If city_state is not explicitly mentioned in the text but you can infer it \
+from the location name (e.g. you know "Muscle Shoals Sailing Club" is in \
+Muscle Shoals, AL), provide your best inference. Most yacht clubs and sailing \
+clubs are well-known venues with known cities.
 - If no events are found, return an empty array: []
 
 Text to extract from:

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -94,6 +94,11 @@
     border-bottom: 0 !important;
 }
 
+.table-hover .month-divider-row:hover > td {
+    --bs-table-hover-bg: transparent;
+    background-color: transparent !important;
+}
+
 .month-divider-row + tr td {
     border-top: 0 !important;
 }


### PR DESCRIPTION
## Summary
- Disable grey hover highlight on month divider rows in schedule table
- Update AI extraction prompt to infer city/state from venue name when not explicitly stated in source text

Closes #115

## Test plan
- [ ] Verify month divider rows no longer highlight grey on hover
- [ ] Verify event rows still highlight on hover
- [ ] Import a schedule where location is known but city/state is not explicitly mentioned — confirm AI infers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)