### PR TITLE
Remove Calendar Subscription from profile page (v0.69.1)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.69.1
+- Remove Calendar Subscription section from Profile Settings page
+
 ## 0.69.0
 - Add email-based forgot password / reset password flow with 1-hour token expiry
 - Upgrade password requirements to 8+ characters with uppercase, lowercase, and number

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.69.0"
+__version__ = "0.69.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -70,20 +70,6 @@
                 <div class="form-text">Choose whether to receive notifications immediately or batched into a daily summary.</div>
             </div>
             <hr>
-            <h5 class="mt-3">Calendar Subscription</h5>
-            {% if current_user.calendar_token %}
-            <p class="form-text">Paste this URL into your calendar app (Google Calendar, Apple Calendar, Outlook):</p>
-            <div class="input-group mb-3">
-                <input type="text" class="form-control" id="ical-url" readonly
-                       value="{{ url_for('calendar.ical_feed', token=current_user.calendar_token, _external=True) }}">
-                <button class="btn btn-outline-secondary" type="button" id="copy-ical-url"
-                        onclick="navigator.clipboard.writeText(document.getElementById('ical-url').value); this.textContent='Copied!'; setTimeout(() => this.textContent='Copy', 2000);">Copy</button>
-            </div>
-            {% else %}
-            <p class="form-text">Add your Yes/Maybe events to your phone or computer calendar.</p>
-            <a href="{{ url_for('calendar.subscribe') }}" class="btn btn-outline-primary btn-sm mb-3">Generate Calendar Feed</a>
-            {% endif %}
-            <hr>
             <p class="text-muted">Leave password blank to keep your current password.</p>
             <div class="mb-3">
                 <label for="password" class="form-label">New Password</label>


### PR DESCRIPTION
## Summary
- Remove the Calendar Subscription section from Profile Settings page

## Test plan
- [ ] Profile page no longer shows calendar subscription URL or generate button

🤖 Generated with [Claude Code](https://claude.com/claude-code)