### PR TITLE
Purge linux-libc-dev from runtime image (v0.73.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && apt-get purge -y linux-libc-dev \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.73.4
+- Purge `linux-libc-dev` (Debian kernel headers) from the runtime image after `pip install`, eliminating 99 HIGH kernel CVEs flagged by the daily Trivy scan; the package is pulled in transitively by `gcc` for builds, has no runtime use in the container (containers share the host kernel), and `apt-get autoremove` cleans up other build-only deps no longer needed
+
 ## 0.73.3
 - Bring the 18-day training curriculum (training/) up to date with the current application: 7 blueprints (added `help`), 10 models + `skipper_crew`, new permission helper `can_set_crew_rsvp`, public per-skipper schedule pages, skipper-sets-crew-RSVP flow, queued/rate-limited email sender + `process-email-queue` CLI, `crew_rsvp_changed` notification, AI usage logging with monthly budget cap, optional Yacht Club / About Me profile fields, password reset flow, and updated SiteSetting / email template / CLI references in the appendix
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.73.3"
+__version__ = "0.73.4"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Add `apt-get purge -y linux-libc-dev && apt-get autoremove -y` after `pip install` in the Dockerfile so the Debian kernel-headers package (and other build-only deps it pulls along) doesn't end up in the runtime image.
- Eliminates 99 HIGH kernel CVEs flagged by the latest daily Trivy scan ([run](https://github.com/chris-edwards-pub/race-crew-network/actions/runs/25272313685)). The package has no runtime use in a container — containers share the host kernel — so removing it is risk-free for the app.
- Bump version 0.73.3 → 0.73.4 and update `VERSIONS.md`.

Closes #145

## Test plan
- [ ] CI build succeeds
- [ ] Container starts and serves traffic after deploy
- [ ] Next daily Trivy scan reports 0 CRITICAL/HIGH (or auto-closes #145)

🤖 Generated with [Claude Code](https://claude.com/claude-code)