### PR TITLE
Patch cryptography CVE-2026-69247/69249 via version bump (v0.74.4)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 # Version History
 
+## 0.74.4
+- Bump `cryptography` pin from `48.0.1` to `50.0.0` to patch CVE-2026-69247 (HIGH; fixed in 50.0.0) and CVE-2026-69249 (HIGH; fixed in 49.0.0), both flagged against `cryptography 48.0.1` by the daily Trivy scan (closes #159)
+
 ## 0.74.3
 - Rebuild image to pick up Debian `libexpat1` `2.8.2-1~deb13u1`, which patches CVE-2025-59375, CVE-2026-25210, CVE-2026-45186, CVE-2026-56131, and CVE-2026-56408 (all HIGH; denial of service, information disclosure, and integer overflow issues in expat XML parser) flagged by the daily Trivy scan; no Dockerfile changes needed because `apt-get upgrade` already runs on every build and the deploy workflow does not cache layers (closes #157)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__version__ = "0.74.3"
+__version__ = "0.74.4"
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-Migrate==4.0.7
 Flask-WTF==1.2.2
 WTForms==3.2.1
 PyMySQL==1.1.1
-cryptography==48.0.1
+cryptography==50.0.0
 bcrypt==4.2.1
 gunicorn==23.0.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- Bump `cryptography` pin from `48.0.1` to `50.0.0` in `requirements.txt`, patching CVE-2026-69247 (HIGH; fixed in 50.0.0) and CVE-2026-69249 (HIGH; fixed in 49.0.0) flagged by the daily Trivy scan against `cryptography 48.0.1`.
- Version bumped to `0.74.4`; `VERSIONS.md` updated.

Closes #159

## Test plan
- [x] Full local `pytest` suite passes with `cryptography==50.0.0` (603 passed)
- [ ] CI checks pass on PR
- [ ] Post-deploy Trivy scan no longer reports CVE-2026-69247/69249

🤖 Generated with [Claude Code](https://claude.com/claude-code)