### PR TITLE
Wait for in-progress Lightsail deployment before deploying (v0.72.4)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,21 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      - name: Wait for any in-progress Lightsail deployment
+        run: |
+          SERVICE="${{ vars.CONTAINER_SERVICE_NAME }}"
+          for i in $(seq 1 60); do
+            STATE=$(aws lightsail get-container-service-deployments \
+              --service-name "$SERVICE" \
+              --query 'deployments[0].state' --output text 2>/dev/null || echo "")
+            echo "Latest Lightsail deployment state: ${STATE:-unknown} (attempt $i/60)"
+            if [ "$STATE" != "ACTIVATING" ]; then
+              echo "No deployment in progress — ready to deploy."
+              break
+            fi
+            sleep 15
+          done
+
       - name: Deploy to Lightsail Container Service
         run: |
           aws lightsail create-container-service-deployment \

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.72.4
+- Deploy workflow polls for any in-progress Lightsail deployment before calling `create-container-service-deployment`, preventing back-to-back deploys from failing with `InvalidInputException: deployment N is in progress`
+
 ## 0.72.3
 - Drop GHA Docker build cache from the deploy workflow so every push rebuilds from scratch and `apt-get upgrade` always pulls patched Debian system packages
 - Revert the `APT_REFRESH` Dockerfile arg added in 0.72.2 (no longer needed without the build cache)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.72.3"
+__version__ = "0.72.4"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Add a polling step to `deploy.yml` that waits for any in-progress Lightsail deployment to leave `ACTIVATING` state before calling `create-container-service-deployment`
- Polls every 15s for up to ~15 minutes

## Why
GHA's `concurrency: deploy-production` sequences GHA runs, but Lightsail rejects a new deployment while a previous one is still ACTIVATING. Today's back-to-back merges (v0.72.1 and v0.72.3) both hit `InvalidInputException: deployment N is in progress` for this reason. The Lightsail container missed those deploys (the code on master is unaffected, but the running container didn't pick up changes from those PRs).

## Test plan
- [ ] Merge triggers deploy.yml; `Wait for any in-progress Lightsail deployment` step runs and reports state
- [ ] Verify production app still serves traffic post-deploy
- [ ] Manually re-dispatch deploy.yml to redeploy v0.72.3 changes that didn't land (cache removal — these don't affect runtime, but confirm container is current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)