### PR TITLE
Patch libtiff6 CVE-2026-4775 via Dockerfile cache bust (v0.72.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+# Bump APT_REFRESH to invalidate the GHA build cache for the apt layer when a
+# Debian security update is needed (e.g., to pick up CVE-fixed system packages).
+ARG APT_REFRESH=2026-04-26
+RUN echo "apt refresh: $APT_REFRESH" \
+    && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     default-libmysqlclient-dev gcc pkg-config \
     libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
     libffi-dev libcairo2 \

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.72.2
+- Patch `libtiff6` CVE-2026-4775 (HIGH) by adding an `APT_REFRESH` build arg to bust the GHA Docker cache for the apt layer, so `apt-get upgrade` picks up patched system packages on the next build (closes #134)
+
 ## 0.72.1
 - Daily vulnerability scan workflow now assigns the new issue to the repo owner and @mentions them on each comment, so GitHub sends an email each time the scan finds CRITICAL/HIGH vulnerabilities
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.72.1"
+__version__ = "0.72.2"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Adds an `APT_REFRESH` build arg before the apt layer in the Dockerfile so bumping the value invalidates GHA's cached layer
- Forces `apt-get update && apt-get upgrade -y` to run fresh on the next build, picking up `libtiff6 4.7.0-3+deb13u2` (fix for CVE-2026-4775 HIGH)

## Why
Issue #134 reported `libtiff6` CVE-2026-4775. The Dockerfile already runs `apt-get upgrade -y`, but the GHA build cache reuses the apt layer when the surrounding Dockerfile lines don't change, so the upgraded package never hits the image.

## Test plan
- [ ] PR merge triggers `deploy.yml`; build logs show the apt layer is rebuilt (no cache hit on that step)
- [ ] After deploy, manually re-dispatch `vulnerability-scan.yml`
- [ ] Verify scan reports zero CRITICAL/HIGH vulns and the workflow auto-closes #134
- [ ] Confirm production app still serves traffic post-deploy

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)