### PR TITLE
Patch openssl CVE-2026-45447 via image rebuild (v0.73.6)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.73.6
+- Rebuild image to pick up Debian `openssl`/`libssl3t64`/`openssl-provider-legacy` `3.5.6-1~deb13u2`, which patches CVE-2026-45447 (HIGH; malformed PKCS#7/S/MIME signed messages) flagged by the daily Trivy scan against the stale `:latest` built on 2026-05-17; no Dockerfile changes needed because `apt-get upgrade` already runs on every build and the deploy workflow does not cache layers (closes #149)
+
 ## 0.73.5
 - Pin `urllib3>=2.7.0` in `requirements.txt` to patch CVE-2026-44431 (HIGH; sensitive headers forwarded across origins in proxied low-level redirects) and CVE-2026-44432 (HIGH; decompression-bomb safeguards bypassed in streaming API), both flagged against the transitively-installed `urllib3 2.6.3` by the daily Trivy scan (closes #147)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.73.5"
+__version__ = "0.73.6"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Bumps version `0.73.5` → `0.73.6` to trigger a fresh image build that picks up Debian `openssl`/`libssl3t64`/`openssl-provider-legacy` `3.5.6-1~deb13u2`, patching **CVE-2026-45447** (HIGH; malformed PKCS#7/S/MIME signed messages)
- No Dockerfile changes required — the existing `apt-get update && apt-get upgrade -y` step pulls the patched packages on every build, and the deploy workflow does not cache layers (intentional, see v0.72.3)
- Verified locally: built `race-crew-network:0.73.6-local` and ran `trivy image --severity CRITICAL,HIGH --ignore-unfixed --vuln-type os,library` → **0 vulnerabilities** in the Debian target (down from 3 HIGH on `:latest`)

## Test plan
- [x] `pytest` — 603 passed
- [x] Local docker build succeeds
- [x] Local trivy scan reports 0 HIGH/CRITICAL on the new image
- [ ] GHA build-and-push + trivy scan workflow passes on merge
- [ ] Lightsail deploy succeeds and serves v0.73.6

Closes #149