### PR TITLE
Patch libtiff6 CVE-2026-12912 via image rebuild (v0.74.2)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.74.2
+- Rebuild image to pick up Debian `libtiff6` `4.7.0-3+deb13u3`, which patches CVE-2026-12912 (HIGH; heap-based buffer overflow via crafted PixarLog-compressed TIFF image) flagged by the daily Trivy scan; no Dockerfile changes needed because `apt-get upgrade` already runs on every build and the deploy workflow does not cache layers (closes #155)
+
 ## 0.74.1
 - Add a "Database" section to `AGENTS.md` requiring that every feature or code change depending on a schema update must have a corresponding migration applied first — codifies a rule that had been implicit and prevents PRs from landing code that references not-yet-migrated columns
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.74.1"
+__version__ = "0.74.2"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Bumps to v0.74.2 to force an image rebuild that picks up Debian `libtiff6` `4.7.0-3+deb13u3`, patching CVE-2026-12912 (HIGH; heap-based buffer overflow via crafted PixarLog-compressed TIFF image).
- Sole finding from the daily Trivy scan (#155). No Dockerfile changes needed — `apt-get upgrade` runs on every build and the deploy workflow does not cache layers (see v0.72.3).
- Follows the same pattern as v0.73.6 (openssl rebuild).

Closes #155

## Test plan
- [ ] CI build/push succeeds
- [ ] Next Trivy scan reports 0 HIGH/CRITICAL against `:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)