### PR TITLE
Patch urllib3 CVE-2026-44431/44432 (v0.73.5)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.73.5
+- Pin `urllib3>=2.7.0` in `requirements.txt` to patch CVE-2026-44431 (HIGH; sensitive headers forwarded across origins in proxied low-level redirects) and CVE-2026-44432 (HIGH; decompression-bomb safeguards bypassed in streaming API), both flagged against the transitively-installed `urllib3 2.6.3` by the daily Trivy scan (closes #147)
+
 ## 0.73.4
 - Purge `linux-libc-dev` (Debian kernel headers) from the runtime image after `pip install`, eliminating 99 HIGH kernel CVEs flagged by the daily Trivy scan; the package is pulled in transitively by `gcc` for builds, has no runtime use in the container (containers share the host kernel), and `apt-get autoremove` cleans up other build-only deps no longer needed
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.73.4"
+__version__ = "0.73.5"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ multiavatar>=1.0.0
 boto3>=1.35.0
 anthropic>=0.43.0
 requests>=2.31.0
+urllib3>=2.7.0
 beautifulsoup4>=4.12.0
 pypdf>=4.0.0
 python-docx>=1.1.0


### PR DESCRIPTION
## Summary
- Pin `urllib3>=2.7.0` in `requirements.txt` so the runtime image installs the patched release instead of the transitively-pulled `urllib3 2.6.3`
- Bump `__version__` to 0.73.5 and add the corresponding VERSIONS.md entry

## Vulnerabilities patched
- **CVE-2026-44431** (HIGH) — sensitive headers forwarded across origins in proxied low-level redirects
- **CVE-2026-44432** (HIGH) — decompression-bomb safeguards bypassed in parts of the streaming API

Both flagged by the daily Trivy scan in #147; fixed in urllib3 2.7.0.

## Test plan
- [x] `pytest` — 603 passed in 3:24
- [ ] After merge, confirm next Trivy scan shows urllib3 findings cleared

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)