### PR TITLE
Add skipper-set crew RSVP and enhanced invites (v0.72.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ A simple web app for organizing sailing events. Track dates, locations, NOR/SI d
 - Upload/download NOR and SI PDFs (stored in S3)
 - Profile pictures with S3 storage, displayed in navbar and crew profiles
 - Crew RSVP (Yes / No / Maybe) with color-coded initials and unique Multiavatar icons
+- Skippers can set crew RSVP on their behalf via clickable crew badges with "+" to add missing crew
 - AI-powered schedule import: paste text or URL, Claude extracts events for review and bulk import, with auto-discovery of NOR/SI/WWW documents from event detail pages and event websites (including clubspot Parse API integration)
 - Admin: manage all users, site settings, invite skippers
-- Skipper: add/edit/delete own events, upload documents, invite crew, import schedules
-- Crew: view skipper's schedule, download docs, set RSVP
+- Skipper: add/edit/delete own events, upload documents, invite crew (with name/initials/phone), import schedules, set crew RSVP, resend invitations
+- Crew: view skipper's schedule, download docs, set RSVP, receive email when skipper changes their RSVP
 - AI usage tracking with cost statistics dashboard, monthly budget cap, and automatic 80% budget alert
 - Email rate limiting with queueing, admin alerts, and statistics dashboard
 - Email-based password reset with secure token expiry
@@ -120,10 +121,11 @@ Open http://localhost and login with your admin credentials.
 
 ### Invite crew
 
-1. Go to **Crew** in the navbar
-2. Enter a crew member's email and click **Send Invite**
-3. Copy the invite link and send it to them
-4. They click the link, set their name/initials/password, and they're in
+1. Go to **My Crew** in the navbar
+2. Enter the crew member's name, initials, email, and optionally phone number
+3. Click **Invite** (optionally send invite via email)
+4. They click the invite link, confirm their name/initials, set a password, and they're in
+5. Use the **Resend** button next to pending crew to re-send the invite (once per day)
 
 ### Stop
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 0.72.0
+- Skipper can set crew RSVP status (Yes/No/Maybe/Clear) on behalf of crew members via clickable crew badges, with View Profile link in the modal
+- "+" badge in its own column allows setting RSVP for crew (including pending) who haven't responded
+- Skipper's own badge in the crew column is not editable — use the "Your RSVP" dropdown instead
+- Crew members receive email notification when their skipper changes their RSVP (skippers do not self-notify)
+- Enhanced crew invite: collect name, initials (required), and phone (optional) at invite time
+- Resend invitation button on My Crew page for pending members (rate limited to once per day)
+
 ## 0.71.0
 - Add public schedule page per skipper with anonymous access (`/schedule/<slug>`)
 - Published by default; URL slug auto-generated from display name

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.71.0"
+__version__ = "0.72.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -380,7 +380,9 @@ def profile():
                 return redirect(url_for("auth.profile"))
 
     # Ensure skippers/admins always have a schedule slug for display
-    if (current_user.is_skipper or current_user.is_admin) and not current_user.schedule_slug:
+    if (
+        current_user.is_skipper or current_user.is_admin
+    ) and not current_user.schedule_slug:
         current_user.schedule_slug = current_user.generate_schedule_slug()
         db.session.commit()
 
@@ -395,9 +397,14 @@ def profile():
 @login_required
 def view_profile(user_id: int):
     user = db.session.get(User, user_id)
-    if not user or user.invite_token:
+    if not user:
         flash("User not found.", "error")
         return redirect(url_for("regattas.index"))
+    # Pending users visible only to their skipper or admin
+    if user.invite_token:
+        if not (current_user.is_admin or user in current_user.crew_members.all()):
+            flash("User not found.", "error")
+            return redirect(url_for("regattas.index"))
     return render_template(
         "view_profile.html",
         user=user,
@@ -706,6 +713,7 @@ def my_crew():
         "my_crew.html",
         crew=[current_user] + crew,
         email_configured=is_email_configured(),
+        now=datetime.now(timezone.utc).replace(tzinfo=None),
     )
 
 
@@ -744,8 +752,18 @@ def invite_crew():
         return redirect(url_for("regattas.index"))
 
     email = request.form.get("email", "").strip().lower()
+    display_name = request.form.get("display_name", "").strip()
+    initials = request.form.get("initials", "").strip().upper()
+    phone = request.form.get("phone", "").strip() or None
+
     if not email:
         flash("Email is required.", "error")
+        return redirect(url_for("auth.my_crew"))
+    if not display_name:
+        flash("Name is required.", "error")
+        return redirect(url_for("auth.my_crew"))
+    if not initials:
+        flash("Initials are required.", "error")
         return redirect(url_for("auth.my_crew"))
 
     existing_user = User.query.filter_by(email=email).first()
@@ -764,8 +782,9 @@ def invite_crew():
     user = User(
         email=email,
         password_hash="pending",
-        display_name=email,
-        initials="??",
+        display_name=display_name,
+        initials=initials,
+        phone=phone,
         invite_token=token,
         invited_by=current_user.id,
         avatar_seed=User.generate_avatar_seed(),
@@ -781,6 +800,8 @@ def invite_crew():
     if send_email_invite and is_email_configured():
         try:
             _send_invite_email(email, invite_url, current_user.display_name)
+            user.invite_sent_at = datetime.now(timezone.utc)
+            db.session.commit()
             flash(f"Invite email sent to {email}.", "success")
         except Exception:
             logger.exception("Failed to send invite email to %s", email)
@@ -788,6 +809,48 @@ def invite_crew():
             flash(f"Invite link: {invite_url}", "success")
     else:
         flash(f"Invite link: {invite_url}", "success")
+
+    return redirect(url_for("auth.my_crew"))
+
+
+@bp.route("/my-crew/<int:user_id>/resend-invite", methods=["POST"])
+@login_required
+def resend_invite(user_id: int):
+    if not (current_user.is_admin or current_user.is_skipper):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index"))
+
+    user = db.session.get(User, user_id)
+    if not user or not user.invite_token:
+        flash("User not found or already registered.", "error")
+        return redirect(url_for("auth.my_crew"))
+
+    if user not in current_user.crew_members.all():
+        flash("That user is not on your crew.", "warning")
+        return redirect(url_for("auth.my_crew"))
+
+    # Rate limit: one resend per day
+    if user.invite_sent_at:
+        hours_since = (
+            datetime.now(timezone.utc).replace(tzinfo=None) - user.invite_sent_at
+        ).total_seconds() / 3600
+        if hours_since < 24:
+            flash("Invite was already sent today. Try again tomorrow.", "warning")
+            return redirect(url_for("auth.my_crew"))
+
+    if not is_email_configured():
+        flash("Email is not configured.", "error")
+        return redirect(url_for("auth.my_crew"))
+
+    invite_url = url_for("auth.register", token=user.invite_token, _external=True)
+    try:
+        _send_invite_email(user.email, invite_url, current_user.display_name)
+        user.invite_sent_at = datetime.now(timezone.utc)
+        db.session.commit()
+        flash(f"Invite resent to {user.email}.", "success")
+    except Exception:
+        logger.exception("Failed to resend invite to %s", user.email)
+        flash("Failed to resend invite email.", "error")
 
     return redirect(url_for("auth.my_crew"))
 

--- a/app/models.py
+++ b/app/models.py
@@ -38,6 +38,8 @@ class User(UserMixin, db.Model):
 
     # Registration invite token (null after registration is complete)
     invite_token = db.Column(db.String(64), unique=True, nullable=True)
+    # When the last invite email was sent (for resend rate limiting)
+    invite_sent_at = db.Column(db.DateTime, nullable=True)
     # Token for iCal subscription feed (generated on first request)
     calendar_token = db.Column(db.String(64), unique=True, nullable=True)
     # Password reset token and expiry

--- a/app/notifications/service.py
+++ b/app/notifications/service.py
@@ -178,6 +178,70 @@ def notify_rsvp_to_skipper(rsvp) -> None:
     db.session.commit()
 
 
+def notify_crew_rsvp_changed(
+    crew_user: User, regatta: "Regatta", status: str, skipper: User
+) -> None:
+    """Notify a crew member that the skipper changed their RSVP."""
+    if not is_email_configured():
+        return
+
+    # Skip pending (unregistered) crew — they can't log in anyway
+    if crew_user.invite_token:
+        return
+
+    if not crew_user.email_opt_in:
+        return
+
+    schedule_url = url_for("regattas.index", _external=True)
+
+    if status:
+        subject = (
+            f"RSVP Update: {skipper.display_name} set you as {status} — {regatta.name}"
+        )
+    else:
+        subject = (
+            f"RSVP Update: {skipper.display_name} cleared your RSVP — {regatta.name}"
+        )
+
+    body_html = render_template(
+        "email/crew_rsvp_changed.html",
+        skipper_name=skipper.display_name,
+        status=status,
+        regatta_name=regatta.name,
+        regatta_date=regatta.start_date,
+        regatta_end_date=regatta.end_date,
+        regatta_location=regatta.full_location,
+        schedule_url=schedule_url,
+    )
+    body_text = render_template(
+        "email/crew_rsvp_changed.txt",
+        skipper_name=skipper.display_name,
+        status=status,
+        regatta_name=regatta.name,
+        regatta_date=regatta.start_date,
+        regatta_end_date=regatta.end_date,
+        regatta_location=regatta.full_location,
+        schedule_url=schedule_url,
+    )
+
+    send_email(
+        to=crew_user.email,
+        subject=subject,
+        body_text=body_text,
+        body_html=body_html,
+    )
+
+    db.session.add(
+        NotificationLog(
+            notification_type="crew_rsvp_changed",
+            regatta_id=regatta.id,
+            user_id=crew_user.id,
+            trigger_date=date.today(),
+        )
+    )
+    db.session.commit()
+
+
 def notify_crew_joined(crew_member: User, skipper: User) -> None:
     """Notify skipper that a crew member has completed registration."""
     if not is_email_configured():

--- a/app/permissions.py
+++ b/app/permissions.py
@@ -39,6 +39,18 @@ def can_manage_regatta(user, regatta) -> bool:
     return user.is_skipper and regatta.created_by == user.id
 
 
+def can_set_crew_rsvp(user, regatta, crew_user) -> bool:
+    """True if user can set RSVP for crew_user on this regatta.
+
+    Allowed for: admin, or regatta owner if crew_user is in their crew.
+    """
+    if user.is_admin:
+        return True
+    if regatta.created_by == user.id and crew_user in user.crew_members.all():
+        return True
+    return False
+
+
 def can_rsvp_to_regatta(user, regatta) -> bool:
     """True if user can RSVP to this regatta.
 

--- a/app/regattas/routes.py
+++ b/app/regattas/routes.py
@@ -12,8 +12,10 @@ from weasyprint import HTML
 from app import db, storage
 from app.models import RSVP, Document, Regatta, User
 from app.notifications.service import (get_eligible_crew, notify_crew,
+                                       notify_crew_rsvp_changed,
                                        notify_rsvp_to_skipper)
-from app.permissions import can_manage_regatta, can_rsvp_to_regatta
+from app.permissions import (can_manage_regatta, can_rsvp_to_regatta,
+                             can_set_crew_rsvp)
 from app.regattas import bp
 
 logger = logging.getLogger(__name__)
@@ -409,6 +411,77 @@ def rsvp(regatta_id: int):
         notify_rsvp_to_skipper(rsvp_obj)
     except Exception:
         logger.exception("Failed to send RSVP notification for regatta %s", regatta.id)
+
+    return redirect(url_for("regattas.index", **redirect_args))
+
+
+@bp.route("/regattas/<int:regatta_id>/crew-rsvp", methods=["POST"])
+@login_required
+def crew_rsvp(regatta_id: int):
+    """Allow a skipper to set RSVP status for one of their crew members."""
+    crew_user_id = request.form.get("crew_user_id", type=int)
+    status = request.form.get("status", "").lower()
+
+    # Build redirect args — same pattern as self-RSVP route
+    redirect_args = {}
+    redirect_skipper = request.form.get("redirect_skipper")
+    if redirect_skipper is not None and redirect_skipper != "":
+        redirect_args["skipper"] = redirect_skipper
+    redirect_rsvp = request.form.getlist("redirect_rsvp")
+    if redirect_rsvp:
+        redirect_args["rsvp"] = redirect_rsvp
+
+    regatta = db.session.get(Regatta, regatta_id)
+    crew_user = db.session.get(User, crew_user_id) if crew_user_id else None
+    skipper = db.session.get(User, current_user.id)
+
+    if (
+        not regatta
+        or not crew_user
+        or not can_set_crew_rsvp(current_user, regatta, crew_user)
+    ):
+        flash("Access denied.", "error")
+        return redirect(url_for("regattas.index", **redirect_args))
+
+    if not status:
+        # Clear the crew member's RSVP
+        existing = RSVP.query.filter_by(
+            regatta_id=regatta_id, user_id=crew_user.id
+        ).first()
+        if existing:
+            db.session.delete(existing)
+            db.session.commit()
+            try:
+                notify_crew_rsvp_changed(crew_user, regatta, "", skipper)
+            except Exception:
+                logger.exception(
+                    "Failed to send crew RSVP notification for regatta %s",
+                    regatta.id,
+                )
+        return redirect(url_for("regattas.index", **redirect_args))
+
+    if status not in ("yes", "no", "maybe"):
+        flash("Invalid RSVP status.", "error")
+        return redirect(url_for("regattas.index", **redirect_args))
+
+    existing = RSVP.query.filter_by(regatta_id=regatta_id, user_id=crew_user.id).first()
+
+    if existing:
+        existing.status = status
+        rsvp_obj = existing
+    else:
+        rsvp_obj = RSVP(regatta_id=regatta_id, user_id=crew_user.id, status=status)
+        db.session.add(rsvp_obj)
+
+    db.session.commit()
+
+    # Notify the crew member that their RSVP was changed
+    try:
+        notify_crew_rsvp_changed(crew_user, regatta, status, skipper)
+    except Exception:
+        logger.exception(
+            "Failed to send crew RSVP notification for regatta %s", regatta.id
+        )
 
     return redirect(url_for("regattas.index", **redirect_args))
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -70,6 +70,11 @@
     text-decoration: underline;
 }
 
+.crew-badge.editable:hover {
+    text-decoration: none;
+    box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.5);
+}
+
 .crew-badge.yes { background-color: #d1e7dd; color: #0f5132; }
 .crew-badge.no { background-color: #f8d7da; color: #842029; }
 .crew-badge.maybe { background-color: #fff3cd; color: #664d03; }

--- a/app/templates/email/crew_rsvp_changed.html
+++ b/app/templates/email/crew_rsvp_changed.html
@@ -1,0 +1,23 @@
+<h2>RSVP Update from Your Skipper</h2>
+<p>Your skipper <strong>{{ skipper_name }}</strong> has {% if status %}set your RSVP to <strong>{{ status }}</strong>{% else %}cleared your RSVP{% endif %} for <strong>{{ regatta_name }}</strong>.</p>
+<table style="border-collapse:collapse;margin:16px 0;" cellpadding="8">
+    <tr>
+        <td style="border:1px solid #dee2e6;background-color:#f8f9fa;font-weight:bold;">Event</td>
+        <td style="border:1px solid #dee2e6;">{{ regatta_name }}</td>
+    </tr>
+    <tr>
+        <td style="border:1px solid #dee2e6;background-color:#f8f9fa;font-weight:bold;">Date</td>
+        <td style="border:1px solid #dee2e6;">{{ regatta_date.strftime('%b %d') }}{% if regatta_end_date %} – {{ regatta_end_date.strftime('%b %d') }}{% endif %}, {{ regatta_date.strftime('%Y') }}</td>
+    </tr>
+    <tr>
+        <td style="border:1px solid #dee2e6;background-color:#f8f9fa;font-weight:bold;">Location</td>
+        <td style="border:1px solid #dee2e6;">{{ regatta_location }}</td>
+    </tr>
+    {% if status %}
+    <tr>
+        <td style="border:1px solid #dee2e6;background-color:#f8f9fa;font-weight:bold;">Your RSVP</td>
+        <td style="border:1px solid #dee2e6;">{{ status }}</td>
+    </tr>
+    {% endif %}
+</table>
+<p><a href="{{ schedule_url }}">View your schedule</a></p>

--- a/app/templates/email/crew_rsvp_changed.txt
+++ b/app/templates/email/crew_rsvp_changed.txt
@@ -1,0 +1,10 @@
+RSVP Update from Your Skipper
+
+Your skipper {{ skipper_name }} has {% if status %}set your RSVP to {{ status }}{% else %}cleared your RSVP{% endif %} for {{ regatta_name }}.
+
+Event: {{ regatta_name }}
+Date: {{ regatta_date.strftime('%b %d') }}{% if regatta_end_date %} – {{ regatta_end_date.strftime('%b %d') }}{% endif %}, {{ regatta_date.strftime('%Y') }}
+Location: {{ regatta_location }}
+{% if status %}Your RSVP: {{ status }}{% endif %}
+
+View your schedule: {{ schedule_url }}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -384,7 +384,7 @@
                     <button type="button" class="btn btn-warning crew-rsvp-btn" data-status="maybe" onclick="submitCrewRsvp('maybe')">Maybe</button>
                     <button type="button" class="btn btn-danger crew-rsvp-btn" data-status="no" onclick="submitCrewRsvp('no')">No</button>
                     <button type="button" class="btn btn-outline-secondary crew-rsvp-btn" data-status="" onclick="submitCrewRsvp('')">Clear</button>
-                    <a href="#" id="crewRsvpProfileLink" class="btn btn-outline-info">View Profile</a>
+                    <a href="#" id="crewRsvpProfileLink" class="btn btn-primary">View Profile</a>
                 </div>
             </div>
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -84,7 +84,7 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 </form>
 {% endif %}
-{% set divider_colspan = 6 + (1 if show_skipper else 0) + (0 if is_past else 1) + (2 if can_manage_any else 0) %}
+{% set divider_colspan = 6 + (1 if show_skipper else 0) + (0 if is_past else 1) + (1 if current_user.is_skipper and not is_past else 0) + (2 if can_manage_any else 0) %}
 <div class="table-responsive event-table-desktop">
     <table class="table table-hover align-middle{% if is_past %} event-past{% endif %}">
         <thead>
@@ -96,6 +96,9 @@
                 <th>Location</th>
                 <th class="text-nowrap">Docs</th>
                 <th class="text-nowrap">Crew</th>
+                {% if current_user.is_skipper and not is_past %}
+                <th style="width:1px;">+</th>
+                {% endif %}
                 {% if not is_past %}
                 <th>Your RSVP</th>
                 {% endif %}
@@ -148,10 +151,25 @@
                     {% endfor %}
                 </td>
                 <td>
+                    {% set is_own_regatta = current_user.id == regatta.created_by %}
                     {% for rsvp in regatta.rsvps|sort_rsvps %}
+                    {% if is_own_regatta and not is_past and rsvp.user.id != current_user.id %}
+                    <a href="#" class="crew-badge editable {{ rsvp.status }}" title="{{ rsvp.user.display_name }}" data-crew-id="{{ rsvp.user.id }}" data-crew-name="{{ rsvp.user.display_name }}" data-regatta-id="{{ regatta.id }}" data-current-status="{{ rsvp.status }}" onclick="openCrewRsvpModal(this); return false;">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }} {{ rsvp.user|user_icon(26) }}</a>
+                    {% else %}
                     <a href="{{ url_for('auth.view_profile', user_id=rsvp.user.id) }}" class="crew-badge {{ rsvp.status }}" title="{{ rsvp.user.display_name }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }} {{ rsvp.user|user_icon(26) }}</a>
+                    {% endif %}
                     {% endfor %}
                 </td>
+                {% if current_user.is_skipper and not is_past %}
+                <td>
+                    {% if is_own_regatta %}
+                    {% set all_crew = current_user.crew_members.all()|rejectattr('id', 'equalto', current_user.id)|list %}
+                    {% if all_crew %}
+                    <a href="#" class="crew-badge editable" style="background-color:#e9ecef;color:#666;" title="Add Crew" data-regatta-id="{{ regatta.id }}" data-all-crew='[{% for c in all_crew %}{"id":{{ c.id }},"name":"{{ c.display_name }}"}{% if not loop.last %},{% endif %}{% endfor %}]' onclick="openAddCrewRsvpModal(this); return false;">+</a>
+                    {% endif %}
+                    {% endif %}
+                </td>
+                {% endif %}
                 {% if not is_past %}
                 <td>
                     <form method="POST" action="{{ url_for('regattas.rsvp', regatta_id=regatta.id) }}" class="d-inline">
@@ -241,9 +259,20 @@
                 {% for doc in regatta.documents|sort(attribute='doc_type') %}
                 <a href="{% if doc.url %}{{ doc.url }}{% else %}{{ url_for('regattas.download_doc', doc_id=doc.id) }}{% endif %}" class="badge bg-info text-decoration-none doc-link" target="_blank">{{ doc.doc_type }}</a>
                 {% endfor %}
+                {% set is_own_regatta_m = current_user.id == regatta.created_by %}
                 {% for rsvp in regatta.rsvps|sort_rsvps %}
+                {% if is_own_regatta_m and not is_past and rsvp.user.id != current_user.id %}
+                <a href="#" class="crew-badge editable {{ rsvp.status }}" title="{{ rsvp.user.display_name }}" data-crew-id="{{ rsvp.user.id }}" data-crew-name="{{ rsvp.user.display_name }}" data-regatta-id="{{ regatta.id }}" data-current-status="{{ rsvp.status }}" onclick="openCrewRsvpModal(this); return false;">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }} {{ rsvp.user|user_icon(26) }}</a>
+                {% else %}
                 <a href="{{ url_for('auth.view_profile', user_id=rsvp.user.id) }}" class="crew-badge {{ rsvp.status }}" title="{{ rsvp.user.display_name }}">{% if rsvp.status == 'yes' %}&#10003;{% elif rsvp.status == 'no' %}&#10007;{% elif rsvp.status == 'maybe' %}?{% endif %} {{ rsvp.user.initials }} {{ rsvp.user|user_icon(26) }}</a>
+                {% endif %}
                 {% endfor %}
+                {% if is_own_regatta_m and not is_past %}
+                {% set all_crew_m = current_user.crew_members.all()|rejectattr('id', 'equalto', current_user.id)|list %}
+                {% if all_crew_m %}
+                <a href="#" class="crew-badge editable" style="background-color:#e9ecef;color:#666;" title="Add Crew" data-regatta-id="{{ regatta.id }}" data-all-crew='[{% for c in all_crew_m %}{"id":{{ c.id }},"name":"{{ c.display_name }}"}{% if not loop.last %},{% endif %}{% endfor %}]' onclick="openAddCrewRsvpModal(this); return false;">+</a>
+                {% endif %}
+                {% endif %}
             </div>
             {% if not is_past %}
             <div class="mt-1">
@@ -324,6 +353,40 @@
                     <button type="submit" class="btn btn-primary">Send Notification</button>
                 </div>
             </form>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{% if current_user.is_skipper %}
+<!-- Crew RSVP Modal -->
+<div class="modal fade" id="crewRsvpModal" tabindex="-1" aria-labelledby="crewRsvpModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm modal-dialog-centered">
+        <div class="modal-content">
+            <form method="POST" id="crewRsvpForm">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="crew_user_id" id="crewRsvpUserId">
+                <input type="hidden" name="status" id="crewRsvpStatus">
+                {% if selected_skipper is not none %}<input type="hidden" name="redirect_skipper" value="{{ selected_skipper }}">{% endif %}
+                {% for rf in rsvp_filters %}<input type="hidden" name="redirect_rsvp" value="{{ rf }}">{% endfor %}
+            </form>
+            <div class="modal-header">
+                <h5 class="modal-title" id="crewRsvpModalLabel">Set RSVP</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-center mb-3" id="crewRsvpName"></p>
+                <div id="crewRsvpPicker" style="display:none;">
+                    <div id="crewRsvpList" class="list-group mb-3" style="max-height:240px;overflow-y:auto;"></div>
+                </div>
+                <div id="crewRsvpButtons" class="d-grid gap-2" style="display:none;">
+                    <button type="button" class="btn btn-success crew-rsvp-btn" data-status="yes" onclick="submitCrewRsvp('yes')">Yes</button>
+                    <button type="button" class="btn btn-warning crew-rsvp-btn" data-status="maybe" onclick="submitCrewRsvp('maybe')">Maybe</button>
+                    <button type="button" class="btn btn-danger crew-rsvp-btn" data-status="no" onclick="submitCrewRsvp('no')">No</button>
+                    <button type="button" class="btn btn-outline-secondary crew-rsvp-btn" data-status="" onclick="submitCrewRsvp('')">Clear</button>
+                    <a href="#" id="crewRsvpProfileLink" class="btn btn-outline-info">View Profile</a>
+                </div>
+            </div>
         </div>
     </div>
 </div>
@@ -472,6 +535,79 @@ function openNotifyModal(tableId) {
 {% endif %}
 
 <script>
+function openCrewRsvpModal(el) {
+    document.getElementById('crewRsvpUserId').value = el.dataset.crewId;
+    document.getElementById('crewRsvpName').textContent = el.dataset.crewName;
+    document.getElementById('crewRsvpForm').action = '/regattas/' + el.dataset.regattaId + '/crew-rsvp';
+    document.getElementById('crewRsvpPicker').style.display = 'none';
+    document.getElementById('crewRsvpProfileLink').href = '/crew/' + el.dataset.crewId;
+    document.getElementById('crewRsvpProfileLink').style.display = '';
+    document.getElementById('crewRsvpButtons').style.display = 'grid';
+    // Highlight current status
+    var currentStatus = el.dataset.currentStatus;
+    document.querySelectorAll('.crew-rsvp-btn').forEach(function(btn) {
+        btn.classList.remove('active');
+        if (btn.dataset.status === currentStatus) btn.classList.add('active');
+    });
+    var modal = new bootstrap.Modal(document.getElementById('crewRsvpModal'));
+    modal.show();
+}
+
+function selectCrewFromList(item) {
+    document.getElementById('crewRsvpUserId').value = item.dataset.crewId;
+    document.getElementById('crewRsvpName').textContent = item.dataset.crewName;
+    // Highlight selected item
+    document.querySelectorAll('#crewRsvpList .list-group-item').forEach(function(li) {
+        li.classList.remove('active');
+    });
+    item.classList.add('active');
+    // Show RSVP buttons
+    document.getElementById('crewRsvpButtons').style.display = 'grid';
+    document.querySelectorAll('.crew-rsvp-btn').forEach(function(btn) {
+        btn.classList.remove('active');
+    });
+}
+
+function openAddCrewRsvpModal(el) {
+    var crew = JSON.parse(el.dataset.allCrew);
+    var list = document.getElementById('crewRsvpList');
+    list.innerHTML = '';
+    crew.forEach(function(c) {
+        var item = document.createElement('a');
+        item.href = '#';
+        item.className = 'list-group-item list-group-item-action';
+        item.dataset.crewId = c.id;
+        item.dataset.crewName = c.name;
+        item.textContent = c.name;
+        item.onclick = function(e) { e.preventDefault(); selectCrewFromList(this); };
+        list.appendChild(item);
+    });
+    document.getElementById('crewRsvpUserId').value = '';
+    document.getElementById('crewRsvpName').textContent = 'Select a crew member';
+    document.getElementById('crewRsvpForm').action = '/regattas/' + el.dataset.regattaId + '/crew-rsvp';
+    document.getElementById('crewRsvpPicker').style.display = 'block';
+    document.getElementById('crewRsvpProfileLink').style.display = 'none';
+    document.getElementById('crewRsvpButtons').style.display = 'none';
+    document.querySelectorAll('.crew-rsvp-btn').forEach(function(btn) {
+        btn.classList.remove('active');
+    });
+    var modal = new bootstrap.Modal(document.getElementById('crewRsvpModal'));
+    modal.show();
+}
+
+function submitCrewRsvp(status) {
+    document.getElementById('crewRsvpStatus').value = status;
+    sessionStorage.setItem('rsvpScrollY', window.scrollY);
+    var checked = [];
+    document.querySelectorAll('input[name="selected"]:checked').forEach(function(cb) {
+        checked.push(cb.value);
+    });
+    if (checked.length) {
+        sessionStorage.setItem('rsvpChecked', JSON.stringify(checked));
+    }
+    document.getElementById('crewRsvpForm').submit();
+}
+
 function saveScrollAndSubmit(form) {
     sessionStorage.setItem('rsvpScrollY', window.scrollY);
     var checked = [];

--- a/app/templates/my_crew.html
+++ b/app/templates/my_crew.html
@@ -8,9 +8,21 @@
         <h5 class="card-title">Invite Crew Member</h5>
         <form method="POST" action="{{ url_for('auth.invite_crew') }}" class="row g-2 align-items-end">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <div class="col-12 col-sm">
+            <div class="col-12 col-sm-6 col-md">
+                <label for="display_name" class="form-label">Name</label>
+                <input type="text" class="form-control" id="display_name" name="display_name" required placeholder="John Doe">
+            </div>
+            <div class="col-6 col-sm-3 col-md-auto" style="max-width: 100px;">
+                <label for="initials" class="form-label">Initials</label>
+                <input type="text" class="form-control text-uppercase" id="initials" name="initials" required maxlength="5" placeholder="JD" style="text-transform:uppercase;">
+            </div>
+            <div class="col-12 col-sm-6 col-md">
                 <label for="email" class="form-label">Email</label>
                 <input type="email" class="form-control" id="email" name="email" required placeholder="crew@example.com">
+            </div>
+            <div class="col-12 col-sm-6 col-md">
+                <label for="phone" class="form-label">Phone <small class="text-muted">(optional)</small></label>
+                <input type="tel" class="form-control" id="phone" name="phone" placeholder="555-123-4567">
             </div>
             {% if email_configured %}
             <div class="col-12 col-sm-auto d-flex align-items-center">
@@ -60,8 +72,15 @@
                     <span class="badge bg-success">Active</span>
                     {% endif %}
                 </td>
-                <td>
+                <td class="text-nowrap">
                     {% if member.id != current_user.id %}
+                    {% if member.invite_token and email_configured %}
+                    {% set can_resend = not member.invite_sent_at or (now - member.invite_sent_at).total_seconds() >= 86400 %}
+                    <form method="POST" action="{{ url_for('auth.resend_invite', user_id=member.id) }}" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="btn btn-sm btn-outline-primary" {% if not can_resend %}disabled title="Resent today"{% endif %}>Resend</button>
+                    </form>
+                    {% endif %}
                     <form method="POST" action="{{ url_for('auth.remove_crew', user_id=member.id) }}" class="d-inline" onsubmit="return confirm('Remove {{ member.display_name }} from your crew?')">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>

--- a/app/templates/view_profile.html
+++ b/app/templates/view_profile.html
@@ -50,10 +50,21 @@
             {% endif %}
             <tr>
                 <th>Role</th>
-                <td>{{ "Admin" if user.is_admin else "Crew" }}</td>
+                <td>
+                    {% if user.invite_token %}
+                    <span class="badge bg-warning text-dark">Pending Invite</span>
+                    {% elif user.is_admin %}
+                    Admin
+                    {% else %}
+                    Crew
+                    {% endif %}
+                </td>
             </tr>
         </table>
         <a href="{{ url_for('regattas.index') }}" class="btn btn-outline-secondary btn-sm">Back</a>
+        {% if user.id == current_user.id %}
+        <a href="{{ url_for('auth.profile') }}" class="btn btn-outline-primary btn-sm">Edit Profile</a>
+        {% endif %}
     </div>
 </div>
 

--- a/migrations/versions/p6f7a8b9c0d1_add_invite_sent_at_to_users.py
+++ b/migrations/versions/p6f7a8b9c0d1_add_invite_sent_at_to_users.py
@@ -1,0 +1,22 @@
+"""Add invite_sent_at to users
+
+Revision ID: p6f7a8b9c0d1
+Revises: o5e6f7a8b9c0
+Create Date: 2026-04-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "p6f7a8b9c0d1"
+down_revision = "o5e6f7a8b9c0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("invite_sent_at", sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("users", "invite_sent_at")

--- a/tests/test_crew_rsvp.py
+++ b/tests/test_crew_rsvp.py
@@ -1,0 +1,561 @@
+"""Tests for skipper crew RSVP management, enhanced invite, and resend invitation."""
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+
+from app.models import RSVP, Regatta, User
+from app.notifications.service import notify_crew_rsvp_changed
+
+
+def _make_regatta(db, skipper):
+    """Helper to create a future regatta owned by the given skipper."""
+    r = Regatta(
+        name="Test Regatta",
+        location="Test Location",
+        start_date=date.today() + timedelta(days=7),
+        created_by=skipper.id,
+    )
+    db.session.add(r)
+    db.session.commit()
+    return r
+
+
+def _login(client, email):
+    client.post(
+        "/login", data={"email": email, "password": "password"}, follow_redirects=True
+    )
+
+
+# ── Crew RSVP route tests ────────────────────────────────────────────
+
+
+class TestSkipperCrewRsvp:
+
+    def test_skipper_sets_crew_rsvp_yes(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        resp = logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "yes"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        rsvp = RSVP.query.filter_by(regatta_id=regatta.id, user_id=crew_user.id).first()
+        assert rsvp is not None
+        assert rsvp.status == "yes"
+
+    def test_skipper_sets_crew_rsvp_no(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "no"},
+            follow_redirects=True,
+        )
+        rsvp = RSVP.query.filter_by(regatta_id=regatta.id, user_id=crew_user.id).first()
+        assert rsvp is not None
+        assert rsvp.status == "no"
+
+    def test_skipper_sets_crew_rsvp_maybe(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "maybe"},
+            follow_redirects=True,
+        )
+        rsvp = RSVP.query.filter_by(regatta_id=regatta.id, user_id=crew_user.id).first()
+        assert rsvp is not None
+        assert rsvp.status == "maybe"
+
+    def test_skipper_clears_crew_rsvp(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        # Create initial RSVP
+        rsvp = RSVP(regatta_id=regatta.id, user_id=crew_user.id, status="yes")
+        db.session.add(rsvp)
+        db.session.commit()
+        # Clear it
+        logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": ""},
+            follow_redirects=True,
+        )
+        assert (
+            RSVP.query.filter_by(regatta_id=regatta.id, user_id=crew_user.id).first()
+            is None
+        )
+
+    def test_skipper_updates_existing_crew_rsvp(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        rsvp = RSVP(regatta_id=regatta.id, user_id=crew_user.id, status="yes")
+        db.session.add(rsvp)
+        db.session.commit()
+        logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "no"},
+            follow_redirects=True,
+        )
+        rsvp = RSVP.query.filter_by(regatta_id=regatta.id, user_id=crew_user.id).first()
+        assert rsvp.status == "no"
+
+    def test_skipper_sets_rsvp_for_pending_crew(
+        self, app, db, logged_in_skipper, skipper_user
+    ):
+        # Create a pending (invited) crew member
+        pending = User(
+            email="pending@test.com",
+            password_hash="pending",
+            display_name="Pending Sailor",
+            initials="PS",
+            invite_token="test-token-123",
+            invited_by=skipper_user.id,
+        )
+        db.session.add(pending)
+        db.session.flush()
+        skipper_user.crew_members.append(pending)
+        db.session.commit()
+
+        regatta = _make_regatta(db, skipper_user)
+        logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": pending.id, "status": "yes"},
+            follow_redirects=True,
+        )
+        rsvp = RSVP.query.filter_by(regatta_id=regatta.id, user_id=pending.id).first()
+        assert rsvp is not None
+        assert rsvp.status == "yes"
+
+    def test_crew_rsvp_denied_for_non_skipper(
+        self, app, db, logged_in_crew, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        resp = logged_in_crew.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "yes"},
+            follow_redirects=True,
+        )
+        assert b"Access denied" in resp.data
+        assert (
+            RSVP.query.filter_by(regatta_id=regatta.id, user_id=crew_user.id).first()
+            is None
+        )
+
+    def test_crew_rsvp_denied_for_wrong_skipper(
+        self, app, db, skipper_user, crew_user, client
+    ):
+        # Create another skipper
+        other_skipper = User(
+            email="other@test.com",
+            display_name="Other Skipper",
+            initials="OS",
+            is_skipper=True,
+        )
+        other_skipper.set_password("password")
+        db.session.add(other_skipper)
+        db.session.commit()
+
+        regatta = _make_regatta(db, skipper_user)
+        _login(client, "other@test.com")
+        resp = client.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "yes"},
+            follow_redirects=True,
+        )
+        assert b"Access denied" in resp.data
+
+    def test_crew_rsvp_denied_for_non_crew_member(
+        self, app, db, logged_in_skipper, skipper_user
+    ):
+        # Create a user who is NOT on skipper's crew
+        outsider = User(
+            email="outsider@test.com",
+            display_name="Outsider",
+            initials="OU",
+        )
+        outsider.set_password("password")
+        db.session.add(outsider)
+        db.session.commit()
+
+        regatta = _make_regatta(db, skipper_user)
+        resp = logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": outsider.id, "status": "yes"},
+            follow_redirects=True,
+        )
+        assert b"Access denied" in resp.data
+
+    def test_crew_rsvp_invalid_status_rejected(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        resp = logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "invalid"},
+            follow_redirects=True,
+        )
+        assert b"Invalid RSVP status" in resp.data
+
+    def test_crew_rsvp_preserves_redirect_params(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        resp = logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={
+                "crew_user_id": crew_user.id,
+                "status": "yes",
+                "redirect_skipper": str(skipper_user.id),
+            },
+        )
+        assert resp.status_code == 302
+        assert f"skipper={skipper_user.id}" in resp.location
+
+    @patch("app.regattas.routes.notify_crew_rsvp_changed")
+    def test_crew_rsvp_notifies_crew_member(
+        self, mock_notify, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": "yes"},
+            follow_redirects=True,
+        )
+        mock_notify.assert_called_once()
+        args = mock_notify.call_args[0]
+        assert args[0].id == crew_user.id
+        assert args[1].id == regatta.id
+        assert args[2] == "yes"
+        assert args[3].id == skipper_user.id
+
+    @patch("app.regattas.routes.notify_crew_rsvp_changed")
+    def test_crew_rsvp_notifies_on_clear(
+        self, mock_notify, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        regatta = _make_regatta(db, skipper_user)
+        rsvp = RSVP(regatta_id=regatta.id, user_id=crew_user.id, status="yes")
+        db.session.add(rsvp)
+        db.session.commit()
+        logged_in_skipper.post(
+            f"/regattas/{regatta.id}/crew-rsvp",
+            data={"crew_user_id": crew_user.id, "status": ""},
+            follow_redirects=True,
+        )
+        mock_notify.assert_called_once()
+        args = mock_notify.call_args[0]
+        assert args[0].id == crew_user.id
+        assert args[1].id == regatta.id
+        assert args[2] == ""
+        assert args[3].id == skipper_user.id
+
+    @patch("app.regattas.routes.notify_crew_rsvp_changed")
+    def test_crew_rsvp_no_skipper_notification(
+        self, mock_notify, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        """Verify notify_rsvp_to_skipper is NOT called (skipper doesn't notify themselves)."""
+        regatta = _make_regatta(db, skipper_user)
+        with patch("app.regattas.routes.notify_rsvp_to_skipper") as mock_skipper:
+            logged_in_skipper.post(
+                f"/regattas/{regatta.id}/crew-rsvp",
+                data={"crew_user_id": crew_user.id, "status": "yes"},
+                follow_redirects=True,
+            )
+            mock_skipper.assert_not_called()
+
+
+# ── Enhanced invite tests ─────────────────────────────────────────────
+
+
+class TestEnhancedInvite:
+
+    def test_invite_crew_with_name_and_initials(
+        self, app, db, logged_in_skipper, skipper_user
+    ):
+        logged_in_skipper.post(
+            "/my-crew/invite",
+            data={
+                "email": "newcrew@test.com",
+                "display_name": "New Crew",
+                "initials": "NC",
+            },
+            follow_redirects=True,
+        )
+        user = User.query.filter_by(email="newcrew@test.com").first()
+        assert user is not None
+        assert user.display_name == "New Crew"
+        assert user.initials == "NC"
+        assert user.invite_token is not None
+
+    def test_invite_crew_with_phone(self, app, db, logged_in_skipper, skipper_user):
+        logged_in_skipper.post(
+            "/my-crew/invite",
+            data={
+                "email": "phonecrew@test.com",
+                "display_name": "Phone Crew",
+                "initials": "PC",
+                "phone": "555-123-4567",
+            },
+            follow_redirects=True,
+        )
+        user = User.query.filter_by(email="phonecrew@test.com").first()
+        assert user is not None
+        assert user.phone == "555-123-4567"
+
+    def test_invite_crew_requires_name(self, app, db, logged_in_skipper, skipper_user):
+        resp = logged_in_skipper.post(
+            "/my-crew/invite",
+            data={
+                "email": "noname@test.com",
+                "display_name": "",
+                "initials": "NN",
+            },
+            follow_redirects=True,
+        )
+        assert b"Name is required" in resp.data
+        assert User.query.filter_by(email="noname@test.com").first() is None
+
+    def test_invite_crew_requires_initials(
+        self, app, db, logged_in_skipper, skipper_user
+    ):
+        resp = logged_in_skipper.post(
+            "/my-crew/invite",
+            data={
+                "email": "noinit@test.com",
+                "display_name": "No Init",
+                "initials": "",
+            },
+            follow_redirects=True,
+        )
+        assert b"Initials are required" in resp.data
+        assert User.query.filter_by(email="noinit@test.com").first() is None
+
+
+# ── Resend invitation tests ──────────────────────────────────────────
+
+
+class TestResendInvite:
+
+    def _make_pending_crew(self, db, skipper):
+        user = User(
+            email="resend@test.com",
+            password_hash="pending",
+            display_name="Resend Crew",
+            initials="RC",
+            invite_token="resend-token-abc",
+            invited_by=skipper.id,
+        )
+        db.session.add(user)
+        db.session.flush()
+        skipper.crew_members.append(user)
+        db.session.commit()
+        return user
+
+    @patch("app.auth.routes._send_invite_email")
+    @patch("app.auth.routes.is_email_configured", return_value=True)
+    def test_resend_invite_success(
+        self, mock_configured, mock_send, app, db, logged_in_skipper, skipper_user
+    ):
+        pending = self._make_pending_crew(db, skipper_user)
+        resp = logged_in_skipper.post(
+            f"/my-crew/{pending.id}/resend-invite",
+            follow_redirects=True,
+        )
+        assert b"Invite resent" in resp.data
+        mock_send.assert_called_once()
+        db.session.refresh(pending)
+        assert pending.invite_sent_at is not None
+
+    @patch("app.auth.routes.is_email_configured", return_value=True)
+    def test_resend_invite_rate_limited(
+        self, mock_configured, app, db, logged_in_skipper, skipper_user
+    ):
+        pending = self._make_pending_crew(db, skipper_user)
+        pending.invite_sent_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        db.session.commit()
+
+        resp = logged_in_skipper.post(
+            f"/my-crew/{pending.id}/resend-invite",
+            follow_redirects=True,
+        )
+        assert b"already sent today" in resp.data
+
+    def test_resend_invite_not_pending(
+        self, app, db, logged_in_skipper, skipper_user, crew_user
+    ):
+        resp = logged_in_skipper.post(
+            f"/my-crew/{crew_user.id}/resend-invite",
+            follow_redirects=True,
+        )
+        assert b"not found or already registered" in resp.data
+
+    def test_resend_invite_not_own_crew(self, app, db, skipper_user, client):
+        # Create a pending user on skipper's crew
+        pending = User(
+            email="notmine@test.com",
+            password_hash="pending",
+            display_name="Not Mine",
+            initials="NM",
+            invite_token="notmine-token",
+            invited_by=skipper_user.id,
+        )
+        db.session.add(pending)
+        db.session.flush()
+        skipper_user.crew_members.append(pending)
+        db.session.commit()
+
+        # Log in as a different skipper
+        other = User(
+            email="other2@test.com",
+            display_name="Other2",
+            initials="O2",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+        _login(client, "other2@test.com")
+
+        resp = client.post(
+            f"/my-crew/{pending.id}/resend-invite",
+            follow_redirects=True,
+        )
+        assert b"not on your crew" in resp.data
+
+
+# ── Notification service tests ────────────────────────────────────────
+
+
+class TestNotifyCrewRsvpChanged:
+
+    def _make_crew_and_regatta(self, db, skipper):
+        crew = User(
+            email="notifycrew@test.com",
+            display_name="Notify Crew",
+            initials="NC",
+            invited_by=skipper.id,
+        )
+        crew.set_password("password")
+        db.session.add(crew)
+        db.session.flush()
+        skipper.crew_members.append(crew)
+        db.session.commit()
+        regatta = _make_regatta(db, skipper)
+        return crew, regatta
+
+    @patch("app.notifications.service.send_email")
+    @patch("app.notifications.service.render_template", return_value="mocked")
+    @patch("app.notifications.service.is_email_configured", return_value=True)
+    def test_notifies_active_crew(
+        self, mock_configured, mock_render, mock_send, app, db, skipper_user
+    ):
+        crew, regatta = self._make_crew_and_regatta(db, skipper_user)
+        notify_crew_rsvp_changed(crew, regatta, "yes", skipper_user)
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args
+        assert call_kwargs[1]["to"] == "notifycrew@test.com"
+        assert "yes" in call_kwargs[1]["subject"]
+
+    @patch("app.notifications.service.send_email")
+    @patch("app.notifications.service.render_template", return_value="mocked")
+    @patch("app.notifications.service.is_email_configured", return_value=True)
+    def test_notifies_on_clear(
+        self, mock_configured, mock_render, mock_send, app, db, skipper_user
+    ):
+        crew, regatta = self._make_crew_and_regatta(db, skipper_user)
+        notify_crew_rsvp_changed(crew, regatta, "", skipper_user)
+        mock_send.assert_called_once()
+        assert "cleared" in mock_send.call_args[1]["subject"]
+
+    @patch("app.notifications.service.send_email")
+    @patch("app.notifications.service.is_email_configured", return_value=True)
+    def test_skips_pending_crew(
+        self, mock_configured, mock_send, app, db, skipper_user
+    ):
+        pending = User(
+            email="pendingnotify@test.com",
+            password_hash="pending",
+            display_name="Pending Notify",
+            initials="PN",
+            invite_token="pending-notify-token",
+            invited_by=skipper_user.id,
+        )
+        db.session.add(pending)
+        db.session.flush()
+        skipper_user.crew_members.append(pending)
+        db.session.commit()
+        regatta = _make_regatta(db, skipper_user)
+        notify_crew_rsvp_changed(pending, regatta, "yes", skipper_user)
+        mock_send.assert_not_called()
+
+    @patch("app.notifications.service.send_email")
+    @patch("app.notifications.service.is_email_configured", return_value=True)
+    def test_skips_opted_out_crew(
+        self, mock_configured, mock_send, app, db, skipper_user
+    ):
+        crew, regatta = self._make_crew_and_regatta(db, skipper_user)
+        crew.email_opt_in = False
+        db.session.commit()
+        notify_crew_rsvp_changed(crew, regatta, "yes", skipper_user)
+        mock_send.assert_not_called()
+
+    @patch("app.notifications.service.send_email")
+    @patch("app.notifications.service.is_email_configured", return_value=False)
+    def test_skips_when_email_not_configured(
+        self, mock_configured, mock_send, app, db, skipper_user
+    ):
+        crew, regatta = self._make_crew_and_regatta(db, skipper_user)
+        notify_crew_rsvp_changed(crew, regatta, "yes", skipper_user)
+        mock_send.assert_not_called()
+
+
+# ── Permission helper tests ───────────────────────────────────────────
+
+
+class TestCanSetCrewRsvp:
+
+    def test_skipper_can_set_own_crew(self, app, db, skipper_user, crew_user):
+        from app.permissions import can_set_crew_rsvp
+
+        regatta = _make_regatta(db, skipper_user)
+        assert can_set_crew_rsvp(skipper_user, regatta, crew_user) is True
+
+    def test_skipper_cannot_set_non_crew(self, app, db, skipper_user):
+        from app.permissions import can_set_crew_rsvp
+
+        outsider = User(
+            email="perm_outsider@test.com",
+            display_name="Outsider",
+            initials="OU",
+        )
+        outsider.set_password("password")
+        db.session.add(outsider)
+        db.session.commit()
+        regatta = _make_regatta(db, skipper_user)
+        assert can_set_crew_rsvp(skipper_user, regatta, outsider) is False
+
+    def test_wrong_skipper_denied(self, app, db, skipper_user, crew_user):
+        from app.permissions import can_set_crew_rsvp
+
+        other = User(
+            email="perm_other@test.com",
+            display_name="Other",
+            initials="OT",
+            is_skipper=True,
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+        regatta = _make_regatta(db, skipper_user)
+        assert can_set_crew_rsvp(other, regatta, crew_user) is False
+
+    def test_admin_can_set(self, app, db, admin_user, skipper_user, crew_user):
+        from app.permissions import can_set_crew_rsvp
+
+        regatta = _make_regatta(db, skipper_user)
+        assert can_set_crew_rsvp(admin_user, regatta, crew_user) is True

--- a/tests/test_multiavatar.py
+++ b/tests/test_multiavatar.py
@@ -202,7 +202,11 @@ class TestAutoAvatarSeedOnInvite:
     def test_invite_crew_sets_avatar_seed(self, logged_in_client, admin_user, db):
         resp = logged_in_client.post(
             "/my-crew/invite",
-            data={"email": "crewnew@test.com"},
+            data={
+                "email": "crewnew@test.com",
+                "display_name": "Crew New",
+                "initials": "CN",
+            },
             follow_redirects=True,
         )
         assert resp.status_code == 200

--- a/tests/test_profile_picture_display.py
+++ b/tests/test_profile_picture_display.py
@@ -176,3 +176,134 @@ class TestProfilePagePreview:
         html = resp.data.decode()
         assert "<svg" in html
         assert "avatar-icon" in html
+
+
+class TestViewProfileEditButton:
+    def test_edit_button_shown_on_own_profile(self, app, client, db):
+        user = User(
+            email="self@test.com",
+            display_name="Self",
+            initials="SE",
+        )
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "self@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get(f"/crew/{user.id}")
+        html = resp.data.decode()
+        assert "Edit Profile" in html
+        assert "/profile" in html
+
+    def test_edit_button_hidden_on_other_profile(self, app, client, db):
+        viewer = User(
+            email="viewer@test.com",
+            display_name="Viewer",
+            initials="VW",
+        )
+        viewer.set_password("password")
+        db.session.add(viewer)
+
+        other = User(
+            email="other@test.com",
+            display_name="Other",
+            initials="OT",
+        )
+        other.set_password("password")
+        db.session.add(other)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "viewer@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get(f"/crew/{other.id}")
+        html = resp.data.decode()
+        assert "Edit Profile" not in html
+
+
+class TestPendingCrewProfile:
+    def test_skipper_can_view_pending_crew_profile(self, app, db, client):
+        skipper = User(
+            email="skipper@test.com",
+            display_name="Skipper",
+            initials="SK",
+            is_skipper=True,
+        )
+        skipper.set_password("password")
+        db.session.add(skipper)
+
+        pending = User(
+            email="pending@test.com",
+            display_name="Pending Crew",
+            initials="PC",
+            password_hash="pending",
+            invite_token="abc123",
+            invited_by=skipper.id,
+            phone="555-1234",
+        )
+        db.session.add(pending)
+        db.session.flush()
+        skipper.crew_members.append(pending)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "skipper@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get(f"/crew/{pending.id}")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "Pending Crew" in html
+        assert "Pending Invite" in html
+        assert "555-1234" in html
+
+    def test_other_user_cannot_view_pending_crew_profile(self, app, db, client):
+        skipper = User(
+            email="skipper@test.com",
+            display_name="Skipper",
+            initials="SK",
+            is_skipper=True,
+        )
+        skipper.set_password("password")
+        db.session.add(skipper)
+
+        other = User(
+            email="other@test.com",
+            display_name="Other",
+            initials="OT",
+        )
+        other.set_password("password")
+        db.session.add(other)
+
+        pending = User(
+            email="pending@test.com",
+            display_name="Pending Crew",
+            initials="PC",
+            password_hash="pending",
+            invite_token="abc123",
+            invited_by=skipper.id,
+        )
+        db.session.add(pending)
+        db.session.flush()
+        skipper.crew_members.append(pending)
+        db.session.commit()
+
+        client.post(
+            "/login",
+            data={"email": "other@test.com", "password": "password"},
+            follow_redirects=True,
+        )
+
+        resp = client.get(f"/crew/{pending.id}", follow_redirects=True)
+        html = resp.data.decode()
+        assert "User not found" in html

--- a/tests/test_public_schedule.py
+++ b/tests/test_public_schedule.py
@@ -86,7 +86,10 @@ class TestPublicSchedule:
     def test_public_schedule_shows_skipper_name(self, db, client, admin_user):
         _publish_skipper(db, admin_user, "admin-schedule")
         resp = client.get("/schedule/admin-schedule")
-        assert b"Admin&#39;s Race Schedule" in resp.data or b"Admin's Race Schedule" in resp.data
+        assert (
+            b"Admin&#39;s Race Schedule" in resp.data
+            or b"Admin's Race Schedule" in resp.data
+        )
 
     def test_public_schedule_hides_rsvp_controls(self, db, client, admin_user):
         _publish_skipper(db, admin_user, "admin-schedule")

--- a/tests/test_skipper_crew.py
+++ b/tests/test_skipper_crew.py
@@ -31,7 +31,11 @@ class TestInviteCrew:
     def test_invite_crew_creates_user(self, app, logged_in_skipper, db, skipper_user):
         resp = logged_in_skipper.post(
             "/my-crew/invite",
-            data={"email": "newcrew@test.com"},
+            data={
+                "email": "newcrew@test.com",
+                "display_name": "New Crew",
+                "initials": "NC",
+            },
             follow_redirects=True,
         )
         assert b"Invite link:" in resp.data
@@ -58,7 +62,11 @@ class TestInviteCrew:
 
         resp = logged_in_skipper.post(
             "/my-crew/invite",
-            data={"email": "other@test.com"},
+            data={
+                "email": "other@test.com",
+                "display_name": "Other",
+                "initials": "OT",
+            },
             follow_redirects=True,
         )
         assert b"added to your crew" in resp.data
@@ -67,7 +75,11 @@ class TestInviteCrew:
     def test_invite_duplicate_warns(self, logged_in_skipper, crew_user):
         resp = logged_in_skipper.post(
             "/my-crew/invite",
-            data={"email": crew_user.email},
+            data={
+                "email": crew_user.email,
+                "display_name": crew_user.display_name,
+                "initials": crew_user.initials,
+            },
             follow_redirects=True,
         )
         assert b"already on your crew" in resp.data


### PR DESCRIPTION
## Summary
- Skipper can set crew RSVP (Yes/No/Maybe/Clear) via clickable crew badges; "+" badge column for crew without responses
- Skipper's own crew badge is read-only (use Your RSVP dropdown)
- Crew receive email notification when skipper changes their RSVP
- Crew invite collects name, initials (required), phone (optional)
- Resend invitation for pending crew, rate limited once/day (new `invite_sent_at` column)
- View Profile button in crew RSVP modal upgraded to high-contrast solid blue

## Test plan
- [ ] Skipper-set RSVP buttons set, change, and clear status
- [ ] "+" badge appears for crew without RSVP and opens modal
- [ ] Skipper's own badge in crew column is non-interactive
- [ ] Email sent to crew on skipper change; not sent to skipper for self-changes
- [ ] Crew invite form requires initials; phone optional
- [ ] Resend invite blocked within 24h of last send
- [ ] Migration `p6f7a8b9c0d1` applies cleanly
- [ ] View Profile button is clearly readable in the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)