### PR TITLE
Simplify GHCR retention workflow (v0.73.2)

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -15,28 +15,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Delete SHA-only tags older than 30 days
+      - name: Keep last 5 tagged versions, delete untagged
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           package: race-crew-network
           owner: chris-edwards-pub
-          tags: ^[0-9a-f]{40}$
-          older-than: 30 days
-          exclude-tags: latest
-
-      - name: Keep last 5 semver release tags
-        uses: dataaxiom/ghcr-cleanup-action@v1
-        with:
-          package: race-crew-network
-          owner: chris-edwards-pub
-          tags: ^\d+\.\d+\.\d+$
           keep-n-tagged: 5
-          exclude-tags: latest
-
-      - name: Delete untagged manifests
-        uses: dataaxiom/ghcr-cleanup-action@v1
-        with:
-          package: race-crew-network
-          owner: chris-edwards-pub
           delete-untagged: true
           exclude-tags: latest

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.73.2
+- Simplify GHCR retention workflow to a single step (`keep-n-tagged: 5` + `delete-untagged: true`); the previous three-step regex-filtered version deleted 0 release versions because each commit's package version carries both semver and SHA tags simultaneously, which made each step's tag filter skip every version
+
 ## 0.73.1
 - Wrap transactional emails in a light-gray (`#F8F9FA`) page with a white (`#FFFFFF`) inner card so messages have a more polished, modern look across email clients
 - Move the logo above the white card so it sits on the light-gray page background

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.73.1"
+__version__ = "0.73.2"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- The original three-step retention workflow (introduced in 0.73.0) deleted 0 release versions on its first run because each commit's package version carries both a semver tag and a commit-SHA tag, and `dataaxiom/ghcr-cleanup-action` skips any version whose tag set extends beyond the step's `tags` regex
- Collapse to a single step: `keep-n-tagged: 5` + `delete-untagged: true`, exclude `latest`
- Net effect is identical to the original intent (keep the latest 5 release versions + their referenced platform manifests, drop everything older), but actually executes

## Test plan
- [x] `pytest` — 603 passed
- [ ] Trigger `GHCR Retention Cleanup` workflow manually after merge
- [ ] Confirm the GHCR Versions page drops to ~5 tagged + their platform manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)