### PR TITLE
Fix Email Statistics 500 error from tz-aware datetime comparisons

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.69.2
+- Fix Email Statistics and rate limit queries failing on MySQL due to timezone-aware datetime comparisons against naive DATETIME columns
+
 ## 0.69.1
 - Remove Calendar Subscription section from Profile Settings page
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.69.1"
+__version__ = "0.69.2"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/email_stats.py
+++ b/app/admin/email_stats.py
@@ -168,7 +168,7 @@ def get_ses_cost(months: int = 1) -> dict | None:
 
 def get_app_email_stats() -> dict:
     """Query NotificationLog and EmailQueue for app-level statistics."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     week_start = today_start - timedelta(days=today_start.weekday())
     month_start = today_start.replace(day=1)

--- a/app/notifications/rate_limits.py
+++ b/app/notifications/rate_limits.py
@@ -26,7 +26,7 @@ def get_hourly_email_limit() -> int:
 
 def get_emails_sent_this_hour() -> int:
     """Count emails sent in the last hour (NotificationLog + sent queue entries)."""
-    one_hour_ago = datetime.now(timezone.utc) - timedelta(hours=1)
+    one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(tzinfo=None)
     log_count = NotificationLog.query.filter(
         NotificationLog.sent_at >= one_hour_ago
     ).count()
@@ -68,7 +68,7 @@ def send_rate_limit_alert() -> None:
     Bypasses the rate limit by calling _send_via_ses() directly.
     Deduped to at most one alert per hour via NotificationLog.
     """
-    one_hour_ago = datetime.now(timezone.utc) - timedelta(hours=1)
+    one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(tzinfo=None)
     recent_alert = NotificationLog.query.filter(
         NotificationLog.notification_type == "rate_limit_alert",
         NotificationLog.sent_at >= one_hour_ago,
@@ -133,7 +133,7 @@ def process_email_queue() -> dict:
                 entry.to_email, entry.subject, entry.body_text, entry.body_html
             )
             entry.status = "sent"
-            entry.sent_at = datetime.now(timezone.utc)
+            entry.sent_at = datetime.now(timezone.utc).replace(tzinfo=None)
         except Exception as exc:
             entry.status = "failed"
             entry.error_message = str(exc)[:500]


### PR DESCRIPTION
## Summary
- Strip `tzinfo` from UTC datetimes used in MySQL `DATETIME` column queries in `email_stats.py` and `rate_limits.py`
- Same class of bug fixed in AI Statistics (commit 8146432)
- Bump version to 0.69.2

Fixes #123

## Test plan
- [x] `pytest tests/test_rate_limits.py tests/test_email_service.py` — no regressions
- [x] Full test suite passes (525/525 relevant tests; 2 pre-existing calendar test failures from v0.69.1)
- [ ] Verify email stats page renders without error in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)