### PR TITLE
Fix Email Statistics 500 from non-existent BillingViewNotFoundException

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.69.3
+- Fix Email Statistics 500 error caused by referencing non-existent `BillingViewNotFoundException` exception in botocore
+
 ## 0.69.2
 - Fix Email Statistics and rate limit queries failing on MySQL due to timezone-aware datetime comparisons against naive DATETIME columns
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.69.2"
+__version__ = "0.69.3"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/email_stats.py
+++ b/app/admin/email_stats.py
@@ -155,11 +155,12 @@ def get_ses_cost(months: int = 1) -> dict | None:
             result["last_month"] = "$0.00"
 
         return result
-    except client.exceptions.BillingViewNotFoundException:
-        logger.info("Cost Explorer billing view not found")
-        return None
     except Exception as exc:
-        if "AccessDenied" in str(type(exc).__name__) or "AccessDenied" in str(exc):
+        exc_str = str(exc)
+        if "BillingView" in exc_str:
+            logger.info("Cost Explorer billing view not found")
+            return None
+        if "AccessDenied" in str(type(exc).__name__) or "AccessDenied" in exc_str:
             logger.info("Cost Explorer access denied — ce:GetCostAndUsage not granted")
             return None
         logger.exception("Failed to fetch SES cost data")


### PR DESCRIPTION
## Summary
- The `except client.exceptions.BillingViewNotFoundException:` clause in `get_ses_cost()` crashes with `AttributeError` because this exception class doesn't exist in the production botocore version
- When an `AccessDenied` error is raised, Python evaluates the except clause and the `AttributeError` escapes the entire try/except, causing a 500
- Replaced with string-based error checking in a single `except Exception` handler
- Bump version to 0.69.3

## Test plan
- [x] Full test suite passes (525/525 relevant tests)
- [ ] Verify email stats page renders without error in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)