### PR TITLE
Fix crew nav link for skipper+crew users (v0.70.2)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.70.2
+- Fix crew nav link for skipper+crew users: show "My Crew" on own schedule, swap to "<Skipper>'s Crew" when viewing another skipper's schedule
+
 ## 0.70.1
 - Add optional Yacht Club and About Me fields to user profiles
 - Display new fields on view profile page (hidden when empty)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.70.1"
+__version__ = "0.70.2"
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -115,11 +115,15 @@ def create_app(test_config=None):
             return {"nav_crew_skipper": None}
 
         skippers = list(cu.skippers)
-        if len(skippers) == 1:
+
+        # Pure crew with one skipper: always show their crew link
+        if len(skippers) == 1 and not cu.is_skipper:
             return {"nav_crew_skipper": skippers[0]}
 
+        # Multi-skipper or skipper+crew: only show when viewing
+        # a specific other skipper's schedule
         skipper_id = request.args.get("skipper", type=int)
-        if skipper_id and skipper_id != 0:
+        if skipper_id and skipper_id != 0 and skipper_id != cu.id:
             for s in skippers:
                 if s.id == skipper_id:
                     return {"nav_crew_skipper": s}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -34,11 +34,10 @@
                     {% if current_user.is_authenticated %}
                     <a class="nav-link nav-pill-link" href="{{ url_for('regattas.index') }}">Home</a>
                     <a class="nav-link nav-pill-link" href="{{ url_for('calendar.subscribe') }}">Calendar</a>
-                    {% if current_user.is_admin or current_user.is_skipper %}
-                    <a class="nav-link nav-pill-link" href="{{ url_for('auth.my_crew') }}">My Crew</a>
-                    {% endif %}
                     {% if nav_crew_skipper %}
                     <a class="nav-link nav-pill-link" href="{{ url_for('auth.crew_view', skipper_id=nav_crew_skipper.id) }}">{{ nav_crew_skipper.display_name }}'s Crew</a>
+                    {% elif current_user.is_admin or current_user.is_skipper %}
+                    <a class="nav-link nav-pill-link" href="{{ url_for('auth.my_crew') }}">My Crew</a>
                     {% endif %}
                     {% endif %}
                     <a class="nav-link nav-pill-link" href="{{ url_for('help.index') }}">Help</a>


### PR DESCRIPTION
## Summary
- Skipper+crew users now see contextual nav: "My Crew" on own schedule, "<Skipper>'s Crew" when viewing another skipper's schedule
- Pure crew and skipper-only behavior unchanged

## Test plan
- [x] 543 tests pass, 0 failures
- [ ] Manual: skipper+crew user viewing own schedule → sees "My Crew"
- [ ] Manual: skipper+crew user switches to another skipper's schedule → nav swaps to "<Skipper>'s Crew"
- [ ] Manual: pure crew → still sees "<Skipper>'s Crew"
- [ ] Manual: skipper only → still sees "My Crew"

🤖 Generated with [Claude Code](https://claude.com/claude-code)