### PR TITLE
Preserve bulk-select checkboxes across RSVP changes (v0.69.4)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,6 +5,7 @@
 - Skip sending RSVP notification email when a skipper changes their own RSVP status
 - Improve AI extraction prompt to reliably extract city/state from schedule imports (file and paste)
 - Add Excel (.xlsx) file import support for schedule imports
+- Preserve bulk-select checkbox state across RSVP status changes
 
 ## 0.69.3
 - Fix Email Statistics 500 error caused by referencing non-existent `BillingViewNotFoundException` exception in botocore

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -422,6 +422,13 @@ function openNotifyModal(tableId) {
 <script>
 function saveScrollAndSubmit(form) {
     sessionStorage.setItem('rsvpScrollY', window.scrollY);
+    var checked = [];
+    document.querySelectorAll('input[name="selected"]:checked').forEach(function(cb) {
+        checked.push(cb.value);
+    });
+    if (checked.length) {
+        sessionStorage.setItem('rsvpChecked', JSON.stringify(checked));
+    }
     form.submit();
 }
 
@@ -430,6 +437,14 @@ function saveScrollAndSubmit(form) {
     if (scrollY !== null) {
         sessionStorage.removeItem('rsvpScrollY');
         window.scrollTo(0, parseInt(scrollY, 10));
+    }
+    var checked = sessionStorage.getItem('rsvpChecked');
+    if (checked !== null) {
+        sessionStorage.removeItem('rsvpChecked');
+        JSON.parse(checked).forEach(function(val) {
+            var cb = document.querySelector('input[name="selected"][value="' + val + '"]');
+            if (cb) cb.checked = true;
+        });
     }
 })();
 </script>


### PR DESCRIPTION
## Summary
- Save checked bulk-select checkbox state to `sessionStorage` before RSVP form submit and restore on page load
- Prevents losing event selections when changing RSVP status mid-page

## Test plan
- [x] Full test suite passes (529/529, 2 pre-existing calendar failures unrelated)
- [ ] Manual: check several event checkboxes, change an RSVP, confirm checkboxes remain checked after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)