### PR TITLE
Add GHCR retention workflow and sort crew lists (v0.73.0)

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,42 @@
+name: GHCR Retention Cleanup
+
+on:
+  schedule:
+    - cron: "0 4 * * 0"   # Sunday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Trim GHCR image tags
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Delete SHA-only tags older than 30 days
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: race-crew-network
+          owner: chris-edwards-pub
+          tags: ^[0-9a-f]{40}$
+          older-than: 30 days
+          exclude-tags: latest
+
+      - name: Keep last 5 semver release tags
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: race-crew-network
+          owner: chris-edwards-pub
+          tags: ^\d+\.\d+\.\d+$
+          keep-n-tagged: 5
+          exclude-tags: latest
+
+      - name: Delete untagged manifests
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: race-crew-network
+          owner: chris-edwards-pub
+          delete-untagged: true
+          exclude-tags: latest

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.73.0
+- Add weekly GHCR retention workflow (`ghcr-cleanup.yml`) that keeps `:latest`, the 5 most recent semver release tags, and SHA-only tags newer than 30 days; deletes everything else and any untagged manifests
+- Sort the "Set RSVP" crew picker alphabetically by display name (case-insensitive)
+- Sort the "My Crew" page alphabetically by display name (case-insensitive); skipper stays pinned at the top
+
 ## 0.72.4
 - Deploy workflow polls for any in-progress Lightsail deployment before calling `create-container-service-deployment`, preventing back-to-back deploys from failing with `InvalidInputException: deployment N is in progress`
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.72.4"
+__version__ = "0.73.0"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from flask import (current_app, flash, redirect, render_template, request,
                    session, url_for)
 from flask_login import current_user, login_required, login_user, logout_user
+from sqlalchemy import func
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.utils import secure_filename
 
@@ -708,7 +709,7 @@ def my_crew():
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
 
-    crew = current_user.crew_members.order_by(User.display_name).all()
+    crew = current_user.crew_members.order_by(func.lower(User.display_name)).all()
     return render_template(
         "my_crew.html",
         crew=[current_user] + crew,
@@ -724,7 +725,7 @@ def crew_view(skipper_id: int):
     if not skipper or skipper not in current_user.skippers:
         flash("Access denied.", "error")
         return redirect(url_for("regattas.index"))
-    crew = skipper.crew_members.order_by(User.display_name).all()
+    crew = skipper.crew_members.order_by(func.lower(User.display_name)).all()
     return render_template("crew_view.html", skipper=skipper, crew=[skipper] + crew)
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -163,7 +163,7 @@
                 {% if current_user.is_skipper and not is_past %}
                 <td>
                     {% if is_own_regatta %}
-                    {% set all_crew = current_user.crew_members.all()|rejectattr('id', 'equalto', current_user.id)|list %}
+                    {% set all_crew = current_user.crew_members.all()|rejectattr('id', 'equalto', current_user.id)|sort(attribute='display_name', case_sensitive=false)|list %}
                     {% if all_crew %}
                     <a href="#" class="crew-badge editable" style="background-color:#e9ecef;color:#666;" title="Add Crew" data-regatta-id="{{ regatta.id }}" data-all-crew='[{% for c in all_crew %}{"id":{{ c.id }},"name":"{{ c.display_name }}"}{% if not loop.last %},{% endif %}{% endfor %}]' onclick="openAddCrewRsvpModal(this); return false;">+</a>
                     {% endif %}
@@ -268,7 +268,7 @@
                 {% endif %}
                 {% endfor %}
                 {% if is_own_regatta_m and not is_past %}
-                {% set all_crew_m = current_user.crew_members.all()|rejectattr('id', 'equalto', current_user.id)|list %}
+                {% set all_crew_m = current_user.crew_members.all()|rejectattr('id', 'equalto', current_user.id)|sort(attribute='display_name', case_sensitive=false)|list %}
                 {% if all_crew_m %}
                 <a href="#" class="crew-badge editable" style="background-color:#e9ecef;color:#666;" title="Add Crew" data-regatta-id="{{ regatta.id }}" data-all-crew='[{% for c in all_crew_m %}{"id":{{ c.id }},"name":"{{ c.display_name }}"}{% if not loop.last %},{% endif %}{% endfor %}]' onclick="openAddCrewRsvpModal(this); return false;">+</a>
                 {% endif %}


### PR DESCRIPTION
## Summary
- Add weekly `.github/workflows/ghcr-cleanup.yml` (Sun 04:00 UTC + manual dispatch) using `dataaxiom/ghcr-cleanup-action@v1`
- Retention policy: keep `:latest`, last 5 semver tags, and SHA-only tags newer than 30 days; delete the rest plus untagged manifests
- Sort the Set RSVP crew picker alphabetically (case-insensitive) in `index.html`
- Sort the My Crew page alphabetically (case-insensitive) via `func.lower(User.display_name)`; current_user is prepended so the skipper stays pinned at the top

## Why
- GHCR has been accumulating every image ever built, including unpatched historical CVEs. Industry standard is retention by policy, not rescan-and-remediate (every old image is "vulnerable" by definition).
- Crew lists were ordered by SQL default collation, which can be inconsistent (case-sensitive on SQLite, case-insensitive on MySQL).

## Test plan
- [x] `pytest` — 603 passed
- [ ] After merge, manually `gh workflow run ghcr-cleanup.yml`; confirm last 5 semver tags + `:latest` survive
- [ ] Open Set RSVP modal on a regatta; confirm crew list is alphabetical
- [ ] Visit `/my-crew`; confirm skipper is first row, then crew alphabetical regardless of case

🤖 Generated with [Claude Code](https://claude.com/claude-code)