### PR TITLE
Drop Docker build cache instead of APT_REFRESH arg (v0.72.3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,6 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   scan-image:
     name: Scan Image for Vulnerabilities

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,7 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
-# Bump APT_REFRESH to invalidate the GHA build cache for the apt layer when a
-# Debian security update is needed (e.g., to pick up CVE-fixed system packages).
-ARG APT_REFRESH=2026-04-26
-RUN echo "apt refresh: $APT_REFRESH" \
-    && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     default-libmysqlclient-dev gcc pkg-config \
     libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
     libffi-dev libcairo2 \

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.72.3
+- Drop GHA Docker build cache from the deploy workflow so every push rebuilds from scratch and `apt-get upgrade` always pulls patched Debian system packages
+- Revert the `APT_REFRESH` Dockerfile arg added in 0.72.2 (no longer needed without the build cache)
+
 ## 0.72.2
 - Patch `libtiff6` CVE-2026-4775 (HIGH) by adding an `APT_REFRESH` build arg to bust the GHA Docker cache for the apt layer, so `apt-get upgrade` picks up patched system packages on the next build (closes #134)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.72.2"
+__version__ = "0.72.3"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Revert the `APT_REFRESH` build arg added in 0.72.2
- Drop `cache-from: type=gha` / `cache-to: type=gha,mode=max` from `deploy.yml`'s build-and-push step
- Every push to master now does a clean rebuild, so `apt-get update && apt-get upgrade -y` always picks up patched Debian system packages

## Why
APT_REFRESH was a manual knob — easy to forget to bump. Removing the GHA cache makes patching automatic at the cost of ~2-3 min slower builds, which is fine for this app.

## Test plan
- [ ] After merge, `deploy.yml` builds without cache (no cache-import lines in build logs)
- [ ] Re-dispatch `vulnerability-scan.yml` and confirm zero CRITICAL/HIGH findings
- [ ] Verify production app still serves traffic post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)