### PR TITLE
Notify repo owner on Trivy vulnerability findings (v0.72.1)

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -94,6 +94,8 @@ jobs:
           # Find existing open issue with our label
           EXISTING_ISSUE=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
 
+          OWNER="${{ github.repository_owner }}"
+
           if [ "$HAS_VULNS" = "true" ]; then
             # Build issue body in a temp file to avoid heredoc indentation issues
             BODY_FILE=$(mktemp)
@@ -103,6 +105,8 @@ jobs:
               echo "**Scan date:** $SCAN_DATE"
               echo "**Image:** \`$REGISTRY/$IMAGE_NAME:latest\`"
               echo "**Severity filter:** CRITICAL, HIGH (unfixed ignored)"
+              echo ""
+              echo "cc @$OWNER"
               echo ""
               echo '```'
               cat trivy-results.txt
@@ -116,7 +120,8 @@ jobs:
               gh issue comment "$EXISTING_ISSUE" --body-file "$BODY_FILE"
             else
               echo "Creating new issue"
-              gh issue create --title "$TITLE" --label "$LABEL" --body-file "$BODY_FILE"
+              gh issue create --title "$TITLE" --label "$LABEL" \
+                --assignee "$OWNER" --body-file "$BODY_FILE"
             fi
             rm -f "$BODY_FILE"
           else

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.72.1
+- Daily vulnerability scan workflow now assigns the new issue to the repo owner and @mentions them on each comment, so GitHub sends an email each time the scan finds CRITICAL/HIGH vulnerabilities
+
 ## 0.72.0
 - Skipper can set crew RSVP status (Yes/No/Maybe/Clear) on behalf of crew members via clickable crew badges, with View Profile link in the modal
 - "+" badge in its own column allows setting RSVP for crew (including pending) who haven't responded

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.72.0"
+__version__ = "0.72.1"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Assign the auto-created Trivy vulnerability scan issue to the repo owner so GitHub emails them on creation
- Add `cc @<owner>` mention in each daily comment so GitHub also emails them on every recurrence

## Why
Issue #134 was filed by github-actions with no assignees and no mentions, so GitHub's default notification level (Participating and @mentions) didn't email the owner.

## Test plan
- [ ] Manually dispatch the workflow with vulnerabilities present — verify new issue is assigned to repo owner
- [ ] Manually dispatch again — verify follow-up comment includes `cc @<owner>` and triggers an email
- [ ] Confirm clean-scan close path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)