### PR TITLE
Polish transactional email layout (v0.73.1)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.73.1
+- Wrap transactional emails in a light-gray (`#F8F9FA`) page with a white (`#FFFFFF`) inner card so messages have a more polished, modern look across email clients
+- Move the logo above the white card so it sits on the light-gray page background
+- Place the logo on a dark slate (`#1f2937`) rounded panel so the transparent PNG's white elements remain visible
+
 ## 0.73.0
 - Add weekly GHCR retention workflow (`ghcr-cleanup.yml`) that keeps `:latest`, the 5 most recent semver release tags, and SHA-only tags newer than 30 days; deletes everything else and any untagged manifests
 - Sort the "Set RSVP" crew picker alphabetically by display name (case-insensitive)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.73.0"
+__version__ = "0.73.1"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/admin/email_service.py
+++ b/app/admin/email_service.py
@@ -133,19 +133,38 @@ def _send_via_ses(
             filename="img/race-crew-network-1536x1024.png",
             _external=True,
         )
-        header = (
-            '<div style="text-align:center;margin-bottom:20px;">'
+        logo_block = (
+            '<table role="presentation" width="600" cellpadding="0" '
+            'cellspacing="0" border="0" '
+            'style="max-width:600px;width:100%;">'
+            '<tr><td align="center" style="padding:8px 0 16px 0;">'
+            '<table role="presentation" cellpadding="0" cellspacing="0" '
+            'border="0" style="background-color:#1f2937;border-radius:8px;">'
+            '<tr><td align="center" style="padding:16px 24px;">'
             f'<img src="{logo_url}" alt="Race Crew Network" '
-            'style="max-width:350px;width:100%;height:auto;" />'
-            "</div>"
+            'style="max-width:320px;width:100%;height:auto;display:block;" />'
+            "</td></tr></table>"
+            "</td></tr></table>"
         )
         footer = (
             '<hr style="margin-top:20px;border:none;border-top:1px solid #ddd;">'
-            '<p style="font-size:12px;color:#888;">'
+            '<p style="font-size:12px;color:#888;margin:0;">'
             f'<a href="{unsubscribe_url}">Unsubscribe</a> from Race Crew Network emails.'
             "</p>"
         )
-        body_html_with_footer = header + body_html + footer
+        body_html_with_footer = (
+            '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+            'border="0" style="background-color:#F8F9FA;margin:0;padding:0;">'
+            '<tr><td align="center" style="padding:24px 16px;">'
+            f"{logo_block}"
+            '<table role="presentation" width="600" cellpadding="0" cellspacing="0" '
+            'border="0" style="background-color:#FFFFFF;border-radius:8px;'
+            'max-width:600px;width:100%;">'
+            '<tr><td style="padding:24px;">'
+            f"{body_html}{footer}"
+            "</td></tr></table>"
+            "</td></tr></table>"
+        )
         msg.attach(MIMEText(body_html_with_footer, "html", "utf-8"))
 
     client.send_raw_email(

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -244,7 +244,7 @@ class TestEmailBranding:
         decoded_html = _decode_html_body(raw_data)
         assert "race-crew-network-1536x1024.png" in decoded_html
         assert 'alt="Race Crew Network"' in decoded_html
-        assert "max-width:350px" in decoded_html
+        assert "max-width:320px" in decoded_html
 
     @patch("app.admin.email_service._get_ses_client")
     def test_logo_before_body_before_footer(self, mock_get_client, app, db):


### PR DESCRIPTION
## Summary
- Wrap every transactional email in a `#F8F9FA` page with a `#FFFFFF` rounded inner card so messages match modern transactional-email styling (Stripe / Linear-style)
- Move the logo above the white card and place it on a dark slate (`#1f2937`) rounded panel so the transparent PNG's white boat/wave/text strokes remain visible
- All seven email templates inherit the new wrapper via `_send_via_ses` — no per-template changes

## Test plan
- [x] `pytest` — 603 passed
- [ ] Trigger a transactional email locally and view in Gmail web, Apple Mail, and Outlook web
- [ ] Verify dark-mode rendering keeps the white card legible
- [ ] Confirm plain-text MIME part is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)