### PR TITLE
Patch cryptography GHSA-537c-gmf6-5ccf via 48.0.1 pin (v0.73.7)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.73.7
+- Bump `cryptography` pin from `46.0.5` to `48.0.1` to patch GHSA-537c-gmf6-5ccf (HIGH; vulnerable OpenSSL bundled in `cryptography` wheels), flagged by the daily Trivy scan (closes #151)
+
 ## 0.73.6
 - Rebuild image to pick up Debian `openssl`/`libssl3t64`/`openssl-provider-legacy` `3.5.6-1~deb13u2`, which patches CVE-2026-45447 (HIGH; malformed PKCS#7/S/MIME signed messages) flagged by the daily Trivy scan against the stale `:latest` built on 2026-05-17; no Dockerfile changes needed because `apt-get upgrade` already runs on every build and the deploy workflow does not cache layers (closes #149)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.73.6"
+__version__ = "0.73.7"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-Migrate==4.0.7
 Flask-WTF==1.2.2
 WTForms==3.2.1
 PyMySQL==1.1.1
-cryptography==46.0.5
+cryptography==48.0.1
 bcrypt==4.2.1
 gunicorn==23.0.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- Bump `cryptography` pin from `46.0.5` to `48.0.1` to patch **GHSA-537c-gmf6-5ccf** (HIGH; vulnerable OpenSSL bundled in `cryptography` wheels), flagged by the daily Trivy scan against `:latest`
- Bump app version to `0.73.7`

Closes #151.

## Test plan
- [x] `pytest` — 603 passed
- [ ] CI green
- [ ] Post-merge: daily Trivy scan no longer flags `cryptography`

🤖 Generated with [Claude Code](https://claude.com/claude-code)