### PR TITLE
Patch libexpat1 HIGH CVEs via image rebuild (v0.74.3)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.74.3
+- Rebuild image to pick up Debian `libexpat1` `2.8.2-1~deb13u1`, which patches CVE-2025-59375, CVE-2026-25210, CVE-2026-45186, CVE-2026-56131, and CVE-2026-56408 (all HIGH; denial of service, information disclosure, and integer overflow issues in expat XML parser) flagged by the daily Trivy scan; no Dockerfile changes needed because `apt-get upgrade` already runs on every build and the deploy workflow does not cache layers (closes #157)
+
 ## 0.74.2
 - Rebuild image to pick up Debian `libtiff6` `4.7.0-3+deb13u3`, which patches CVE-2026-12912 (HIGH; heap-based buffer overflow via crafted PixarLog-compressed TIFF image) flagged by the daily Trivy scan; no Dockerfile changes needed because `apt-get upgrade` already runs on every build and the deploy workflow does not cache layers (closes #155)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.74.2"
+__version__ = "0.74.3"
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
## Summary
- Trivy daily scan (#157) flagged `libexpat1 2.7.1-2` with five HIGH CVEs (CVE-2025-59375, CVE-2026-25210, CVE-2026-45186, CVE-2026-56131, CVE-2026-56408).
- Debian shipped fixes in `2.8.2-1~deb13u1`. Version bump triggers a rebuild; `apt-get upgrade` in the Dockerfile and the no-cache deploy workflow pick up the patched package without any Dockerfile change.
- Same pattern as PR #156 for libtiff6.

## Test plan
- [x] `pytest` — 603 passed locally
- [ ] Post-merge: confirm next Trivy scan no longer reports the libexpat1 CVEs

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)