### PR TITLE
Add Database migration-first rule to AGENTS.md (v0.74.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,6 @@ Semantic Versioning (SemVer): `MAJOR.MINOR.PATCH`
 - Testing can be done locally.  Docker and Mysql are both locally installed.
 - Testing should be done with each PR
 - Local admin credentials are set via `INIT_ADMIN_EMAIL` and `INIT_ADMIN_PASSWORD` in `.env`
+
+## Database
+- Every feature or code change that depends on a schema update must have a corresponding migration applied first.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.74.1
+- Add a "Database" section to `AGENTS.md` requiring that every feature or code change depending on a schema update must have a corresponding migration applied first — codifies a rule that had been implicit and prevents PRs from landing code that references not-yet-migrated columns
+
 ## 0.74.0
 - Adopt the cross-tool [AGENTS.md](https://agents.md) convention: `AGENTS.md` is now the canonical source of project standards for AI coding agents (Cursor, Codex, Aider, etc.), and `CLAUDE.md` is a symlink to it so Claude Code continues to load the same instructions without duplicating content
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.74.0"
+__version__ = "0.74.1"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Codify the rule that any feature or code change depending on a schema update must ship with (and apply) its migration first
- Prevents PRs from landing code that references not-yet-migrated columns
- Same rule ported to `flask-app-template` and `pyc-rc-organizer` in parallel

## Test plan
- [ ] N/A — documentation-only change to `AGENTS.md` + version bump