### PR TITLE
Add AI Statistics admin page (v0.68.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A simple web app for organizing sailing events. Track dates, locations, NOR/SI d
 - Admin: manage all users, site settings, invite skippers
 - Skipper: add/edit/delete own events, upload documents, invite crew, import schedules
 - Crew: view skipper's schedule, download docs, set RSVP
+- AI usage tracking with cost statistics dashboard, monthly budget cap, and automatic 80% budget alert
 - Email rate limiting with queueing, admin alerts, and statistics dashboard
 - Invite-based registration (no public sign-up)
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 0.68.0
+- Add AI Statistics admin page with usage tracking, cost breakdown, and per-function stats
+- Log all Anthropic API calls (tokens, cost) to new `ai_usage_log` table
+- Configurable monthly AI budget cap with progress bar (default $20)
+- Automatic email alert when AI spending reaches 80% of monthly budget
+
 ## 0.67.2
 - Fix month divider rows highlighting grey on hover in schedule table
 - Update AI extraction prompt to infer city/state from venue name when not explicitly stated (#115)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.67.2"
+__version__ = "0.68.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/ai_service.py
+++ b/app/admin/ai_service.py
@@ -1,10 +1,96 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 import anthropic
 from flask import current_app
 
+from app import db
+
 logger = logging.getLogger(__name__)
+
+# Claude Sonnet 4 pricing (per token)
+INPUT_PRICE_PER_TOKEN = 3.00 / 1_000_000
+OUTPUT_PRICE_PER_TOKEN = 15.00 / 1_000_000
+
+
+def _log_ai_usage(function_name: str, model: str, message) -> None:
+    """Log AI API usage to the database. Failures are swallowed to never break AI ops."""
+    try:
+        from app.models import AIUsageLog
+
+        input_tokens = message.usage.input_tokens
+        output_tokens = message.usage.output_tokens
+        cost = (input_tokens * INPUT_PRICE_PER_TOKEN) + (
+            output_tokens * OUTPUT_PRICE_PER_TOKEN
+        )
+
+        entry = AIUsageLog(
+            function_name=function_name,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost,
+        )
+        db.session.add(entry)
+        db.session.commit()
+
+        _check_and_send_cost_alert()
+    except Exception:
+        db.session.rollback()
+        logger.exception("Failed to log AI usage for %s", function_name)
+
+
+def _check_and_send_cost_alert() -> None:
+    """Send an email alert if monthly AI cost reaches 80% of budget."""
+    try:
+        from app.admin.ai_stats import (check_cost_threshold,
+                                        get_monthly_cost_limit)
+        from app.admin.email_service import _send_via_ses, load_email_settings
+        from app.models import SiteSetting
+
+        if not check_cost_threshold():
+            return
+
+        # Get current month cost for the alert body
+        from app.admin.ai_stats import get_ai_usage_stats
+
+        stats = get_ai_usage_stats()
+        limit = get_monthly_cost_limit()
+
+        settings = load_email_settings()
+        admin_email = settings.get("ses_sender", "")
+        if not admin_email:
+            logger.warning("No SES sender configured; cannot send AI cost alert")
+            return
+
+        subject = "AI Cost Alert — 80% of Monthly Budget Reached"
+        body_text = (
+            f"AI spending has reached ${stats['month_cost']:.2f} "
+            f"of your ${limit:.2f} monthly budget "
+            f"({stats['budget_pct']:.0f}%).\n\n"
+            f"API calls this month: {stats['month_calls']}\n"
+            f"Review usage at your AI Statistics admin page."
+        )
+
+        _send_via_ses(to=admin_email, subject=subject, body_text=body_text)
+
+        # Mark alert as sent for this month
+        now = datetime.now(timezone.utc)
+        month_key = now.strftime("%Y-%m")
+        setting = SiteSetting.query.filter_by(key="ai_cost_alert_sent_month").first()
+        if setting:
+            setting.value = month_key
+        else:
+            setting = SiteSetting(key="ai_cost_alert_sent_month", value=month_key)
+            db.session.add(setting)
+        db.session.commit()
+
+        logger.info("AI cost alert sent for %s", month_key)
+    except Exception:
+        db.session.rollback()
+        logger.exception("Failed to send AI cost alert")
+
 
 EXTRACTION_PROMPT = """\
 You are a data extraction assistant. Extract regatta/sailing event information \
@@ -132,6 +218,8 @@ def extract_regattas(content: str, year: int) -> list[dict]:
     except anthropic.APIStatusError as e:
         raise ConnectionError(f"Claude API error: {e.message}")
 
+    _log_ai_usage("extract_regattas", "claude-sonnet-4-20250514", message)
+
     raw = message.content[0].text.strip()
 
     # Strip markdown code fences if present
@@ -207,6 +295,8 @@ def discover_documents(content: str, regatta_name: str, source_url: str) -> list
     except anthropic.APIStatusError as e:
         raise ConnectionError(f"Claude API error: {e.message}")
 
+    _log_ai_usage("discover_documents", "claude-sonnet-4-20250514", message)
+
     raw = message.content[0].text.strip()
     return _parse_json_response(raw)
 
@@ -242,6 +332,8 @@ def discover_documents_deep(
         raise ConnectionError("Claude API rate limit exceeded. Try again shortly.")
     except anthropic.APIStatusError as e:
         raise ConnectionError(f"Claude API error: {e.message}")
+
+    _log_ai_usage("discover_documents_deep", "claude-sonnet-4-20250514", message)
 
     raw = message.content[0].text.strip()
     return _parse_json_response(raw)

--- a/app/admin/ai_stats.py
+++ b/app/admin/ai_stats.py
@@ -1,0 +1,137 @@
+"""AI usage statistics helpers — cost tracking, budget monitoring, and alerts."""
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import func
+
+from app import db
+from app.models import AIUsageLog, SiteSetting
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MONTHLY_COST_LIMIT = 20.00
+
+
+def get_monthly_cost_limit() -> float:
+    """Read the monthly AI cost limit from SiteSetting (default $20)."""
+    setting = SiteSetting.query.filter_by(key="ai_monthly_cost_limit").first()
+    if setting and setting.value:
+        try:
+            return float(setting.value)
+        except (ValueError, TypeError):
+            pass
+    return DEFAULT_MONTHLY_COST_LIMIT
+
+
+def get_ai_usage_stats() -> dict:
+    """Query AIUsageLog for usage statistics."""
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    month_start = today_start.replace(day=1)
+
+    # Last month range
+    if month_start.month == 1:
+        last_month_start = month_start.replace(year=month_start.year - 1, month=12)
+    else:
+        last_month_start = month_start.replace(month=month_start.month - 1)
+    last_month_end = month_start
+
+    # Cost aggregations
+    today_cost = (
+        db.session.query(func.coalesce(func.sum(AIUsageLog.cost_usd), 0.0))
+        .filter(AIUsageLog.created_at >= today_start)
+        .scalar()
+    )
+    month_cost = (
+        db.session.query(func.coalesce(func.sum(AIUsageLog.cost_usd), 0.0))
+        .filter(AIUsageLog.created_at >= month_start)
+        .scalar()
+    )
+    last_month_cost = (
+        db.session.query(func.coalesce(func.sum(AIUsageLog.cost_usd), 0.0))
+        .filter(
+            AIUsageLog.created_at >= last_month_start,
+            AIUsageLog.created_at < last_month_end,
+        )
+        .scalar()
+    )
+    all_time_cost = db.session.query(
+        func.coalesce(func.sum(AIUsageLog.cost_usd), 0.0)
+    ).scalar()
+
+    # Call counts
+    today_calls = AIUsageLog.query.filter(AIUsageLog.created_at >= today_start).count()
+    month_calls = AIUsageLog.query.filter(AIUsageLog.created_at >= month_start).count()
+    all_time_calls = AIUsageLog.query.count()
+
+    # Token counts (this month)
+    month_input_tokens = (
+        db.session.query(func.coalesce(func.sum(AIUsageLog.input_tokens), 0))
+        .filter(AIUsageLog.created_at >= month_start)
+        .scalar()
+    )
+    month_output_tokens = (
+        db.session.query(func.coalesce(func.sum(AIUsageLog.output_tokens), 0))
+        .filter(AIUsageLog.created_at >= month_start)
+        .scalar()
+    )
+
+    # Per-function breakdown (this month)
+    function_breakdown = (
+        db.session.query(
+            AIUsageLog.function_name,
+            func.count(AIUsageLog.id),
+            func.coalesce(func.sum(AIUsageLog.cost_usd), 0.0),
+        )
+        .filter(AIUsageLog.created_at >= month_start)
+        .group_by(AIUsageLog.function_name)
+        .all()
+    )
+    by_function = [
+        {"name": name, "calls": calls, "cost": cost}
+        for name, calls, cost in function_breakdown
+    ]
+
+    # Budget percentage
+    limit = get_monthly_cost_limit()
+    budget_pct = (month_cost / limit * 100) if limit > 0 else 0.0
+
+    return {
+        "today_cost": float(today_cost),
+        "month_cost": float(month_cost),
+        "last_month_cost": float(last_month_cost),
+        "all_time_cost": float(all_time_cost),
+        "today_calls": today_calls,
+        "month_calls": month_calls,
+        "all_time_calls": all_time_calls,
+        "month_input_tokens": int(month_input_tokens),
+        "month_output_tokens": int(month_output_tokens),
+        "by_function": by_function,
+        "budget_limit": limit,
+        "budget_pct": budget_pct,
+    }
+
+
+def check_cost_threshold() -> bool:
+    """Return True if monthly cost >= 80% of limit AND alert not yet sent this month."""
+    now = datetime.now(timezone.utc)
+    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    month_cost = (
+        db.session.query(func.coalesce(func.sum(AIUsageLog.cost_usd), 0.0))
+        .filter(AIUsageLog.created_at >= month_start)
+        .scalar()
+    )
+
+    limit = get_monthly_cost_limit()
+    if limit <= 0 or float(month_cost) < limit * 0.8:
+        return False
+
+    # Check if alert already sent this month
+    current_month = now.strftime("%Y-%m")
+    setting = SiteSetting.query.filter_by(key="ai_cost_alert_sent_month").first()
+    if setting and setting.value == current_month:
+        return False
+
+    return True

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -19,6 +19,7 @@ from app import csrf, db
 from app.admin import bp
 from app.admin.ai_service import (discover_documents, discover_documents_deep,
                                   extract_regattas)
+from app.admin.ai_stats import get_ai_usage_stats
 from app.admin.email_service import (is_email_configured, load_email_settings,
                                      send_email)
 from app.admin.email_stats import (get_app_email_stats, get_ses_cost,
@@ -666,6 +667,37 @@ def email_stats():
         app_stats=app_stats,
         delivery_health=delivery_health,
     )
+
+
+@bp.route("/admin/ai-stats", methods=["GET", "POST"])
+@login_required
+def ai_stats():
+    denied = _require_admin()
+    if denied:
+        return denied
+
+    if request.method == "POST":
+        new_limit = request.form.get("cost_limit", "").strip()
+        try:
+            limit_val = float(new_limit)
+            if limit_val < 0:
+                raise ValueError
+        except (ValueError, TypeError):
+            flash("Invalid cost limit value.", "error")
+            return redirect(url_for("admin.ai_stats"))
+
+        setting = SiteSetting.query.filter_by(key="ai_monthly_cost_limit").first()
+        if setting:
+            setting.value = str(limit_val)
+        else:
+            setting = SiteSetting(key="ai_monthly_cost_limit", value=str(limit_val))
+            db.session.add(setting)
+        db.session.commit()
+        flash(f"Monthly AI budget updated to ${limit_val:.2f}.", "success")
+        return redirect(url_for("admin.ai_stats"))
+
+    stats = get_ai_usage_stats()
+    return render_template("admin/ai_stats.html", stats=stats)
 
 
 @bp.route("/admin/import-schedule/extract", methods=["POST"])

--- a/app/models.py
+++ b/app/models.py
@@ -280,6 +280,22 @@ class EmailQueue(db.Model):
     error_message = db.Column(db.Text, nullable=True)
 
 
+class AIUsageLog(db.Model):
+    __tablename__ = "ai_usage_log"
+
+    id = db.Column(db.Integer, primary_key=True)
+    function_name = db.Column(db.String(50), nullable=False)
+    model = db.Column(db.String(100), nullable=False)
+    input_tokens = db.Column(db.Integer, nullable=False)
+    output_tokens = db.Column(db.Integer, nullable=False)
+    cost_usd = db.Column(db.Float, nullable=False)
+    created_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+
 class SiteSetting(db.Model):
     __tablename__ = "site_settings"
 

--- a/app/templates/admin/ai_stats.html
+++ b/app/templates/admin/ai_stats.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+{% block title %}AI Statistics — Race Crew Network{% endblock %}
+{% block content %}
+<div class="container mt-3">
+    <h2 class="mb-3">AI Statistics</h2>
+
+    <div class="row g-3">
+        <!-- Monthly Budget -->
+        <div class="col-md-6 col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Monthly Budget</h5>
+                    {% set pct = stats.budget_pct | round %}
+                    {% if pct >= 90 %}
+                        {% set bar_color = "bg-danger" %}
+                    {% elif pct >= 70 %}
+                        {% set bar_color = "bg-warning" %}
+                    {% else %}
+                        {% set bar_color = "bg-success" %}
+                    {% endif %}
+                    <p class="mb-1"><strong>${{ "%.2f" | format(stats.month_cost) }}</strong> / ${{ "%.2f" | format(stats.budget_limit) }}</p>
+                    <div class="progress mb-2" style="height: 20px;">
+                        <div class="progress-bar {{ bar_color }}" role="progressbar" style="width: {{ [pct, 100] | min }}%;" aria-valuenow="{{ pct }}" aria-valuemin="0" aria-valuemax="100">{{ pct | int }}%</div>
+                    </div>
+                    <form method="POST" class="d-flex align-items-center gap-2 mt-2">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <label for="cost_limit" class="form-label mb-0 text-nowrap">Limit $</label>
+                        <input type="number" step="0.01" min="0" name="cost_limit" id="cost_limit" class="form-control form-control-sm" style="max-width: 100px;" value="{{ "%.2f" | format(stats.budget_limit) }}">
+                        <button type="submit" class="btn btn-primary btn-sm">Update</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Cost Summary -->
+        <div class="col-md-6 col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Cost Summary</h5>
+                    <ul class="list-unstyled mb-0">
+                        <li><strong>Today:</strong> ${{ "%.4f" | format(stats.today_cost) }}</li>
+                        <li><strong>This month:</strong> ${{ "%.4f" | format(stats.month_cost) }}</li>
+                        <li><strong>Last month:</strong> ${{ "%.4f" | format(stats.last_month_cost) }}</li>
+                        <li><strong>All time:</strong> ${{ "%.4f" | format(stats.all_time_cost) }}</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <!-- API Calls -->
+        <div class="col-md-6 col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">API Calls</h5>
+                    <ul class="list-unstyled mb-0">
+                        <li><strong>Today:</strong> {{ stats.today_calls }}</li>
+                        <li><strong>This month:</strong> {{ stats.month_calls }}</li>
+                        <li><strong>All time:</strong> {{ stats.all_time_calls }}</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <!-- Token Usage -->
+        <div class="col-md-6 col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Token Usage (This Month)</h5>
+                    <ul class="list-unstyled mb-0">
+                        <li><strong>Input tokens:</strong> {{ "{:,}".format(stats.month_input_tokens) }}</li>
+                        <li><strong>Output tokens:</strong> {{ "{:,}".format(stats.month_output_tokens) }}</li>
+                        <li><strong>Total tokens:</strong> {{ "{:,}".format(stats.month_input_tokens + stats.month_output_tokens) }}</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <!-- Usage by Function -->
+        <div class="col-md-6 col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Usage by Function (This Month)</h5>
+                    {% if stats.by_function %}
+                    <ul class="list-unstyled mb-0">
+                        {% for fn in stats.by_function %}
+                        <li><strong>{{ fn.name }}:</strong> {{ fn.calls }} calls — ${{ "%.4f" | format(fn.cost) }}</li>
+                        {% endfor %}
+                    </ul>
+                    {% else %}
+                    <p class="text-muted mb-0">No API calls this month.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <!-- Pricing Info -->
+        <div class="col-md-6 col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Pricing Info</h5>
+                    <ul class="list-unstyled mb-0">
+                        <li><strong>Model:</strong> Claude Sonnet 4</li>
+                        <li><strong>Input:</strong> $3.00 / 1M tokens</li>
+                        <li><strong>Output:</strong> $15.00 / 1M tokens</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,6 +48,7 @@
                             <li><a class="dropdown-item" href="{{ url_for('admin.analytics_settings') }}">Analytics Settings</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('admin.email_settings') }}">Email Settings</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('admin.email_stats') }}">Email Statistics</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('admin.ai_stats') }}">AI Statistics</a></li>
                         </ul>
                     </li>
                     {% endif %}

--- a/migrations/versions/l2b3c4d5e6f7_add_ai_usage_log.py
+++ b/migrations/versions/l2b3c4d5e6f7_add_ai_usage_log.py
@@ -1,0 +1,31 @@
+"""Add ai_usage_log table
+
+Revision ID: l2b3c4d5e6f7
+Revises: k1a2b3c4d5e6
+Create Date: 2026-03-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "l2b3c4d5e6f7"
+down_revision = "k1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "ai_usage_log",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("function_name", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=False),
+        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column("cost_usd", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table("ai_usage_log")

--- a/tests/test_ai_stats.py
+++ b/tests/test_ai_stats.py
@@ -1,0 +1,421 @@
+"""Tests for AI usage logging, statistics, cost alerts, and the admin route."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.admin.ai_service import (INPUT_PRICE_PER_TOKEN,
+                                  OUTPUT_PRICE_PER_TOKEN,
+                                  _check_and_send_cost_alert, _log_ai_usage)
+from app.admin.ai_stats import (check_cost_threshold, get_ai_usage_stats,
+                                get_monthly_cost_limit)
+from app.models import AIUsageLog, SiteSetting
+
+# --- AIUsageLog Model ---
+
+
+class TestAIUsageLogModel:
+    def test_create_entry(self, app, db):
+        with app.app_context():
+            entry = AIUsageLog(
+                function_name="extract_regattas",
+                model="claude-sonnet-4-20250514",
+                input_tokens=1000,
+                output_tokens=500,
+                cost_usd=0.0105,
+            )
+            db.session.add(entry)
+            db.session.commit()
+
+            saved = AIUsageLog.query.first()
+            assert saved.function_name == "extract_regattas"
+            assert saved.model == "claude-sonnet-4-20250514"
+            assert saved.input_tokens == 1000
+            assert saved.output_tokens == 500
+            assert saved.cost_usd == pytest.approx(0.0105)
+            assert saved.created_at is not None
+
+
+# --- _log_ai_usage ---
+
+
+class TestLogAIUsage:
+    def test_logs_usage_correctly(self, app, db):
+        with app.app_context():
+            mock_msg = MagicMock()
+            mock_msg.usage.input_tokens = 2000
+            mock_msg.usage.output_tokens = 1000
+
+            _log_ai_usage("extract_regattas", "claude-sonnet-4-20250514", mock_msg)
+
+            entry = AIUsageLog.query.first()
+            assert entry is not None
+            assert entry.function_name == "extract_regattas"
+            assert entry.input_tokens == 2000
+            assert entry.output_tokens == 1000
+            expected_cost = (2000 * INPUT_PRICE_PER_TOKEN) + (
+                1000 * OUTPUT_PRICE_PER_TOKEN
+            )
+            assert entry.cost_usd == pytest.approx(expected_cost)
+
+    def test_db_error_does_not_propagate(self, app, db):
+        """Logging failures must never break AI operations."""
+        with app.app_context():
+            mock_msg = MagicMock()
+            mock_msg.usage.input_tokens = 100
+            mock_msg.usage.output_tokens = 50
+
+            with patch(
+                "app.admin.ai_service.db.session.commit",
+                side_effect=Exception("DB down"),
+            ):
+                # Should not raise
+                _log_ai_usage("extract_regattas", "test-model", mock_msg)
+
+            # No entry saved due to error
+            assert AIUsageLog.query.count() == 0
+
+
+# --- Integration: AI functions log usage ---
+
+
+class TestAIFunctionLogging:
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_extract_regattas_logs_usage(self, mock_cls, app, db):
+        from app.admin.ai_service import extract_regattas
+
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text='[{"name": "Test"}]')]
+        mock_msg.usage.input_tokens = 500
+        mock_msg.usage.output_tokens = 200
+        mock_client.messages.create.return_value = mock_msg
+
+        with app.app_context():
+            extract_regattas("content", 2026)
+            entry = AIUsageLog.query.first()
+            assert entry is not None
+            assert entry.function_name == "extract_regattas"
+
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_discover_documents_logs_usage(self, mock_cls, app, db):
+        from app.admin.ai_service import discover_documents
+
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="[]")]
+        mock_msg.usage.input_tokens = 300
+        mock_msg.usage.output_tokens = 100
+        mock_client.messages.create.return_value = mock_msg
+
+        with app.app_context():
+            discover_documents("content", "Test", "http://example.com")
+            entry = AIUsageLog.query.first()
+            assert entry is not None
+            assert entry.function_name == "discover_documents"
+
+    @patch("app.admin.ai_service.anthropic.Anthropic")
+    def test_discover_documents_deep_logs_usage(self, mock_cls, app, db):
+        from app.admin.ai_service import discover_documents_deep
+
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="[]")]
+        mock_msg.usage.input_tokens = 400
+        mock_msg.usage.output_tokens = 150
+        mock_client.messages.create.return_value = mock_msg
+
+        with app.app_context():
+            discover_documents_deep("content", "Test", "http://example.com")
+            entry = AIUsageLog.query.first()
+            assert entry is not None
+            assert entry.function_name == "discover_documents_deep"
+
+
+# --- Stats helpers ---
+
+
+class TestGetMonthlyLimit:
+    def test_default_value(self, app, db):
+        with app.app_context():
+            assert get_monthly_cost_limit() == 20.00
+
+    def test_reads_from_site_setting(self, app, db):
+        with app.app_context():
+            db.session.add(SiteSetting(key="ai_monthly_cost_limit", value="50.00"))
+            db.session.commit()
+            assert get_monthly_cost_limit() == 50.00
+
+    def test_invalid_value_returns_default(self, app, db):
+        with app.app_context():
+            db.session.add(SiteSetting(key="ai_monthly_cost_limit", value="abc"))
+            db.session.commit()
+            assert get_monthly_cost_limit() == 20.00
+
+
+class TestGetAIUsageStats:
+    def test_empty_stats_returns_zeros(self, app, db):
+        with app.app_context():
+            stats = get_ai_usage_stats()
+            assert stats["today_cost"] == 0.0
+            assert stats["month_cost"] == 0.0
+            assert stats["all_time_cost"] == 0.0
+            assert stats["today_calls"] == 0
+            assert stats["month_calls"] == 0
+            assert stats["all_time_calls"] == 0
+            assert stats["month_input_tokens"] == 0
+            assert stats["month_output_tokens"] == 0
+            assert stats["by_function"] == []
+            assert stats["budget_pct"] == 0.0
+
+    def test_aggregation_with_data(self, app, db):
+        with app.app_context():
+            now = datetime.now(timezone.utc)
+            entry1 = AIUsageLog(
+                function_name="extract_regattas",
+                model="test-model",
+                input_tokens=1000,
+                output_tokens=500,
+                cost_usd=0.01,
+                created_at=now,
+            )
+            entry2 = AIUsageLog(
+                function_name="discover_documents",
+                model="test-model",
+                input_tokens=2000,
+                output_tokens=1000,
+                cost_usd=0.02,
+                created_at=now,
+            )
+            db.session.add_all([entry1, entry2])
+            db.session.commit()
+
+            stats = get_ai_usage_stats()
+            assert stats["today_cost"] == pytest.approx(0.03)
+            assert stats["month_cost"] == pytest.approx(0.03)
+            assert stats["all_time_cost"] == pytest.approx(0.03)
+            assert stats["today_calls"] == 2
+            assert stats["month_calls"] == 2
+            assert stats["all_time_calls"] == 2
+            assert stats["month_input_tokens"] == 3000
+            assert stats["month_output_tokens"] == 1500
+            assert len(stats["by_function"]) == 2
+
+    def test_budget_pct_calculation(self, app, db):
+        with app.app_context():
+            db.session.add(SiteSetting(key="ai_monthly_cost_limit", value="10.00"))
+            db.session.add(
+                AIUsageLog(
+                    function_name="test",
+                    model="m",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=5.00,
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+            db.session.commit()
+
+            stats = get_ai_usage_stats()
+            assert stats["budget_pct"] == pytest.approx(50.0)
+
+
+# --- check_cost_threshold ---
+
+
+class TestCheckCostThreshold:
+    def test_below_threshold_returns_false(self, app, db):
+        with app.app_context():
+            # $1 of $20 limit = 5% — well below 80%
+            db.session.add(
+                AIUsageLog(
+                    function_name="test",
+                    model="m",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=1.00,
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+            db.session.commit()
+            assert check_cost_threshold() is False
+
+    def test_at_threshold_returns_true(self, app, db):
+        with app.app_context():
+            # $16 of $20 limit = 80%
+            db.session.add(
+                AIUsageLog(
+                    function_name="test",
+                    model="m",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=16.00,
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+            db.session.commit()
+            assert check_cost_threshold() is True
+
+    def test_already_alerted_returns_false(self, app, db):
+        with app.app_context():
+            now = datetime.now(timezone.utc)
+            db.session.add(
+                AIUsageLog(
+                    function_name="test",
+                    model="m",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=16.00,
+                    created_at=now,
+                )
+            )
+            db.session.add(
+                SiteSetting(
+                    key="ai_cost_alert_sent_month",
+                    value=now.strftime("%Y-%m"),
+                )
+            )
+            db.session.commit()
+            assert check_cost_threshold() is False
+
+
+# --- Route tests ---
+
+
+class TestAIStatsRoute:
+    def test_unauthenticated_redirects_to_login(self, client):
+        resp = client.get("/admin/ai-stats")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_non_admin_denied(self, app, db, client):
+        from app.models import User
+
+        with app.app_context():
+            user = User(
+                email="crew@test.com",
+                display_name="Crew",
+                initials="CR",
+                is_admin=False,
+                is_skipper=False,
+            )
+            user.set_password("password")
+            db.session.add(user)
+            db.session.commit()
+
+        client.post("/login", data={"email": "crew@test.com", "password": "password"})
+        resp = client.get("/admin/ai-stats", follow_redirects=True)
+        assert b"Access denied" in resp.data
+
+    def test_admin_sees_page(self, logged_in_client):
+        resp = logged_in_client.get("/admin/ai-stats")
+        assert resp.status_code == 200
+        assert b"AI Statistics" in resp.data
+        assert b"Monthly Budget" in resp.data
+
+    def test_post_updates_cost_limit(self, logged_in_client, app, db):
+        resp = logged_in_client.post(
+            "/admin/ai-stats",
+            data={"cost_limit": "35.00"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert b"35.00" in resp.data
+
+        with app.app_context():
+            setting = SiteSetting.query.filter_by(key="ai_monthly_cost_limit").first()
+            assert setting is not None
+            assert setting.value == "35.0"
+
+    def test_post_invalid_limit_shows_error(self, logged_in_client):
+        resp = logged_in_client.post(
+            "/admin/ai-stats",
+            data={"cost_limit": "abc"},
+            follow_redirects=True,
+        )
+        assert b"Invalid cost limit" in resp.data
+
+
+# --- Alert email tests ---
+
+
+class TestCostAlert:
+    @patch("app.admin.email_service._send_via_ses")
+    @patch("app.admin.email_service.load_email_settings")
+    def test_alert_sent_at_threshold(self, mock_settings, mock_send, app, db):
+        mock_settings.return_value = {"ses_sender": "admin@test.com"}
+
+        with app.app_context():
+            # Create usage at 80% of $20 limit
+            db.session.add(
+                AIUsageLog(
+                    function_name="test",
+                    model="m",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=16.00,
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+            db.session.commit()
+
+            _check_and_send_cost_alert()
+
+            mock_send.assert_called_once()
+            call_kwargs = mock_send.call_args
+            assert "80%" in call_kwargs.kwargs.get(
+                "subject", call_kwargs[1].get("subject", "")
+            ) or "80%" in str(call_kwargs)
+
+    @patch("app.admin.email_service._send_via_ses")
+    @patch("app.admin.email_service.load_email_settings")
+    def test_alert_not_sent_twice(self, mock_settings, mock_send, app, db):
+        mock_settings.return_value = {"ses_sender": "admin@test.com"}
+
+        with app.app_context():
+            now = datetime.now(timezone.utc)
+            db.session.add(
+                AIUsageLog(
+                    function_name="test",
+                    model="m",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=16.00,
+                    created_at=now,
+                )
+            )
+            db.session.add(
+                SiteSetting(
+                    key="ai_cost_alert_sent_month",
+                    value=now.strftime("%Y-%m"),
+                )
+            )
+            db.session.commit()
+
+            _check_and_send_cost_alert()
+            mock_send.assert_not_called()
+
+    @patch("app.admin.email_service._send_via_ses")
+    @patch("app.admin.email_service.load_email_settings")
+    def test_alert_below_threshold_not_sent(self, mock_settings, mock_send, app, db):
+        mock_settings.return_value = {"ses_sender": "admin@test.com"}
+
+        with app.app_context():
+            db.session.add(
+                AIUsageLog(
+                    function_name="test",
+                    model="m",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost_usd=1.00,
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+            db.session.commit()
+
+            _check_and_send_cost_alert()
+            mock_send.assert_not_called()


### PR DESCRIPTION
## Summary
- Log all Anthropic API calls (tokens, cost) to new `ai_usage_log` table
- Add AI Statistics admin page with 6-card dashboard: monthly budget progress, cost summary, API call counts, token usage, per-function breakdown, and pricing info
- Configurable monthly budget cap (default $20) with admin form
- Automatic email alert via SES when AI spending reaches 80% of monthly budget
- 23 new tests covering model, logging, stats helpers, threshold logic, route access control, and alert emails

## Test plan
- [x] All 509 tests pass (23 new + 486 existing)
- [ ] Local docker test: verify AI Statistics page renders at `/admin/ai-stats`
- [ ] Run an AI import to verify `ai_usage_log` rows are created
- [ ] Set low budget limit, verify 80% alert triggers

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)